### PR TITLE
removes and adds calls to @compat

### DIFF
--- a/src/CelesteTypes.jl
+++ b/src/CelesteTypes.jl
@@ -443,7 +443,7 @@ end
 align(::StarPosParams, CanonicalParams) = ids.u
 align(::GalaxyPosParams, CanonicalParams) =
    [ids.u; ids.e_dev; ids.e_axis; ids.e_angle; ids.e_scale]
-align(::CanonicalParams, CanonicalParams) = [1:length(CanonicalParams)]
+align(::CanonicalParams, CanonicalParams) = collect(1:length(CanonicalParams))
 
 const shape_standard_alignment = (ids.u,
    [ids.u; ids.e_dev; ids.e_axis; ids.e_angle; ids.e_scale])
@@ -455,7 +455,7 @@ const brightness_standard_alignment = (bright_ids(1), bright_ids(2))
 function get_id_names(
   ids::@compat(Union{CanonicalParams, UnconstrainedParams}))
   ids_names = Array(ASCIIString, length(ids))
-  for (name in @compat(fieldnames(ids)))
+  for (name in fieldnames(ids))
     inds = ids.(name)
     if length(size(inds)) == 0
       ids_names[inds] = "$(name)"
@@ -528,7 +528,7 @@ Display model parameters with the variable names.
 function print_params(mp::ModelParams)
     for s in 1:mp.S
         println("=======================\n Object $(s):")
-        for var_name in @compat(fieldnames(ids))
+        for var_name in fieldnames(ids)
             println(var_name)
             println(mp.vp[s][ids.(var_name)])
         end
@@ -542,7 +542,7 @@ function print_params(mp_tuple::ModelParams...)
     println("Printing for $(length(mp_tuple)) parameters.")
     for s in 1:mp_tuple[1].S
         println("=======================\n Object $(s):")
