### PR TITLE
Per-source unconstrained transform

### DIFF
--- a/doc/unconstrained_parameterization.lyx
+++ b/doc/unconstrained_parameterization.lyx
@@ -136,6 +136,19 @@ Positive numbers can be parameterized with
 \end_layout
 
 \begin_layout Standard
+Lower-bounded numbers can be parameterized with
+\begin_inset Formula 
+\begin{eqnarray*}
+\beta & = & \exp b+\beta_{0}\\
+\frac{df}{db} & = & \frac{df}{d\beta}\frac{d\beta}{db}=\frac{df}{d\beta}\left(\beta-\beta_{0}\right)
+\end{eqnarray*}
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
 If you scale by a constant, then you divide by the constant for the derivative:
 \begin_inset Formula 
 \begin{eqnarray*}

--- a/src/CelesteTypes.jl
+++ b/src/CelesteTypes.jl
@@ -380,21 +380,29 @@ bright_ids(i) = [ids.r1[i]; ids.r2[i]; ids.c1[:, i]; ids.c2[:, i]]
 const brightness_standard_alignment = (bright_ids(1), bright_ids(2))
 
 # TODO: maybe these should be incorporated into the framework above (which I don't really understand.)
-ids_free_names = Array(ASCIIString, length(ids_free))
-for (name in names(ids_free))
-    inds = ids_free.(name)
-    for i = 1:length(inds)
-        ids_free_names[inds[i]] = "$(name)_$(i)"
+function get_id_names(ids::Union(CanonicalParams, UnconstrainedParams))
+  ids_names = Array(ASCIIString, length(ids))
+  for (name in names(this_ids))
+    inds = ids.(name)
+    if length(size(inds)) == 1
+      ids_names[inds] = "$(name)"
+    else if length(size(inds)) == 2
+      for i = 1:size(inds)[1]
+          ids_names[inds[i]] = "$(name)_$(i)"
+      end
+    else if length(size(inds)) == 3
+      for i = 1:size(inds)[1], j = 1:size(inds)[2]
+          ids_names[inds[i, j]] = "$(name)_$(i)_$(j)"
+      end
+    else
+      error("Names of 3d parameters not supported.")
     end
+  end
+  return ids_names
 end
 
-ids_names = Array(ASCIIString, length(ids))
-for (name in names(ids))
-    inds = ids.(name)
-    for i = 1:length(inds)
-        ids_names[inds[i]] = "$(name)_$(i)"
-    end
-end
+const ids_names = get_id_names(ids)
+const ids_free_names = get_id_names(ids_free)
 
 
 #########################################################

--- a/src/CelesteTypes.jl
+++ b/src/CelesteTypes.jl
@@ -15,10 +15,8 @@ export VariationalParams, FreeVariationalParams, RectVariationalParams
 
 export shape_standard_alignment, brightness_standard_alignment, align
 
-export SensitiveFloat
-
-export zero_sensitive_float, clear!
-
+export SensitiveFloat, zero_sensitive_float, clear!
+export print_params
 export set_patch_wcs!
 
 export ids, ids_free, star_ids, gal_ids
@@ -255,7 +253,7 @@ Attributes:
 type SkyPatch
     center::Vector{Float64}
     radius::Float64
-   
+
     psf::Vector{PsfComponent}
     wcs_jacobian::Matrix{Float64}
     pixel_center::Vector{Float64}
@@ -308,7 +306,7 @@ abstract ParamSet
 # r1      = Iax1 shape parameter for r_s. (formerly gamma)
 # r2      = Iax1 scale parameter for r_s. (formerly zeta)
 # c1      = C_s means (formerly beta)
-# c2      = C_s variances (formerly lambda) 
+# c2      = C_s variances (formerly lambda)
 # a       = probability of being a star or galaxy.  a[1] is the
 #           probability of being a star and a[2] of being a galaxy. (formerly chi)
 # k       = {D|D-1}xIa matrix of color prior component indicators. (formerly kappa)
@@ -372,7 +370,7 @@ end
 
 #TODO: build these from ue_align, etc., here.
 align(::StarPosParams, CanonicalParams) = ids.u
-align(::GalaxyPosParams, CanonicalParams) = 
+align(::GalaxyPosParams, CanonicalParams) =
    [ids.u; ids.e_dev; ids.e_axis; ids.e_angle; ids.e_scale]
 align(::CanonicalParams, CanonicalParams) = [1:length(CanonicalParams)]
 
@@ -383,7 +381,7 @@ const brightness_standard_alignment = (bright_ids(1), bright_ids(2))
 
 # TODO: maybe these should be incorporated into the framework above (which I don't really understand.)
 ids_free_names = Array(ASCIIString, length(ids_free))
-for (name in names(ids_free)) 
+for (name in names(ids_free))
     inds = ids_free.(name)
     for i = 1:length(inds)
         ids_free_names[inds[i]] = "$(name)_$(i)"
@@ -391,7 +389,7 @@ for (name in names(ids_free))
 end
 
 ids_names = Array(ASCIIString, length(ids))
-for (name in names(ids)) 
+for (name in names(ids))
     inds = ids.(name)
     for i = 1:length(inds)
         ids_names[inds[i]] = "$(name)_$(i)"
@@ -458,7 +456,7 @@ function print_params(mp_tuple::ModelParams...)
         println("=======================\n Object $(s):")
         for var_name in names(ids)
             println(var_name)
-            mp_vars = [ collect(mp_tuple[index].vp[s][ids.(var_name)]) for index in 1:length(mp_tuple) ] 
+            mp_vars = [ collect(mp_tuple[index].vp[s][ids.(var_name)]) for index in 1:length(mp_tuple) ]
             println(reduce(hcat, mp_vars))
         end
     end
@@ -515,4 +513,3 @@ end
 #########################################################
 
 end
-

--- a/src/CelesteTypes.jl
+++ b/src/CelesteTypes.jl
@@ -382,20 +382,20 @@ const brightness_standard_alignment = (bright_ids(1), bright_ids(2))
 # TODO: maybe these should be incorporated into the framework above (which I don't really understand.)
 function get_id_names(ids::Union(CanonicalParams, UnconstrainedParams))
   ids_names = Array(ASCIIString, length(ids))
-  for (name in names(this_ids))
+  for (name in names(ids))
     inds = ids.(name)
-    if length(size(inds)) == 1
+    if length(size(inds)) == 0
       ids_names[inds] = "$(name)"
-    else if length(size(inds)) == 2
+    elseif length(size(inds)) == 1
       for i = 1:size(inds)[1]
           ids_names[inds[i]] = "$(name)_$(i)"
       end
-    else if length(size(inds)) == 3
+    elseif length(size(inds)) == 2
       for i = 1:size(inds)[1], j = 1:size(inds)[2]
           ids_names[inds[i, j]] = "$(name)_$(i)_$(j)"
       end
     else
-      error("Names of 3d parameters not supported.")
+      error("Names of 3d parameters not supported ($(name))")
     end
   end
   return ids_names
@@ -403,7 +403,6 @@ end
 
 const ids_names = get_id_names(ids)
 const ids_free_names = get_id_names(ids_free)
-
 
 #########################################################
 