-        for var_name in @compat(fieldnames(ids))
+        for var_name in fieldnames(ids)
             println(var_name)
             mp_vars =
               [ collect(mp_tuple[index].vp[s][ids.(var_name)]) for
@@ -557,8 +557,8 @@ end
 Display a Celeste catalog entry.
 """ ->
 function print_cat_entry(cat_entry::CatalogEntry)
-    [ println("$name: $(cat_entry.(name))") for name in 
-            @compat(fieldnames(cat_entry)) ]
+    [println("$name: $(cat_entry.(name))") for name in 
+            fieldnames(cat_entry)]
 end
 
 #########################################################

--- a/src/SkyImages.jl
+++ b/src/SkyImages.jl
@@ -102,7 +102,7 @@ function load_stamp_blob(stamp_dir, stamp_id)
         hdr = FITSIO.read_header(fits[1])
         original_pixels = read(fits[1])
         dn = original_pixels / hdr["CALIB"] + hdr["SKY"]
-        nelec_f32 = @compat(round(dn * hdr["GAIN"]))
+        nelec_f32 = round(dn * hdr["GAIN"])
         nelec = convert(Array{Float64}, nelec_f32)
 
         header_str = FITSIO.read_header(fits[1], ASCIIString)
@@ -130,9 +130,9 @@ function load_stamp_blob(stamp_dir, stamp_id)
         iota = hdr["GAIN"] / hdr["CALIB"]
         epsilon = hdr["SKY"] * hdr["CALIB"]
 
-        run_num = @compat(round(Int, hdr["RUN"]))
-        camcol_num = @compat(round(Int, hdr["CAMCOL"]))
-        field_num = @compat(round(Int, hdr["FIELD"]))
+        run_num = round(Int, hdr["RUN"])
+        camcol_num = round(Int, hdr["CAMCOL"])
+        field_num = round(Int, hdr["FIELD"])
 
         Image(H, W, nelec, b, wcs, epsilon, iota, psf,
               run_num, camcol_num, field_num)
@@ -205,9 +205,9 @@ function load_sdss_blob(field_dir, run_num, camcol_num, field_num;
 
         # Set it to use a constant background but include the non-constant data.
         blob[b] = Image(H, W, nelec, b, wcs, epsilon, iota, psf,
-                      @compat(parse(Int, run_num)),
-                      @compat(parse(Int, camcol_num)),
-                      @compat(parse(Int, field_num)),
+                      parse(Int, run_num),
+                      parse(Int, camcol_num),
+                      parse(Int, field_num),
                       true, epsilon_mat, iota_vec, raw_psf_comp)
     end
 
@@ -240,12 +240,12 @@ function crop_blob_to_location(
     for b=1:5
         # Get the pixels that are near enough to the wcs_center.
         pix_center = WCS.world_to_pixel(blob[b].wcs, wcs_center)
-        h_min = max(@compat(floor(Int, pix_center[1] - width)), 1)
-        h_max = min(@compat(ceil(Int, pix_center[1] + width)), blob[b].H)
+        h_min = max(floor(Int, pix_center[1] - width), 1)
+        h_max = min(ceil(Int, pix_center[1] + width), blob[b].H)
         sub_rows_h = h_min:h_max
 
-        w_min = max(@compat(floor(Int, (pix_center[2] - width))), 1)
-        w_max = min(@compat(ceil(Int, pix_center[2] + width)), blob[b].W)
+        w_min = max(floor(Int, (pix_center[2] - width)), 1)
+        w_max = min(ceil(Int, pix_center[2] + width), blob[b].W)
         sub_rows_w = w_min:w_max
         tiled_blob[b] = fill(ImageTile(blob[b], sub_rows_h, sub_rows_w), 1, 1)
     end
@@ -349,8 +349,8 @@ Returns:
   An array of tiles containing the image.
 """ ->
 function break_image_into_tiles(img::Image, tile_width::Int64)
-  WW = @compat(ceil(Int, img.W / tile_width))
-  HH = @compat(ceil(Int, img.H / tile_width))
+  WW = ceil(Int, img.W / tile_width)
+  HH = ceil(Int, img.H / tile_width)
   ImageTile[ ImageTile(hh, ww, img, tile_width) for hh=1:HH, ww=1:WW ]
 end
 

--- a/src/Synthetic.jl
+++ b/src/Synthetic.jl
@@ -21,8 +21,8 @@ end
 
 function get_patch(the_mean::Vector{Float64}, H::Int64, W::Int64)
     const radius = 50
-    hm = @compat(round(Int, the_mean[1]))
-    wm = @compat(round(Int, the_mean[2]))
+    hm = round(Int, the_mean[1])
+    wm = round(Int, the_mean[2])
     w11 = max(1, wm - radius):min(W, wm + radius)
     h11 = max(1, hm - radius):min(H, hm + radius)
     return(w11, h11)

--- a/src/Transform.jl
+++ b/src/Transform.jl
@@ -13,7 +13,7 @@ export DataTransform, ParamBounds, ParamBox
 export get_mp_transform, generate_valid_parameters
 
 
-immutable ParamBox{T <: Union(Float64, Vector{Float64})}
+immutable ParamBox{T <: @compat(Union{Float64, Vector{Float64}})}
     lb::T
     ub::T
     rescaling::T
@@ -77,10 +77,10 @@ end
 # Functions for a "free transform".
 
 function unbox_parameter{NumType <: Number}(
-  param::Union(NumType, Array{NumType}),
-  lower_bound::Union(Float64, Array{Float64}),
-  upper_bound::Union(Float64, Array{Float64}),
-  scale::Union(Float64, Array{Float64}))
+  param::@compat(Union{NumType, Array{NumType}}),
+  lower_bound::@compat(Union{Float64, Array{Float64}}),
+  upper_bound::@compat(Union{Float64, Array{Float64}}),
+  scale::@compat(Union{Float64, Array{Float64}}))
 
     positive_constraint = any(upper_bound .== Inf)
     if positive_constraint && !all(upper_bound .== Inf)