--- a/src/OptimizeElbo.jl
+++ b/src/OptimizeElbo.jl
@@ -208,8 +208,19 @@ function get_nlopt_unconstrained_bounds(vp::Vector{Vector{Float64}},
     # ubs = [get_nlopt_bounds(vs)[2] for vs in vp]
     # (transform.vp_to_vector(lbs, omitted_ids),
     #     transform.vp_to_vector(ubs, omitted_ids))
-    vec_size = (length(ids_free) - length(omitted_ids)) * length(vp)
-    fill(-100.0, vec_size), fill(100.0, vec_size)
+
+    kept_ids = setdiff(1:length(UnconstrainedParams), omitted_ids)
+    lbs = fill(-100.0, length(ids_free), length(vp))
+    ubs = fill(100.0, length(ids_free), length(vp))
+
+    # Change the bounds to match the scaling
+    for s=1:length(vp)
+      for (param, bounds) in transform.bounds[s]
+        lbs[collect(ids_free.(param)), s] *= bounds[3]
+        ubs[collect(ids_free.(param)), s] *= bounds[3]
+      end
+    end
+    reduce(vcat, lbs[kept_ids, :]), reduce(vcat, ubs[kept_ids, :])
 end
 
 

--- a/src/SDSS.jl
+++ b/src/SDSS.jl
@@ -69,7 +69,7 @@ function load_stamp_catalog_df(cat_dir, stamp_id, blob; match_blob=false)
 
     df = DataFrames.DataFrame()
     for i in 1:num_cols
-        tmp_data = read(cat_fits[2], ttypes[i])        
+        tmp_data = read(cat_fits[2], ttypes[i])
         df[symbol(ttypes[i])] = tmp_data
     end
 
@@ -114,7 +114,7 @@ function convert_catalog_to_celeste(df::DataFrames.DataFrame, blob; match_blob=f
         fits_theta = fracs_dev[1] > .5 ? row[1, :theta_dev] : row[1, :theta_exp]
 
         # tractor defines phi as -1 * the phi catalog for some reason.
-        if !match_blob  
+        if !match_blob
             fits_phi *= -1.
         end
 
@@ -216,7 +216,7 @@ Args:
 
 Returns:
  - nelec: An image of raw electron counts in nanomaggies
- - calib_col: A column of calibration values (the same for every column of the image) 
+ - calib_col: A column of calibration values (the same for every column of the image)
  - sky_grid: A CoordInterpGrid bilinear interpolation object
  - sky_x: The x coordinates at which to evaluate sky_grid to match nelec.
  - sky_y: The y coordinates at which to evaluate sky_grid to match nelec.
@@ -273,9 +273,7 @@ function load_raw_field(field_dir, run_num, camcol_num, field_num, b, gain)
                                     Grid.BCnearest, Grid.InterpLinear)
 
     # This interpolation is really slow.
-    print("...starting sky fit...")
     sky_image = [ sky_grid[x, y] for x in sky_x, y in sky_y ]
-    print("done with sky fit. ")
 
     # Convert to raw electron counts.  Note that these may not be close to integers
     # due to the analog to digital conversion process in the telescope.
@@ -304,7 +302,7 @@ Returns:
 function mask_image!(mask_img, field_dir, run_num, camcol_num, field_num, band;
                      python_indexing = false,
                      mask_planes = Set({"S_MASK_INTERP", "S_MASK_SATUR", "S_MASK_CR", "S_MASK_GHOST"}))
-    # The default mask planes are those used by Dustin's astrometry.net code.    
+    # The default mask planes are those used by Dustin's astrometry.net code.
     # See the comments in sdss/dr8.py for fpM.setMaskedPixels
     # and the function sdss/common.py:fpM.setMaskedPixels
     #
@@ -508,7 +506,7 @@ function load_sdss_blob(field_dir, run_num, camcol_num, field_num)
         H = size(nelec, 1)
         W = size(nelec, 2)
 
-        # For now, use the median noise and sky image.  Here, 
+        # For now, use the median noise and sky image.  Here,
         # epsilon * iota needs to be in units comparable to nelec electron counts.
         # Note that each are actuall pretty variable.
         iota = convert(Float64, band_gain[b] / median(calib_col))

--- a/src/Transform.jl
+++ b/src/Transform.jl
@@ -149,7 +149,7 @@ end
 # Functions to take actual parameter vectors.
 
 # Treat the simplex bounds separately.
-const simplex_min = 0.01
+const simplex_min = 0.005
 
 @doc """
 Convert a variational parameter vector to an unconstrained version using

--- a/src/Transform.jl
+++ b/src/Transform.jl
@@ -377,7 +377,7 @@ function get_mp_transform(mp::ModelParams; loc_width::Float64=1e-3)
     # Bounds that are too large cause numerical errors.
     bounds[s] = ParamBounds()
     bounds[s][:u] = (mp.vp[s][ids.u] - loc_width, mp.vp[s][ids.u] + loc_width, 1.0)
-    bounds[s][:r1] = (1e-4, Inf, 1e-3)
+    bounds[s][:r1] = (1e-4, Inf, 1e-2)
     bounds[s][:r2] = (1e-4, 0.1, 1.0)
     bounds[s][:c1] = (-10., 10., 1.0)
     bounds[s][:c2] = (1e-4, 1., 1.0)

--- a/src/Transform.jl
+++ b/src/Transform.jl
@@ -6,28 +6,31 @@ using Celeste
 using CelesteTypes
 
 import Util
+VERSION < v"0.4.0-dev" && using Docile
 
 export pixel_rect_transform, world_rect_transform, free_transform, identity_transform, DataTransform
+
 
 #export unconstrain_vp, rect_unconstrain_vp, constrain_vp, rect_constrain_vp
 #export unconstrain_vp!, rect_unconstrain_vp!, constrain_vp!, rect_constrain_vp!
 #export rect_unconstrain_sensitive_float, unconstrain_sensitive_float
 
+@doc """
+Functions to move between a single source's variational parameters and a
+transformation of the data for optimization.
+
+to_vp: A function that takes transformed parameters and returns variational parameters
+from_vp: A function that takes variational parameters and returned transformed parameters
+to_vp!: A function that takes (transformed paramters, variational parameters) and updates
+  the variational parameters in place
+from_vp!: A function that takes (variational paramters, transformed parameters) and updates
+  the transformed parameters in place
+...
+transform_sensitive_float: A function that takes (sensitive float, model parameters)
+  where the sensitive float contains partial derivatives with respect to the
+  variational parameters and returns a sensitive float with total derivatives with
+  respect to the transformed parameters. """ ->
 type DataTransform
-	# Functions to move between a ModelParameters object and a
-	# transformation of the data for optimization.
-    #
-    # to_vp: A function that takes transformed parameters and returns variational parameters
-    # from_vp: A function that takes variational parameters and returned transformed parameters
-    # to_vp!: A function that takes (transformed paramters, variational parameters) and updates
-    #   the variational parameters in place
-    # from_vp!: A function that takes (variational paramters, transformed parameters) and updates
-    #   the transformed parameters in place
-    # ...
-    # transform_sensitive_float: A function that takes (sensitive float, model parameters)
-    #   where the sensitive float contains partial derivatives with respect to the
-    #   variational parameters and returns a sensitive float with total derivatives with
-    #   respect to the transformed parameters.
 
 	to_vp::Function
 	from_vp::Function
@@ -41,28 +44,26 @@ type DataTransform
                   vector_to_trans_vp!::Function, trans_vp_to_vector::Function,
                   transform_sensitive_float::Function, id_size::Integer) = begin
 
-        function from_vp{NumType <: Number}(vp::VariationalParams{NumType})
-            S = length(vp)
-            vp_free = [ zeros(NumType, id_size) for s = 1:S]
+        function from_vp{NumType <: Number}(vp::Vector{NumType})
+            vp_free = zeros(NumType, id_size)
             from_vp!(vp, vp_free)
             vp_free
         end
 
-        function to_vp{NumType <: Number}(vp_free::FreeVariationalParams{NumType})
-            S = length(vp_free)
-            vp = [ zeros(length(CanonicalParams)) for s = 1:S]
+        function to_vp{NumType <: Number}(vp_free::Vector{NumType})
+            vp = zeros(length(CanonicalParams))
             to_vp!(vp_free, vp)
             vp
         end
 
-        function vp_to_vector{NumType <: Number}(vp::VariationalParams{NumType},
+        function vp_to_vector{NumType <: Number}(vp::Vector{NumType},
                                                  omitted_ids::Vector{Int64})
             vp_trans = from_vp(vp)
             trans_vp_to_vector(vp_trans, omitted_ids)
         end
 
         function vector_to_vp!{NumType <: Number}(xs::Vector{NumType},
-                                                  vp::VariationalParams{NumType},
+                                                  vp::Vector{NumType},
                                                   omitted_ids::Vector{Int64})
             # This needs to update vp in place so that variables in omitted_ids
             # stay at their original values.
@@ -78,15 +79,11 @@ end
 
 ###############################################
 # Functions for an identity transform.
-function unchanged_vp!(vp::VariationalParams, new_vp::VariationalParams)
-    # Leave the vp unchanged.
-    S = length(vp)
-    for s = 1:S
-        new_vp[s][:] = vp[s]
-    end
+function unchanged_vp!{NumType <: Number}(vp::Vector{NumType}, new_vp::Vector{NumType})
+    new_vp[:] = vp
 end
 
-function unchanged_sensitive_float(sf::SensitiveFloat, mp::ModelParams)
+function unchanged_sensitive_float{NumType <: Number}(sf::SensitiveFloat, vp::Vector{NumType})
     # Leave the sensitive float unchanged.
     deepcopy(sf)
 end
@@ -95,22 +92,22 @@ end
 #####################
 # Conversion to and from vectors.
 
-function unchanged_vp_to_vector(vp::VariationalParams, omitted_ids::Vector{Int64})
+function unchanged_vp_to_vector{NumType <: Number}(vp::Vector{NumType}, omitted_ids::Vector{Int64})
     # There is probably no use for this function, since you'll only be passing
     # trasformations to the optimizer, but I'll include it for completeness.
     error("Converting untransformed VarationalParams to a vector is not supported.")
 end
 
 
-function unchanged_vector_to_vp!(xs::Vector{Float64}, vp::VariationalParams,
-                                 omitted_ids::Vector{Int64})
+function unchanged_vector_to_vp!{NumType <: Number}(xs::Vector{Float64}, vp::Vector{NumType},
+                                                    omitted_ids::Vector{Int64})
     # There is probably no use for this function, since you'll only be passing
     # trasformations to the optimizer, but I'll include it for completeness.
     error("Converting from a vector to untransformed VarationalParams is not supported.")
 end
 
 
-function free_vp_to_vector{NumType <: Number}(vp::FreeVariationalParams{NumType},
+function free_vp_to_vector{NumType <: Number}(vp::Vector{NumType},
                                               omitted_ids::Vector{Int64})
     # vp = variational parameters
     # omitted_ids = ids in ParamIndex
@@ -119,22 +116,13 @@ function free_vp_to_vector{NumType <: Number}(vp::FreeVariationalParams{NumType}
     # trasformations to the optimizer, but I'll include it for completeness.
 
     left_ids = setdiff(1:length(UnconstrainedParams), omitted_ids)
-    new_P = length(left_ids)
-
-    S = length(vp)
-    vp_new = [zeros(NumType, new_P) for s in 1:S]
-
-    for p1 in 1:length(left_ids)
-        p0 = left_ids[p1]
-        [ vp_new[s][p1] = vp[s][p0] for s in 1:S ]
-    end
-
-    reduce(vcat, vp_new)
+    new_p = 1:length(left_ids)
+    new_p[:] = vp[left_ids]
 end
 
 
 function vector_to_free_vp!{NumType <: Number}(xs::Vector{NumType},
-                                               vp_free::FreeVariationalParams{NumType},
+                                               vp_free::Vector{NumType},
                                                omitted_ids::Vector{Int64})
     # xs: A vector created from free variational parameters.
     # free_vp: Free variational parameters.  Only the ids not in omitted_ids
@@ -142,215 +130,72 @@ function vector_to_free_vp!{NumType <: Number}(xs::Vector{NumType},
     # omitted_ids: Ids to omit (from ids_free)
 
     left_ids = setdiff(1:length(UnconstrainedParams), omitted_ids)
-
-    P = length(left_ids)
-    @assert length(xs) % P == 0
-    S = int(length(xs) / P)
-    xs2 = reshape(xs, P, S)
-
-    for s in 1:S
-        for p1 in 1:length(left_ids)
-            p0 = left_ids[p1]
-            vp_free[s][p0] = xs2[p1, s]
-        end
-    end
-end
-
-
-
-###############################################
-# Functions for a "rectangular transform".  This matches the original Celeste
-# script, contraining a to sum to one and scaling r1.
-
-# Rescale some parameters to have similar dimensions to everything else.
-const world_rect_rescaling = ones(length(UnconstrainedParams))
-[world_rect_rescaling[id] *= 1e-3 for id in ids_free.r1]
-[world_rect_rescaling[id] *= 1e5 for id in ids_free.u]
-
-const pixel_rect_rescaling = ones(length(UnconstrainedParams))
-[pixel_rect_rescaling[id] *= 1e-3 for id in ids_free.r1]
-
-rect_unchanged_ids = [ "u", "r1", "r2",
-                       "e_dev", "e_axis", "e_angle", "e_scale",
-                       "c1", "c2"]
-
-function vp_to_rect!{NumType <: Number}(vp::VariationalParams{NumType},
-                                        vp_free::RectVariationalParams{NumType},
-                                        rect_rescaling::Array{Float64, 1})
-    # Convert a constrained to an unconstrained variational parameterization
-    # that does not use logit or exp.
-
-    S = length(vp)
-    for s = 1:S
-        # Variables that are unaffected by constraints (except for scaling):
-        for id_string in rect_unchanged_ids
-            id_symbol = convert(Symbol, id_string)
-            vp_free[s][ids_free.(id_symbol)] = vp[s][ids.(id_symbol)]
-        end
-
-        # Simplicial constriants.  The original script used "a" to only
-        # refer to the probability of being a galaxy, which is now the
-        # second component of a.
-        vp_free[s][ids_free.a[1]] = vp[s][ids.a[2]]
-
-        # Keep all but the last row of k.
-        vp_free[s][ids_free.k] = vp[s][ids.k[1:(D - 1), :]]
-
-        for i in 1:length(ids_free)
-            vp_free[s][i] = vp_free[s][i] .* rect_rescaling[i]
-        end
-    end
-end
-
-function rect_to_vp!{NumType <: Number}(vp_free::RectVariationalParams{NumType},
-                                        vp::VariationalParams{NumType},
-                                        rect_rescaling::Array{Float64, 1})
-    # Convert an unconstrained to an constrained variational parameterization
-    # where we don't use exp or logit.
-
-    S = length(vp_free)
-    for s = 1:S
-        scaled_vp_free = deepcopy(vp_free[s])
-        for i = 1:length(ids_free)
-            scaled_vp_free[i] = scaled_vp_free[i] / rect_rescaling[i]
-        end
-
-        # Variables that are unaffected by constraints (except for scaling):
-        for id_string in rect_unchanged_ids
-            id_symbol = convert(Symbol, id_string)
-            vp[s][ids.(id_symbol)] = scaled_vp_free[ids_free.(id_symbol)]
-        end
-
-        # Simplicial constriants.
-        vp[s][ids.a[2]] = scaled_vp_free[ids_free.a[1]]
-        vp[s][ids.a[1]] = 1.0 - vp[s][ids.a[2]]
-
-        vp[s][ids.k[1, :]] = scaled_vp_free[ids_free.k]
-        vp[s][ids.k[2, :]] = 1 - vp[s][ids.k[1, :]]
-    end
-end
-
-function rect_unconstrain_sensitive_float{NumType  <: Number}(sf::SensitiveFloat,
-                                                              mp::ModelParams{NumType},
-                                                              rect_rescaling::Array{Float64, 1})
-    # Given a sensitive float with derivatives with respect to all the
-    # constrained parameters, calculate derivatives with respect to
-    # the unconstrained parameters.
-    #
-    # Note that all the other functions in ElboDeriv calculated derivatives with
-    # respect to the unconstrained parameterization.
-
-    # Require that the input have all derivatives defined.
-    @assert size(sf.d) == (length(CanonicalParams), mp.S)
-
-    sf_free = zero_sensitive_float(UnconstrainedParams, NumType, mp.S)
-    sf_free.v = sf.v
-
-    for s in 1:mp.S
-        # Variables that are unaffected by constraints (except for scaling):
-        for id_string in rect_unchanged_ids
-            id_symbol = convert(Symbol, id_string)
-
-            # Flatten the indices for matrix indexing
-            id_free_indices = reduce(vcat, ids_free.(id_symbol))
-            id_indices = reduce(vcat, ids.(id_symbol))
-
-            sf_free.d[id_free_indices, s] = sf.d[id_indices, s]
-        end
-
-        # Simplicial constriants.
-        sf_free.d[ids_free.a[1], s] = sf.d[ids.a[2], s] - sf.d[ids.a[1], s]
-
-        sf_free.d[collect(ids_free.k[1, :]), s] =
-            sf.d[collect(ids.k[1, :]), s] - sf.d[collect(ids.k[2, :]), s]
-
-        for i in 1:length(ids_free)
-            sf_free.d[i, s] = sf_free.d[i, s] ./ rect_rescaling[i]
-        end
-    end
-
-    sf_free
-end
-
-
-function pixel_vp_to_rect!{NumType <: Number}(vp::VariationalParams{NumType},
-                                              vp_free::RectVariationalParams{NumType})
-    vp_to_rect!(vp, vp_free, pixel_rect_rescaling)
-end
-
-function world_vp_to_rect!{NumType <: Number}(vp::VariationalParams{NumType},
-                                              vp_free::RectVariationalParams{NumType})
-    vp_to_rect!(vp, vp_free, world_rect_rescaling)
-end
-
-function pixel_rect_to_vp!{NumType <: Number}(vp_free::RectVariationalParams{NumType}, vp::VariationalParams{NumType})
-    rect_to_vp!(vp_free, vp, pixel_rect_rescaling)
-end
-
-function world_rect_to_vp!{NumType <: Number}(vp_free::RectVariationalParams{NumType}, vp::VariationalParams{NumType})
-    rect_to_vp!(vp_free, vp, world_rect_rescaling)
-end
-
-function pixel_rect_unconstrain_sensitive_float(sf::SensitiveFloat, mp::ModelParams)
-    rect_unconstrain_sensitive_float(sf, mp, pixel_rect_rescaling)
-end
-
-function world_rect_unconstrain_sensitive_float(sf::SensitiveFloat, mp::ModelParams)
-    rect_unconstrain_sensitive_float(sf, mp, world_rect_rescaling)
+    vp_free[left_ids] = xs
 end
 
 
 ###############################################
-# Functions for a "free transform".  Eventually the idea is that this will
-# have every parameter completely unconstrained.
-free_unchanged_ids = [ "u", "e_angle", "e_scale", "c1", "c2"]
+# Functions for a "free transform".
 
-# Outside these values the Elbo is not reliable.
-const free_r1_min = 1e-4
-const free_r2_min = 1e-4
-const free_r1_max = 1e12
-const free_r2_max = 0.1
+function unbox_parameter(param::Union(Float64, Vector{Float64}), upper_bound::Float64, lower_bound::Float64)
+    @assert(all(lower_bound .< param .< upper_bound), "param outside bounds: $param ($lower_bound, $upper_bound)")
+    param_scaled = (param - lower_bound) / (upper_bound - lower_bound)
+    Util.inv_logit(param_scaled)
+end
 
-function vp_to_free!{NumType <: Number}(vp::VariationalParams{NumType},
-                                        vp_free::FreeVariationalParams{NumType})
-    # Convert a constrained to an unconstrained variational parameterization
-    # on all of the real line.
-    S = length(vp)
-    for s = 1:S
-        # Variables that are unaffected by constraints:
-        for id_string in free_unchanged_ids
-            id_symbol = convert(Symbol, id_string)
-            vp_free[s][ids_free.(id_symbol)] = vp[s][ids.(id_symbol)]
-        end
+function box_parameter(free_param::Union(Float64, Vector{Float64}), upper_bound::Float64, lower_bound::Float64)
+    Util.logit(free_params) * (upper_bound - lower_bound) + lower_bound
+end
 
-        # Simplicial constriants.  The original script used "a" to only
-        # refer to the probability of being a galaxy, which is now the
-        # second component of a.
-        vp_free[s][ids_free.a[1]] = Util.inv_logit(vp[s][ids.a[2]])
+function unbox_sensitive_float!(sf::SensitiveFloat,
+                                param::Union(Float64, Vector{Float64}), upper_bound::Float64, lower_bound::Float64,
+                                index::Union(Int64, Vector{Int64}), s::Int64)
+    @assert length(param) == length(index)
 
-        # In contrast, the original script used the last component of k
-        # as the free parameter.
-        vp_free[s][ids_free.k[1, :]] = Util.inv_logit(vp[s][ids.k[1, :]])
+    # Box constraints.  Strict inequality is not required for derivatives.
+    @assert(all(lower_bound .<= param .<= upper_bound), "param outside bounds: $param ($lower_bound, $upper_bound)")
+    param_scaled = (param - lower_bound) ./ (upper_bound - lower_bound)
+    sf.d[index, s] = sf.d[index, s] .* param_scaled .* (1 - param_scaled) .* (upper_bound - lower_bound)
+end
 
-        # [0, 1] constraints.
-        vp_free[s][ids_free.e_dev] = Util.inv_logit(vp[s][ids_free.e_dev])
-        vp_free[s][ids_free.e_axis] = Util.inv_logit(vp[s][ids.e_axis])
 
-        # Positivity constraints
-        vp_free[s][ids_free.e_scale] = log(vp[s][ids.e_scale])
-        vp_free[s][ids_free.c2] = log(vp[s][ids.c2])
+# Just for example.  In real life each source gets its own location constraints.
+typealias ParamBounds Dict{Symbol, (Float64, Float64)}
+bounds = ParamBounds()
+bounds[:u] = (-1., 1.)
+bounds[:r1] = (1e-4, 1e12)
+bounds[:r2] = (1e-4, 0.1)
+bounds[:c1] = (-10., 10.)
+bounds[:c2] = (1e-4, 1.)
+bounds[:e_dev] = (1e-2, 1 - 1e-2)
+bounds[:e_axis] = (1e-4, 1 - 1e-4)
+bounds[:e_angle] = (-1e10, 1e10)
+bounds[:e_scale] = (0.2, 15)
 
-        # Box constraints.  Strict inequality is required for the transform to exist.
-        @assert(all(free_r1_min .< vp[s][ids.r1] .< free_r1_max),
-                "r1 outside bounds for $s: $(vp[s][ids.r1])")
-        @assert(all(free_r2_min .< vp[s][ids.r2] .< free_r2_max),
-                "r2 outside bounds for $s: $(vp[s][ids.r2])")
-        free_r1_scaled = (vp[s][ids.r1] - free_r1_min) / (free_r1_max - free_r1_min)
-        free_r2_scaled = (vp[s][ids.r2] - free_r2_min) / (free_r2_max - free_r2_min)
-        vp_free[s][ids_free.r1] = Util.inv_logit(free_r1_scaled)
-        vp_free[s][ids_free.r2] = Util.inv_logit(free_r2_scaled)
+
+
+@doc """
+Convert a variational parameter vector to an unconstrained version using
+the lower bounds lbs and ubs (which are expressed)
+""" ->
+function vp_to_free!{NumType <: Number}(vp::Vector{NumType},
+                                        vp_free::Vector{NumType},
+                                        bounds::ParamBounds)
+    # Simplicial constriants.  The original script used "a" to only
+    # refer to the probability of being a galaxy, which is now the
+    # second component of a.
+    vp_free[ids_free.a[1]] = Util.inv_logit(vp[ids.a[2]])
+
+    # In contrast, the original script used the last component of k
+    # as the free parameter.
+    vp_free[ids_free.k[1, :]] = Util.inv_logit(vp[ids.k[1, :]])
+
+    # Box constraints.
+    for param, limits in bounds
+        vp_free[ids_free.(param)] = unbox_parameter(vp[ids.(param)], limits[1], limits[2])
     end
 end
+
 
 function free_to_vp!{NumType <: Number}(vp_free::FreeVariationalParams{NumType},
                                         vp::VariationalParams{NumType})

--- a/src/Transform.jl
+++ b/src/Transform.jl
@@ -352,7 +352,7 @@ function get_mp_transform(mp::ModelParams; loc_width::Float64=1e-3)
     bounds[s][:c2] = (1e-4, 1.)
     bounds[s][:e_dev] = (1e-2, 1 - 1e-2)
     bounds[s][:e_axis] = (1e-2, 1 - 1e-2)
-    bounds[s][:e_angle] = (-1e4, 1e4)
+    bounds[s][:e_angle] = (-10.0, 10.0)
     bounds[s][:e_scale] = (0.2, 15.)
   end
   DataTransform(bounds)

--- a/src/Transform.jl
+++ b/src/Transform.jl
@@ -47,10 +47,11 @@ end
 ###############################################
 # Functions for a "free transform".
 
+# TODO: These need to be made more flxeible.
 function unbox_parameter{NumType <: Number}(
-  param::Union(NumType, Vector{NumType}), upper_bound::Float64, lower_bound::Float64)
+  param::Union(NumType, Array{NumType}), lower_bound::Float64, upper_bound::Float64)
     @assert(all(lower_bound .< param .< upper_bound),
-            "param outside bounds: $param ($lower_bound, $upper_bound)")
+            "unbox_parameter: param outside bounds: $param ($lower_bound, $upper_bound)")
     param_scaled = (param - lower_bound) / (upper_bound - lower_bound)
     Util.inv_logit(param_scaled)
 end
@@ -67,13 +68,13 @@ to these paraemters.
 """ ->
 function unbox_derivative{NumType <: Number}(
   param::Union(NumType, Vector{NumType}), deriv::Union(NumType, Vector{NumType}),
-  upper_bound::Float64, lower_bound::Float64)
+  lower_bound::Float64, upper_bound::Float64)
     @assert(length(param) == length(deriv) == length(free_deriv),
             "Wrong length parameters for unbox_sensitive_float")
 
     # Box constraints.  Strict inequality is not required for derivatives.
     @assert(all(lower_bound .<= param .<= upper_bound),
-            "param outside bounds: $param ($lower_bound, $upper_bound)")
+            "unbox_derivative: param outside bounds: $param ($lower_bound, $upper_bound)")
     param_scaled = (param - lower_bound) ./ (upper_bound - lower_bound)
 
     deriv .* param_scaled .* (1 - param_scaled) .* (upper_bound - lower_bound)

--- a/src/Transform.jl
+++ b/src/Transform.jl
@@ -135,6 +135,8 @@ function unbox_derivative{NumType <: Number}(
     end
 end
 
+######################
+# Functions to take actual parameter vectors.
 
 @doc """
 Convert a variational parameter vector to an unconstrained version using
@@ -337,6 +339,9 @@ end
 
 function get_mp_transform(mp::ModelParams; loc_width::Float64=1e-3)
   bounds = Array(ParamBounds, mp.S)
+
+  # Note that, for numerical reasons, the bounds must be on the scale
+  # of reasonably meaningful changes.
   for s=1:mp.S
     # Bounds that are too large cause numerical errors.
     bounds[s] = ParamBounds()
@@ -346,7 +351,7 @@ function get_mp_transform(mp::ModelParams; loc_width::Float64=1e-3)
     bounds[s][:c1] = (-10., 10.)
     bounds[s][:c2] = (1e-4, 1.)
     bounds[s][:e_dev] = (1e-2, 1 - 1e-2)
-    bounds[s][:e_axis] = (1e-4, 1 - 1e-4)
+    bounds[s][:e_axis] = (1e-2, 1 - 1e-2)
     bounds[s][:e_angle] = (-1e4, 1e4)
     bounds[s][:e_scale] = (0.2, 15.)
   end

--- a/src/Transform.jl
+++ b/src/Transform.jl
@@ -305,6 +305,12 @@ end
 # have every parameter completely unconstrained.
 free_unchanged_ids = [ "u", "e_angle", "e_scale", "c1", "c2"]
 
+# Outside these values the Elbo is not reliable.
+const free_r1_min = 1e-4
+const free_r2_min = 1e-4
+const free_r1_max = 1e12
+const free_r2_max = 0.1
+
 function vp_to_free!{NumType <: Number}(vp::VariationalParams{NumType},
                                         vp_free::FreeVariationalParams{NumType})
     # Convert a constrained to an unconstrained variational parameterization
@@ -333,8 +339,16 @@ function vp_to_free!{NumType <: Number}(vp::VariationalParams{NumType},
         # Positivity constraints
         vp_free[s][ids_free.e_scale] = log(vp[s][ids.e_scale])
         vp_free[s][ids_free.c2] = log(vp[s][ids.c2])
-        vp_free[s][ids_free.r1] = log(vp[s][ids.r1])
-        vp_free[s][ids_free.r2] = log(vp[s][ids.r2])
+
+        # Box constraints.  Strict inequality is required for the transform to exist.
+        @assert(all(free_r1_min .< vp[s][ids.r1] .< free_r1_max),
+                "r1 outside bounds for $s: $(vp[s][ids.r1])")
+        @assert(all(free_r2_min .< vp[s][ids.r2] .< free_r2_max),
+                "r2 outside bounds for $s: $(vp[s][ids.r2])")
+        free_r1_scaled = (vp[s][ids.r1] - free_r1_min) / (free_r1_max - free_r1_min)
+        free_r2_scaled = (vp[s][ids.r2] - free_r2_min) / (free_r2_max - free_r2_min)
+        vp_free[s][ids_free.r1] = Util.inv_logit(free_r1_scaled)
+        vp_free[s][ids_free.r2] = Util.inv_logit(free_r2_scaled)
     end
 end
 
@@ -363,8 +377,10 @@ function free_to_vp!{NumType <: Number}(vp_free::FreeVariationalParams{NumType},
         # Positivity constraints
         vp[s][ids.e_scale] = exp(vp_free[s][ids_free.e_scale])
         vp[s][ids.c2] = exp(vp_free[s][ids_free.c2])
-        vp[s][ids.r1] = exp(vp_free[s][ids_free.r1])
-        vp[s][ids.r2] = exp(vp_free[s][ids_free.r2])
+
+        # Box constraints.
+        vp[s][ids.r1] = Util.logit(vp_free[s][ids.r1]) * (free_r1_max - free_r1_min) + free_r1_min
+        vp[s][ids.r2] = Util.logit(vp_free[s][ids.r2]) * (free_r2_max - free_r2_min) + free_r2_min
     end
 end
 
@@ -415,10 +431,17 @@ function free_unconstrain_sensitive_float{NumType <: Number}(sf::SensitiveFloat,
 
         # Positivity constraints.
         sf_free.d[ids_free.e_scale, s] = sf.d[ids.e_scale, s] .* mp.vp[s][ids.e_scale]
-        sf_free.d[collect(ids_free.c2), s] =
-            sf.d[collect(ids.c2), s] .* mp.vp[s][collect(ids.c2)]
-        sf_free.d[ids_free.r1, s] = sf.d[ids.r1, s] .* mp.vp[s][ids.r1]
-        sf_free.d[ids_free.r2, s] = sf.d[ids.r2, s] .* mp.vp[s][ids.r2]
+        sf_free.d[collect(ids_free.c2), s] = sf.d[collect(ids.c2), s] .* mp.vp[s][collect(ids.c2)]
+
+        # Box constraints.  Strict inequality is not required for derivatives.
+        @assert(all(free_r1_min .<= mp.vp[s][ids.r1] .<= free_r1_max),
+                "r1 outside bounds for $s: $(mp.vp[s][ids.r1])")
+        @assert(all(free_r2_min .<= mp.vp[s][ids.r2] .<= free_r2_max),
+                "r2 outside bounds for $s: $(mp.vp[s][ids.r2])")
+        free_r1_scaled = (mp.vp[s][ids.r1] - free_r1_min) / (free_r1_max - free_r1_min)
+        free_r2_scaled = (mp.vp[s][ids.r2] - free_r2_min) / (free_r2_max - free_r2_min)
+        sf_free.d[ids_free.r1, s] = sf.d[ids.r1, s] .* free_r1_scaled .* (1 - free_r1_scaled) .* (free_r1_max - free_r1_min)
+        sf_free.d[ids_free.r2, s] = sf.d[ids.r2, s] .* free_r2_scaled .* (1 - free_r2_scaled) .* (free_r2_max - free_r2_min)
     end
 
     sf_free

--- a/test/test_constraints.jl
+++ b/test/test_constraints.jl
@@ -10,6 +10,7 @@ using Transform
 using DualNumbers
 import ModelInit
 
+println("Running constraint tests.")
 
 function test_transform_box_functions()
 	function box_and_unbox(param, lower_bound, upper_bound; scale=1.0)

--- a/test/test_constraints.jl
+++ b/test/test_constraints.jl
@@ -114,5 +114,5 @@ function test_parameter_conversion()
 	end
 end
 
-test_parameter_conversion()
 test_transform_box_functions()
+test_parameter_conversion()

--- a/test/test_constraints.jl
+++ b/test/test_constraints.jl
@@ -7,7 +7,7 @@ using Base.Test
 using SampleData
 using Transform
 
-import DualNumbers
+using DualNumbers
 import ModelInit
 
 
@@ -21,11 +21,20 @@ function test_transform_box_functions()
 	box_and_unbox(1.0, -1.0, 2.0)
 	box_and_unbox(1.0, -1.0, Inf)
 
+	# Test that the edges work.
+	box_and_unbox(-1.0, -1.0, 2.0)
+	box_and_unbox(2.0, -1.0, 2.0)
+	box_and_unbox(-1.0, -1.0, Inf)
+
 	box_and_unbox([1.0, 1.5], -1.0, 2.0)
 	box_and_unbox([1.0, 1.5], -1.0, Inf)
 
 	box_and_unbox([1.0, 10.0], [-1.0, 9.0], [2.0, 12.0])
 	box_and_unbox([1.0, 10.0], [-1.0, 9.0], [Inf, Inf])
+
+	box_and_unbox(Dual(1.0), -1.0, 2.0)
+	box_and_unbox([Dual(1.0), Dual(1.5)], -1.0, 2.0)
+	box_and_unbox([Dual(1.0), Dual(10.0)], [-1.0, 9.0], [2.0, 12.0])
 
 	# Just check that these run.  The derivatives themselves
 	# will be checked elsewhere.
@@ -35,6 +44,9 @@ function test_transform_box_functions()
 		[1.0, 10.0], [2.0, 3.0], [-1.0, 9.0], [2.0, 12.0])
 	Transform.unbox_derivative(
 		[1.0, 10.0], [2.0, 3.0], [-1.0, 9.0], [Inf, Inf])
+	Transform.unbox_derivative(Dual(1.0), Dual(2.0), -1.0, 2.0)
+	Transform.unbox_derivative(
+		[Dual(1.0), Dual(10.0)], [Dual(2.0), Dual(3.0)], [-1.0, 9.0], [2.0, 12.0])
 
 	# Check the bounds checking errors.
 	@test_throws Exception Transform.unbox_parameter(1.0, 2.0, 3.0)
@@ -49,7 +61,6 @@ function test_transform_box_functions()
 		[1.0, 10.0], [-1.0, 9.0], [2.0, Inf])
 	@test_throws Exception Transform.unbox_derivative(
 		[1.0, 10.0], [2.0, 3.0], [-1.0, 9.0], [2.0, Inf])
-
 end
 
 

--- a/test/test_constraints.jl
+++ b/test/test_constraints.jl
@@ -9,8 +9,9 @@ using Transform
 
 import ModelInit
 
-function test_parameter_conversion(transform::DataTransform)
+function test_parameter_conversion()
 	blob, mp, body = gen_three_body_dataset();
+	transform = get_mp_transform(mp, loc_width=1.0)
 	original_vp = deepcopy(mp.vp);
 
 	# Check that the constrain and unconstrain operations undo each other.

--- a/test/test_constraints.jl
+++ b/test/test_constraints.jl
@@ -9,6 +9,7 @@ using Transform
 
 import ModelInit
 
+
 function test_parameter_conversion()
 	blob, mp, body = gen_three_body_dataset();
 	transform = get_mp_transform(mp, loc_width=1.0);
@@ -19,7 +20,7 @@ function test_parameter_conversion()
 	vp2 = transform.to_vp(vp_free)
 
 	for id in names(ids), s in 1:mp.S
-		@test_approx_eq original_vp[s][ids.(id)] vp2[s][ids.(id)]
+		@test_approx_eq_eps(original_vp[s][ids.(id)], vp2[s][ids.(id)], 1e-6)
 	end
 
 	# Check conversion to and from a vector.
@@ -28,14 +29,19 @@ function test_parameter_conversion()
 	x = transform.vp_to_vector(vp, omitted_ids)
 	@test length(x) == length(vp_free[1]) * mp.S
 
-	# Why is this convert necessary?
-	vp2 = convert(VariationalParams{Float64}, [ zeros(Float64, length(vp[1])) for s = 1:mp.S ])
+	# Generate parameters within the bounds.
+	vp2 = convert(VariationalParams{Float64},
+	              [ zeros(Float64, length(vp[1])) for s = 1:mp.S ])
+	for s=1:mp.S
+		for (param, limits) in transform.bounds[s]
+	    vp2[s][ids.(param)] = 0.5 * (limits[2] - limits[1]) + limits[1]
+	  end
+	end
+
 	transform.vector_to_vp!(x, vp2, omitted_ids)
 	for id in names(ids), s in 1:mp.S
-		@test_approx_eq original_vp[s][ids.(id)] vp2[s][ids.(id)]
+		@test_approx_eq_eps(original_vp[s][ids.(id)], vp2[s][ids.(id)], 1e-6)
 	end
 end
 
-for transform in [ pixel_rect_transform world_rect_transform free_transform ]
-	test_parameter_conversion(transform)
-end
+test_parameter_conversion()

--- a/test/test_constraints.jl
+++ b/test/test_constraints.jl
@@ -11,7 +11,7 @@ import ModelInit
 
 function test_parameter_conversion()
 	blob, mp, body = gen_three_body_dataset();
-	transform = get_mp_transform(mp, loc_width=1.0)
+	transform = get_mp_transform(mp, loc_width=1.0);
 	original_vp = deepcopy(mp.vp);
 
 	# Check that the constrain and unconstrain operations undo each other.

--- a/test/test_derivs.jl
+++ b/test/test_derivs.jl
@@ -240,22 +240,23 @@ function test_derivative_transform()
   box_param = [1.0, 2.0, 1.001]
   lower_bounds = [-1.0, -2.0, 1.0]
   upper_bounds = [2.0, Inf, Inf]
+  scales = [ 2.0, 3.0, 100.0 ]
   N = length(box_param)
 
-  function get_free_param(box_param, lower_bounds, upper_bounds)
+  function get_free_param(box_param, lower_bounds, upper_bounds, scales)
     free_param = zeros(Float64, N)
     for n=1:N
       free_param[n] =
-        Transform.unbox_parameter(box_param[n], lower_bounds[n], upper_bounds[n])
+        Transform.unbox_parameter(box_param[n], lower_bounds[n], upper_bounds[n], scales[n])
     end
     free_param
   end
 
-  function get_box_param(free_param, lower_bounds, upper_bounds)
+  function get_box_param(free_param, lower_bounds, upper_bounds, scales)
     box_param = zeros(Float64, N)
     for n=1:N
       box_param[n] =
-        Transform.box_parameter(free_param[n], lower_bounds[n], upper_bounds[n])
+        Transform.box_parameter(free_param[n], lower_bounds[n], upper_bounds[n], scales[n])
     end
     box_param
   end
@@ -266,17 +267,17 @@ function test_derivative_transform()
   end
 
   function free_function(free_param)
-    box_param = get_box_param(free_param, lower_bounds, upper_bounds)
+    box_param = get_box_param(free_param, lower_bounds, upper_bounds, scales)
     v, box_deriv = box_function(box_param)
     free_deriv = zeros(Float64, N)
     for n=1:N
       free_deriv[n] = Transform.unbox_derivative(
-        box_param[n], box_deriv[n], lower_bounds[n], upper_bounds[n])
+        box_param[n], box_deriv[n], lower_bounds[n], upper_bounds[n], scales[n])
     end
     v, free_deriv
   end
 
-  free_param = get_free_param(box_param, lower_bounds, upper_bounds)
+  free_param = get_free_param(box_param, lower_bounds, upper_bounds, scales)
   test_by_finite_differences(free_function, free_param)
 end
 

--- a/test/test_derivs.jl
+++ b/test/test_derivs.jl
@@ -280,9 +280,11 @@ function test_derivative_transform()
   test_by_finite_differences(free_function, free_param)
 end
 
+test_elbo_derivs_with_transform()
+
+
 test_kl_divergence_derivs()
 test_brightness_derivs()
 test_accum_pixel_source_derivs()
 test_elbo_derivs()
 test_derivative_transform()
-test_elbo_derivs_with_transform()

--- a/test/test_derivs.jl
+++ b/test/test_derivs.jl
@@ -10,6 +10,8 @@ import WCS
 
 import GSL.deriv_central
 
+println("Running derivative tests.")
+
 
 # verify derivatives of fun_to_test by finite differences for functions of
 # ModelParams that return a SensitiveFloat.

--- a/test/test_derivs.jl
+++ b/test/test_derivs.jl
@@ -206,8 +206,9 @@ function test_elbo_derivs()
 end
 
 
-function test_elbo_derivs_with_transform(trans::DataTransform)
+function test_elbo_derivs_with_transform()
     blob, mp0, body = gen_sample_galaxy_dataset();
+    trans = get_mp_transform(mp0, loc_width=1.0);
 
     omitted_ids = Int64[];
     x0 = trans.vp_to_vector(mp0.vp, omitted_ids)
@@ -234,9 +235,9 @@ function test_elbo_derivs_with_transform(trans::DataTransform)
     test_by_finite_differences(wrap_elbo, x0)
 end
 
+test_elbo_derivs_with_transform()
 
 test_kl_divergence_derivs()
 test_brightness_derivs()
 test_accum_pixel_source_derivs()
 test_elbo_derivs()
-test_elbo_derivs_with_transform(free_transform)

--- a/test/test_derivs.jl
+++ b/test/test_derivs.jl
@@ -280,11 +280,9 @@ function test_derivative_transform()
   test_by_finite_differences(free_function, free_param)
 end
 
-test_elbo_derivs_with_transform()
-
-
 test_kl_divergence_derivs()
 test_brightness_derivs()
 test_accum_pixel_source_derivs()
 test_elbo_derivs()
 test_derivative_transform()
+test_elbo_derivs_with_transform()

--- a/test/test_derivs.jl
+++ b/test/test_derivs.jl
@@ -31,7 +31,7 @@ function test_by_finite_differences(fun_to_test::Function, mp::ModelParams)
 
             numeric_deriv, abs_err = deriv_central(fun_to_test_2, 0., 1e-3)
             info("deriv #$p0 (s: $s): $numeric_deriv vs $(f.d[p1, s]) [tol: $abs_err]")
-            obs_err = abs(numeric_deriv - f.d[p1, s]) 
+            obs_err = abs(numeric_deriv - f.d[p1, s])
             @test obs_err < 1e-11 || abs_err < 1e-4 || abs_err / abs(numeric_deriv) < 1e-4
             @test_approx_eq_eps numeric_deriv f.d[p1, s] 10abs_err
         end
@@ -54,7 +54,7 @@ function test_by_finite_differences(fun_to_test::Function, x::Vector{Float64})
 
         numeric_deriv, abs_err = deriv_central(fun_to_test_2, 0., 1e-3)
         info("deriv #$s: $numeric_deriv vs $(grad[s]) [tol: $abs_err]")
-        obs_err = abs(numeric_deriv - grad[s]) 
+        obs_err = abs(numeric_deriv - grad[s])
         @test obs_err < 1e-11 || abs_err < 1e-4 || abs_err / abs(numeric_deriv) < 1e-4
         @test_approx_eq_eps numeric_deriv grad[s] 10abs_err
     end
@@ -235,32 +235,8 @@ function test_elbo_derivs_with_transform(trans::DataTransform)
 end
 
 
-function test_quadratic_derivatives(trans::DataTransform)
-    # A very simple quadratic function to test the derivatives.
-    function quadratic_function(mp::ModelParams)
-        const centers = collect(linrange(0, 10, length(CanonicalParams)))
-        val = zero_sensitive_float(CanonicalParams)
-        val.v = sum((mp.vp[1] - centers) .^ 2)
-        val.d[:] = 2.0 * (mp.vp[1] - centers)
-
-        val
-    end
-
-    # 0.5 is an innocuous value for all parameters.
-    mp = empty_model_params(1)
-    mp.vp = convert(VariationalParams{Float64}, [ fill(0.5, length(CanonicalParams)) 
-        for s in 1:1 ])
-    test_by_finite_differences(quadratic_function, mp)
-end
-
-
-for trans in [ identity_transform, pixel_rect_transform, world_rect_transform, free_transform ]
-    test_quadratic_derivatives(trans)
-end
-
 test_kl_divergence_derivs()
 test_brightness_derivs()
 test_accum_pixel_source_derivs()
 test_elbo_derivs()
-test_elbo_derivs_with_transform()
-
+test_elbo_derivs_with_transform(free_transform)

--- a/test/test_elbo_values.jl
+++ b/test/test_elbo_values.jl
@@ -6,6 +6,8 @@ using SampleData
 
 import WCS
 
+println("Running ELBO value tests.")
+
 function true_star_init()
     blob, mp, body = gen_sample_star_dataset(perturb=false)
 
@@ -313,7 +315,7 @@ function test_elbo_with_nan()
 
     nan_elbo = ElboDeriv.elbo(blob, mp)
 
-    # We deleted a pixel, so there's reason to expect them to be different, 
+    # We deleted a pixel, so there's reason to expect them to be different,
     # but importantly they're reasonably close and not NaN.
     @test_approx_eq_eps (nan_elbo.v - initial_elbo.v) / initial_elbo.v 0. 1e-4
     deriv_rel_err = (nan_elbo.d - initial_elbo.d) ./ initial_elbo.d

--- a/test/test_kl.jl
+++ b/test/test_kl.jl
@@ -3,6 +3,7 @@ using Base.Test
 using Distributions
 import GSL.deriv_central
 
+println("Running KL tests.")
 
 function verify_kl(q_dist, p_dist, claimed_kl::Float64)
     sample_size = 4_000_000
@@ -208,4 +209,3 @@ test_univariate_normal()
 test_isobvnormal()
 test_diagmvn_mvn()
 test_isobvnormal_flat()
-

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -7,6 +7,7 @@ import SDSS
 import Util
 import WCS
 
+println("Running misc tests.")
 
 function test_local_sources()
     # Coarse test that local_sources gets the right objects.

--- a/test/test_optimization.jl
+++ b/test/test_optimization.jl
@@ -93,21 +93,10 @@ end
 
 
 function test_star_optimization()
-    # TODO: this is failing due to bad scaling.
     blob, mp, body = gen_sample_star_dataset();
     trans = get_mp_transform(mp, loc_width=1.0);
     OptimizeElbo.maximize_likelihood(blob, mp, trans)
     verify_sample_star(mp.vp[1], [10.1, 12.2])
-
-    blob, mp, body = gen_sample_star_dataset();
-    #trans = get_mp_transform(mp, loc_width=1.0);
-    trans.bounds[1][:r1] = (0.0001, Inf, 1e-3)
-    omitted_ids = [ids_free.k[:], ids_free.c2[:], ids_free.r2]
-    OptimizeElbo.maximize_f(ElboDeriv.elbo_likelihood, blob, mp, trans,
-               omitted_ids=omitted_ids, xtol_rel=0., ftol_abs=1e-15, verbose=true)
-    verify_sample_star(mp.vp[1], [10.1, 12.2])
-
-
 end
 
 

--- a/test/test_optimization.jl
+++ b/test/test_optimization.jl
@@ -19,6 +19,11 @@ function test_objective_wrapper()
     elbo_result = trans.transform_sensitive_float(ElboDeriv.elbo(blob, mp), mp);
     elbo_grad = reduce(vcat, [ elbo_result.d[kept_ids, s] for s=1:mp.S ]);
 
+    # Tese the print function
+    wrapper.state.verbose = true
+    wrapper.f_objective(x);
+    wrapper.state.verbose = false
+
     w_v, w_grad = wrapper.f_value_grad(x);
     w_grad2 = zeros(Float64, length(x));
     wrapper.f_value_grad!(x, w_grad2);

--- a/test/test_optimization.jl
+++ b/test/test_optimization.jl
@@ -101,7 +101,7 @@ end
 
 
 function test_galaxy_optimization()
-    blob, mp, body = gen_sample_galaxy_dataset()
+    blob, mp, body = gen_sample_galaxy_dataset();
     trans = get_mp_transform(mp, loc_width=1.0);
     OptimizeElbo.maximize_likelihood(blob, mp, trans, xtol_rel=0.0)
     verify_sample_galaxy(mp.vp[1], [8.5, 9.6])
@@ -481,7 +481,6 @@ test_bad_a_init()
 #test_kl_invariance_to_a()
 #test_likelihood_invariance_to_a()
 test_star_optimization()
-
-test_full_elbo_optimization(free_transform)
-test_galaxy_optimization(free_transform)
-test_real_stamp_optimization(free_transform)
+test_galaxy_optimization()
+test_full_elbo_optimization()
+test_real_stamp_optimization()

--- a/test/test_optimization.jl
+++ b/test/test_optimization.jl
@@ -96,13 +96,17 @@ function test_star_optimization()
     # TODO: this is failing due to bad scaling.
     blob, mp, body = gen_sample_star_dataset();
     trans = get_mp_transform(mp, loc_width=1.0);
+    OptimizeElbo.maximize_likelihood(blob, mp, trans)
+    verify_sample_star(mp.vp[1], [10.1, 12.2])
 
+    blob, mp, body = gen_sample_star_dataset();
+    #trans = get_mp_transform(mp, loc_width=1.0);
+    trans.bounds[1][:r1] = (0.0001, Inf, 1e-3)
     omitted_ids = [ids_free.k[:], ids_free.c2[:], ids_free.r2]
     OptimizeElbo.maximize_f(ElboDeriv.elbo_likelihood, blob, mp, trans,
-               omitted_ids=omitted_ids, xtol_rel=0., ftol_abs=1e-7, verbose=true)
+               omitted_ids=omitted_ids, xtol_rel=0., ftol_abs=1e-15, verbose=true)
+    verify_sample_star(mp.vp[1], [10.1, 12.2])
 
-   OptimizeElbo.maximize_likelihood(blob, mp, trans)
-               verify_sample_star(mp.vp[1], [10.1, 12.2])
 
 end
 

--- a/test/test_optimization.jl
+++ b/test/test_optimization.jl
@@ -6,12 +6,13 @@ using Transform
 
 import OptimizeElbo
 
-function test_objective_wrapper(trans::DataTransform)
+function test_objective_wrapper()
     # Note that due to the WCS transformation, location coordinates can't be done with autodiff.
     omitted_ids = [ids_free.u];
     kept_ids = setdiff(1:length(ids_free), omitted_ids);
     blob, mp, body = SampleData.gen_two_body_dataset();
-    
+    trans = get_mp_transform(mp, loc_width=1.0);
+
     wrapper = OptimizeElbo.ObjectiveWrapperFunctions(mp -> ElboDeriv.elbo(blob, mp),
         mp, trans, kept_ids, omitted_ids);
 
@@ -466,4 +467,3 @@ test_star_optimization(free_transform)
 test_full_elbo_optimization(free_transform)
 test_galaxy_optimization(free_transform)
 test_real_stamp_optimization(free_transform)
-

--- a/test/test_optimization.jl
+++ b/test/test_optimization.jl
@@ -7,8 +7,7 @@ using Transform
 import OptimizeElbo
 
 function test_objective_wrapper()
-    # Note that due to the WCS transformation, location coordinates can't be done with autodiff.
-    omitted_ids = [ids_free.u];
+    omitted_ids = [];
     kept_ids = setdiff(1:length(ids_free), omitted_ids);
     blob, mp, body = SampleData.gen_two_body_dataset();
     trans = get_mp_transform(mp, loc_width=1.0);
@@ -88,23 +87,26 @@ end
 #########################################################
 
 
-function test_star_optimization(trans::DataTransform)
+function test_star_optimization()
     # TODO: this is failing due to bad scaling.
     blob, mp, body = gen_sample_star_dataset()
+    trans = get_mp_transform(mp, loc_width=1.0);
     OptimizeElbo.maximize_likelihood(blob, mp, trans)
     verify_sample_star(mp.vp[1], [10.1, 12.2])
 end
 
 
-function test_galaxy_optimization(trans::DataTransform)
+function test_galaxy_optimization()
     blob, mp, body = gen_sample_galaxy_dataset()
+    trans = get_mp_transform(mp, loc_width=1.0);
     OptimizeElbo.maximize_likelihood(blob, mp, trans, xtol_rel=0.0)
     verify_sample_galaxy(mp.vp[1], [8.5, 9.6])
 end
 
 
-function test_kappa_finding(trans::DataTransform)
+function test_kappa_finding()
     blob, mp, body = gen_sample_galaxy_dataset()
+    trans = get_mp_transform(mp, loc_width=1.0);
     omitted_ids = setdiff(1:length(UnconstrainedParams), ids_free.k[:])
 
     get_kl_gal_c() = begin
@@ -175,19 +177,19 @@ function test_bad_a_init()
     blob = Synthetic.gen_blob(blob0, [ce,])
 
     mp = ModelInit.cat_init([ce,])
+    trans = get_mp_transform(mp, loc_width=1.0);
+
     mp.vp[1][ids.a] = [ 0.5, 0.5 ]
 
     omitted_ids = [ids_free.a]
-    OptimizeElbo.maximize_f(ElboDeriv.elbo, blob, mp,
-        pixel_rect_transform, omitted_ids=omitted_ids)
+    OptimizeElbo.maximize_f(ElboDeriv.elbo, blob, mp, trans, omitted_ids=omitted_ids)
 
     mp.vp[1][ids.a] = [ 0.8, 0.2 ]
     elbo_bad = ElboDeriv.elbo_likelihood(blob, mp)
     @test elbo_bad.d[ids.a[2], 1] > 0
 
     omitted_ids = setdiff(1:length(UnconstrainedParams), ids_free.a)
-    OptimizeElbo.maximize_f(ElboDeriv.elbo, blob, mp,
-        pixel_rect_transform, omitted_ids=omitted_ids)
+    OptimizeElbo.maximize_f(ElboDeriv.elbo, blob, mp, trans, omitted_ids=omitted_ids)
     @test mp.vp[1][ids.a[2]] >= 0.5
 
     mp2 = deepcopy(mp)
@@ -212,15 +214,17 @@ function test_likelihood_invariance_to_a()
     blob = Synthetic.gen_blob(blob0, [ce,])
 
     mp = ModelInit.cat_init([ce,])
+    trans = get_mp_transform(mp, loc_width=1.0);
+
     mp.vp[1][ids.a] = [ 0.8, 0.2 ]
     omitted_ids = [ids_free.a, ids_free.r2[:]]
     OptimizeElbo.maximize_f(ElboDeriv.elbo_likelihood, blob, mp,
-        pixel_rect_transform, omitted_ids=omitted_ids)
+        trans, omitted_ids=omitted_ids)
 
     mp2 = ModelInit.cat_init([ce,])
     mp2.vp[1][ids.a] = [ 0.2, 0.8 ]
     OptimizeElbo.maximize_f(ElboDeriv.elbo_likelihood, blob, mp2,
-        pixel_rect_transform, omitted_ids=omitted_ids)
+        trans, omitted_ids=omitted_ids)
 
     mp.vp[1][ids.a] = [ 0.5, 0.5 ]
     mp2.vp[1][ids.a] = [ 0.5, 0.5 ]
@@ -250,15 +254,16 @@ function test_kl_invariance_to_a()
     end
 
     mp = ModelInit.cat_init([ce,])
+    trans = get_mp_transform(mp, loc_width=1.0);
     mp.vp[1][ids.a] = [ 0.2, 0.8 ]
     omitted_ids = [ids_free.a;]
     OptimizeElbo.maximize_f(kl_wrapper, blob, mp,
-        pixel_rect_transform, omitted_ids=omitted_ids, ftol_abs=1e-9)
+        trans, omitted_ids=omitted_ids, ftol_abs=1e-9)
 
     mp2 = ModelInit.cat_init([ce,])
     mp2.vp[1][ids.a] = [ 0.8, 0.2 ]
     OptimizeElbo.maximize_f(kl_wrapper, blob, mp2,
-        pixel_rect_transform, omitted_ids=omitted_ids, ftol_abs=1e-9)
+        trans, omitted_ids=omitted_ids, ftol_abs=1e-9)
 
     mp.vp[1][ids.a] = [ 0.5, 0.5 ]
     mp2.vp[1][ids.a] = [ 0.5, 0.5 ]
@@ -281,15 +286,17 @@ function test_elbo_invariance_to_a()
     blob = Synthetic.gen_blob(blob0, [ce,])
 
     mp = ModelInit.cat_init([ce,])
+    trans = get_mp_transform(mp, loc_width=1.0);
+
     mp.vp[1][ids.a] = [ 0.8, 0.2 ]
     omitted_ids = [ids_free.a, ids_free.r2[:], ids_free.c2[:], ids_free.e_dev]
     OptimizeElbo.maximize_f(ElboDeriv.elbo, blob, mp,
-        pixel_rect_transform, omitted_ids=omitted_ids)
+        trans, omitted_ids=omitted_ids)
 
     mp2 = ModelInit.cat_init([ce,])
     mp2.vp[1][ids.a] = [ 0.2, 0.8 ]
     OptimizeElbo.maximize_f(ElboDeriv.elbo, blob, mp2,
-        pixel_rect_transform, omitted_ids=omitted_ids)
+        trans, omitted_ids=omitted_ids)
 
     mp.vp[1][ids.a] = [ 0.5, 0.5 ]
     mp2.vp[1][ids.a] = [ 0.5, 0.5 ]
@@ -301,15 +308,17 @@ function test_elbo_invariance_to_a()
 end
 
 
-function test_peak_init_galaxy_optimization(trans::DataTransform)
+function test_peak_init_galaxy_optimization()
     blob, mp, body = gen_sample_galaxy_dataset()
     mp = ModelInit.peak_init(blob)
+    trans = get_mp_transform(mp, loc_width=1.0);
+
     OptimizeElbo.maximize_likelihood(blob, mp, trans)
     verify_sample_galaxy(mp.vp[1], [8.5, 9.6])
 end
 
 
-function test_peak_init_2body_optimization(trans::DataTransform)
+function test_peak_init_2body_optimization()
     srand(1)
     blob0 = SDSS.load_stamp_blob(dat_dir, "164.4311-39.0359")
 
@@ -320,6 +329,8 @@ function test_peak_init_2body_optimization(trans::DataTransform)
 
     blob = Synthetic.gen_blob(blob0, two_bodies)
     mp = ModelInit.peak_init(blob) #one giant tile, giant patches
+    trans = get_mp_transform(mp, loc_width=1.0);
+
     @test mp.S == 2
 
     OptimizeElbo.maximize_likelihood(blob, mp, trans)
@@ -329,14 +340,15 @@ function test_peak_init_2body_optimization(trans::DataTransform)
 end
 
 
-function test_full_elbo_optimization(trans::DataTransform)
+function test_full_elbo_optimization()
     blob, mp, body = gen_sample_galaxy_dataset(perturb=true)
+    trans = get_mp_transform(mp, loc_width=1.0);
     OptimizeElbo.maximize_elbo(blob, mp, trans, xtol_rel=0.0)
     verify_sample_galaxy(mp.vp[1], [8.5, 9.6])
 end
 
 
-function test_real_stamp_optimization(trans::DataTransform)
+function test_real_stamp_optimization()
     blob = SDSS.load_stamp_blob(dat_dir, "5.0073-0.0739")
     cat_entries = SDSS.load_stamp_catalog(dat_dir, "s82-5.0073-0.0739", blob)
     bright(ce) = sum(ce.star_fluxes) > 3 || sum(ce.gal_fluxes) > 3
@@ -346,11 +358,12 @@ function test_real_stamp_optimization(trans::DataTransform)
     cat_entries = filter(inbounds, cat_entries)
 
     mp = ModelInit.cat_init(cat_entries)
+    trans = get_mp_transform(mp, loc_width=1.0);
     OptimizeElbo.maximize_elbo(blob, mp, trans, xtol_rel=0.0)
 end
 
 
-function test_bad_galaxy_init(trans::DataTransform)
+function test_bad_galaxy_init()
     stamp_id = "5.0624-0.1528"
     blob0 = SDSS.load_stamp_blob(ENV["STAMP"], stamp_id)
 
@@ -367,13 +380,14 @@ function test_bad_galaxy_init(trans::DataTransform)
     cat_primary = filter(only_center, cat_primary)
     @test length(cat_primary) == 1
 
+    mp_good_init = ModelInit.cat_init(cat_coadd)
+    trans = get_mp_transform(mp_good_init, loc_width=1.0);
+    OptimizeElbo.maximize_elbo(blob, mp_good_init, trans)
+    @test mp_good_init.vp[1][ids.a[2]] > .5
+
     mp_bad_init = ModelInit.cat_init(cat_primary)
     OptimizeElbo.maximize_f(ElboDeriv.elbo, blob, mp_bad_init, trans)
     @test mp_bad_init.vp[1][ids.a[2]] > .5
-
-    mp_good_init = ModelInit.cat_init(cat_coadd)
-    OptimizeElbo.maximize_elbo(blob, mp_good_init, trans)
-    @test mp_good_init.vp[1][ids.a[2]] > .5
 
     @test_approx_eq_eps mp_good_init.vp[1][ids.e_scale] mp_bad_init.vp[1][ids.e_scale] 0.2
     @test_approx_eq_eps mp_good_init.vp[1][ids.e_axis] mp_bad_init.vp[1][ids.e_axis] 0.2
@@ -384,6 +398,8 @@ end
 
 function test_color(trans::DataTransform)
     blob, mp, body = gen_sample_galaxy_dataset(perturb=true)
+    trans = get_mp_transform(mp, loc_width=1.0);
+
     # these are a bright star's colors
     mp.vp[1][ids.c1[:, 1]] = [2.42824, 1.13996, 0.475603, 0.283062]
     mp.vp[1][ids.c1[:, 2]] = [2.42824, 1.13996, 0.475603, 0.283062]
@@ -422,8 +438,12 @@ function test_quadratic_optimization(trans::DataTransform)
         val
     end
 
+    ###############
+    # TODO: this needs to be changed for the new transforms.
+
     # 0.5 is an innocuous value for all parameters.
     mp = empty_model_params(1)
+    trans = DataTransform
     n = length(CanonicalParams)
     mp.vp = convert(VariationalParams{Float64}, [fill(0.5, n) for s in 1:1])
     unused_blob = gen_sample_star_dataset()[1]

--- a/test/test_wcs.jl
+++ b/test/test_wcs.jl
@@ -6,6 +6,7 @@ using CelesteTypes
 import SDSS
 import WCS
 
+println("Running WCS tests.")
 
 function test_ray_crossing()
     # Check a line segment that is hit in one direction.
@@ -224,7 +225,7 @@ function test_pixel_deriv_to_world_deriv()
     function test_fun_world(world_loc::Array{Float64, 1}, wcs::WCSLIB.wcsprm)
         pix_loc = WCS.world_to_pixel(wcs, world_loc)
         test_fun(pix_loc)
-    end 
+    end
 
     pix_del = 1e-3
     world_del = 1e-9


### PR DESCRIPTION
This is necessary to allow newton's method to use box constraints on the location, which must be different for each source.  It also tidies up the transform stuff and will give us some more flexibility going forward.