@@ -102,10 +102,10 @@ function unbox_parameter{NumType <: Number}(
 end
 
 function box_parameter{NumType <: Number}(
-  free_param::Union(NumType, Array{NumType}),
-  lower_bound::Union(Float64, Array{Float64}),
-  upper_bound::Union(Float64, Array{Float64}),
-  scale::Union(Float64, Array{Float64}))
+  free_param::@compat(Union{NumType, Array{NumType}}),
+  lower_bound::@compat(Union{Float64, Array{Float64}}),
+  upper_bound::@compat(Union{Float64, Array{Float64}}),
+  scale::@compat(Union{Float64, Array{Float64}}))
 
   positive_constraint = any(upper_bound .== Inf)
   if positive_constraint && !all(upper_bound .== Inf)
@@ -125,11 +125,11 @@ within the box constrains, and <deriv> is the derivative with respect
 to these paraemters.
 """ ->
 function unbox_derivative{NumType <: Number}(
-  param::Union(NumType, Array{NumType}),
-  deriv::Union(NumType, Array{NumType}),
-  lower_bound::Union(Float64, Array{Float64}),
-  upper_bound::Union(Float64, Array{Float64}),
-  scale::Union(Float64, Array{Float64}))
+  param::@compat(Union{NumType, Array{NumType}}),
+  deriv::@compat(Union{NumType, Array{NumType}}),
+  lower_bound::@compat(Union{Float64, Array{Float64}}),
+  upper_bound::@compat(Union{Float64, Array{Float64}}),
+  scale::@compat(Union{Float64, Array{Float64}}))
     @assert(length(param) == length(deriv),
             "Wrong length parameters for unbox_sensitive_float")
 
@@ -303,7 +303,7 @@ DataTransform(bounds::Vector{ParamBounds}) = begin
 
   # Make sure that each variable has its bounds set.
   for s=1:length(bounds)
-    @assert Set(keys(bounds[s])) == Set(setdiff(names(ids), [:a, :k]))
+    @assert Set(keys(bounds[s])) == Set(setdiff(fieldnames(ids), [:a, :k]))
   end
 
   function from_vp!{NumType <: Number}(

--- a/test/test_constraints.jl
+++ b/test/test_constraints.jl
@@ -99,7 +99,7 @@ function test_parameter_conversion()
 	vp_free = transform.from_vp(mp.vp)
 	vp2 = transform.to_vp(vp_free)
 
-	for id in @compat(fieldnames(ids)), s in 1:mp.S
+	for id in fieldnames(ids), s in 1:mp.S
 		@test_approx_eq_eps(original_vp[s][ids.(id)], vp2[s][ids.(id)], 1e-6)
 	end
 
@@ -111,7 +111,7 @@ function test_parameter_conversion()
 
 	vp2 = generate_valid_parameters(Float64, transform.bounds)
 	transform.vector_to_vp!(x, vp2, omitted_ids)
-	for id in @compat(fieldnames(ids)), s in 1:mp.S
+	for id in fieldnames(ids), s in 1:mp.S
 		@test_approx_eq_eps(original_vp[s][ids.(id)], vp2[s][ids.(id)], 1e-6)
 	end
 end

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -21,8 +21,8 @@ function test_tile_image()
 
   tiles = SkyImages.break_image_into_tiles(img, tile_width);
   @test size(tiles) ==
-    (@compat(round(Int, ceil(img.H  / tile_width))),
-     @compat(round(Int, ceil(img.W / tile_width))))
+    (round(Int, ceil(img.H  / tile_width)),
+     round(Int, ceil(img.W / tile_width)))
   for tile in tiles
     @test tile.b == img.b
     @test tile.pixels == img.pixels[tile.h_range, tile.w_range]
@@ -37,8 +37,8 @@ function test_tile_image()
   img.iota_vec = rand(size(img.pixels)[1]);
   tiles = SkyImages.break_image_into_tiles(img, tile_width);
   @test size(tiles) == (
-    @compat(ceil(Int, img.H  / tile_width)),
-    @compat(ceil(Int, img.W / tile_width)))
+    ceil(Int, img.H  / tile_width),
+    ceil(Int, img.W / tile_width))
   for tile in tiles
     @test tile.b == img.b
     @test tile.pixels == img.pixels[tile.h_range, tile.w_range]
@@ -162,8 +162,8 @@ function test_local_sources_3()
 
     # Source should be present
     tile = ImageTile(
-        @compat(round(Int, pix_loc[1] / tile_width)),
-        @compat(round(Int, pix_loc[2] / tile_width)),
+        round(Int, pix_loc[1] / tile_width),
+        round(Int, pix_loc[2] / tile_width),
         blob[test_b],
         tile_width);
     @test SkyImages.local_sources(
@@ -172,18 +172,18 @@ function test_local_sources_3()
     # Source should not match when you're 1 tile and a half away along the diagonal plus
     # the pixel radius from the center of the tile.
     tile = ImageTile(
-        @compat(ceil(Int, (pix_loc[1] + 1.5 * tile_width * sqrt(2) + 
-                patch_radius_pix) / tile_width)),
-        @compat(round(Int, pix_loc[2] / tile_width)),
+        ceil(Int, (pix_loc[1] + 1.5 * tile_width * sqrt(2) + 
+                patch_radius_pix) / tile_width),
+        round(Int, pix_loc[2] / tile_width),
         blob[test_b],
         tile_width)
     @test SkyImages.local_sources(
       tile, mp.patches[:,test_b][:], blob[test_b].wcs) == []
 
     tile = ImageTile(
-        @compat(round(Int, (pix_loc[1]) / tile_width)),
-        @compat(ceil(Int, (pix_loc[2]  + 1.5 * tile_width * sqrt(2) +
-                           patch_radius_pix) / tile_width)),
+        round(Int, (pix_loc[1]) / tile_width),
+        ceil(Int, (pix_loc[2]  + 1.5 * tile_width * sqrt(2) +
+                           patch_radius_pix) / tile_width),
         blob[test_b],
         tile_width)
     @test SkyImages.local_sources(
@@ -290,8 +290,8 @@ function test_add_sensitive_floats()
   sf_bad_size = zero_sensitive_float(CanonicalParams, Float64, S + 1);
   sf_bad_type = zero_sensitive_float(UnconstrainedParams, Float64, S);
 
-  @test_throws @compat(AssertionError) sf_bad_size + sf1
-  @test_throws @compat(AssertionError) sf_bad_type + sf1
+  @test_throws AssertionError sf_bad_size + sf1
+  @test_throws AssertionError sf_bad_type + sf1
 
   function sf_equal(sf1::SensitiveFloat, sf2::SensitiveFloat)
     sf1.v == sf2.v && sf2.d == sf2.d && sf1.h == sf2.h

--- a/test/test_optimization.jl
+++ b/test/test_optimization.jl
@@ -379,7 +379,7 @@ function test_quadratic_optimization()
 
     bounds = Array(ParamBounds, 1)
     bounds[1] = ParamBounds()
-    for param in setdiff(@compat(fieldnames(ids)), [:a, :k])
+    for param in setdiff(fieldnames(ids), [:a, :k])
       bounds[1][symbol(param)] = ParamBox(0., 1.0, 1.0)
     end
     trans = DataTransform(bounds)


### PR DESCRIPTION
@rgiordan , I removed unnecessary calls to `@compat`, and added some new calls to `@compat`. On my machine Celeste now works with Julia 0.4, but it issues a lot of warnings from other packages that Celeste calls. On Travis-CI it still only works with 0.3 so far, so I haven't modified `.travis.yml`. I think all the printing of warning from other packages may be causing it to run really slowly with Julia 0.4, causing the unit tests to timeout on Travis after 50 minutes. A lot of the warnings are from DataFrames.jl. I'm told those will get fixed this weekend.
