### PR TITLE
Active sources and make trust region the default

### DIFF
--- a/bin/forward_autodiff.jl
+++ b/bin/forward_autodiff.jl
@@ -157,7 +157,8 @@ obj_wrapper = OptimizeElbo.ObjectiveWrapperFunctions(
 obj_wrapper.state.verbose = true
 
 obj_hess_time = time()
-obj_hess = obj_wrapper.f_ad_hessian(x0);
+hess = zeros(Float64, length(x0), length(x0));
+obj_hess = obj_wrapper.f_ad_hessian!(x0, hess);
 obj_hess_time = time() - obj_hess_time
 
 i, j = findn((abs(obj_hess) .> 1e-10) & (abs(new_hess) .< 1e-10))
@@ -576,7 +577,8 @@ for iter in 1:max_iters
     x_old = deepcopy(x_new);
     old_val = new_val;
 
-    elbo_hess = obj_wrap.f_ad_hessian(x_new);
+    hess = zeros(Float64, length(x0), length(x0));
+    elbo_hess = obj_wrap.f_ad_hessian!(x_new, hess);
     hesses[iter] = elbo_hess
     hess_ev = eig(elbo_hess)[1]
     min_ev = minimum(hess_ev)

--- a/bin/score_cached.jl
+++ b/bin/score_cached.jl
@@ -112,7 +112,7 @@ function load_photo_obj!(i::Int64, stamp_id::String,
 end
 
 
-function convert(::Type{CatalogEntry}, vs::Vector{Float64})
+function convert(::Type{CatalogEntry}, vs::Vector{Float64}; objid="converted")
     function get_fluxes(i::Int64)
         ret = Array(Float64, 5)
         ret[3] = vs[ids.r1[i]] * vs[ids.r2[i]]
@@ -131,7 +131,8 @@ function convert(::Type{CatalogEntry}, vs::Vector{Float64})
         vs[ids.e_dev],
         vs[ids.e_axis],
         vs[ids.e_angle],
-        vs[ids.e_scale])
+        vs[ids.e_scale],
+        objid)
 end
 
 

--- a/src/CelesteTypes.jl
+++ b/src/CelesteTypes.jl
@@ -58,6 +58,7 @@ type CatalogEntry
     gal_ab::Float64
     gal_angle::Float64
     gal_scale::Float64
+    objid::ASCIIString
 end
 
 ############################################
@@ -489,6 +490,10 @@ Attributes:
  - tile_width: The number of pixels across a tile
  - tile_sources: A vector (over bands) of an array (over tiles) of vectors
                  of sources influencing each tile.
+ - active_sources: Indices of the sources that are currently being fit by the
+                   model.
+ - objids: Global object ids for the sources in this ModelParams object.
+
  - S: The number of sources.
 """ ->
 type ModelParams{NumType <: Number}
@@ -496,6 +501,8 @@ type ModelParams{NumType <: Number}
     pp::PriorParams
     patches::Array{SkyPatch, 2}
     tile_sources::Vector{Array{Array{Int64}}}
+    active_sources::Vector{Int64}
+    objids::Vector{ASCIIString}
 
     S::Int64
 
@@ -504,7 +511,10 @@ type ModelParams{NumType <: Number}
         S = length(vp)
         all_tile_sources = fill(fill(collect(1:S), 1, 1), 5)
         patches = Array(SkyPatch, S, 5)
-        new(vp, pp, patches, all_tile_sources, S)
+        active_sources = collect(1:S)
+        objids = ASCIIString[string(s) for s in 1:S]
+
+        new(vp, pp, patches, all_tile_sources, active_sources, objids, S)
     end
 end
 
@@ -520,6 +530,8 @@ function convert(::Type{ModelParams{DualNumbers.Dual}}, mp::ModelParams{Float64}
                   mp.pp)
     mp_dual.patches = mp.patches
     mp_dual.tile_sources = mp.tile_sources
+    mp_dual.active_sources = mp.active_sources
+    mp_dual.objids = mp.objids
     mp_dual
 end
 

--- a/src/ElboDeriv.jl
+++ b/src/ElboDeriv.jl
@@ -866,7 +866,7 @@ function tile_predicted_image{NumType <: Number}(
 
   b = tile.b
   star_mcs, gal_mcs = load_bvn_mixtures(mp, b)
-  sbs = [SourceBrightness(mp.vp[s]) for s in mp.S]
+  sbs = [SourceBrightness(mp.vp[s]) for s in 1:mp.S]
 
   accum = zero_sensitive_float(CanonicalParams, NumType, mp.S)
   tile_sources = mp.tile_sources[b][tile.hh, tile.ww]

--- a/src/ElboDeriv.jl
+++ b/src/ElboDeriv.jl
@@ -371,7 +371,7 @@ function load_bvn_mixtures{NumType <: Number}(mp::ModelParams{NumType}, b::Int64
     star_mcs = Array(BvnComponent{NumType}, 3, mp.S)
     gal_mcs = Array(GalaxyCacheComponent{NumType}, 3, 8, 2, mp.S)
 
-    for s in mp.S
+    for s in 1:mp.S
         psf = mp.patches[s, b].psf
         vs = mp.vp[s]
 
@@ -673,7 +673,8 @@ Args:
 Returns:
   - Adds the contributions of E_G and var_G to accum in place.
 """ ->
-function accum_pixel_ret!{NumType <: Number}(tile_sources::Vector{Int64},
+function accum_pixel_ret!{NumType <: Number}(
+        tile_sources::Vector{Int64},
         x_nbm::Float64, iota::Float64,
         E_G::SensitiveFloat{CanonicalParams, NumType},
         var_G::SensitiveFloat{CanonicalParams, NumType},
@@ -787,13 +788,12 @@ function tile_likelihood!{NumType <: Number}(
     end
 
     # fs0m and fs1m accumulate contributions from all sources.
-    num_type = typeof(mp.vp[1][1])
-    fs0m = zero_sensitive_float(StarPosParams, num_type)
-    fs1m = zero_sensitive_float(GalaxyPosParams, num_type)
+    fs0m = zero_sensitive_float(StarPosParams, NumType)
+    fs1m = zero_sensitive_float(GalaxyPosParams, NumType)
 
     tile_S = length(tile_sources)
-    E_G = zero_sensitive_float(CanonicalParams, num_type, tile_S)
-    var_G = zero_sensitive_float(CanonicalParams, num_type, tile_S)
+    E_G = zero_sensitive_float(CanonicalParams, NumType, tile_S)
+    var_G = zero_sensitive_float(CanonicalParams, NumType, tile_S)
 
     # Iterate over pixels that are not NaN.
     for w in 1:tile.w_width, h in 1:tile.h_width
@@ -835,13 +835,12 @@ function tile_predicted_image{NumType <: Number}(
         accum::SensitiveFloat{CanonicalParams, NumType})
 
     # fs0m and fs1m accumulate contributions from all sources.
-    num_type = typeof(mp.vp[1][1])
-    fs0m = zero_sensitive_float(StarPosParams, num_type)
-    fs1m = zero_sensitive_float(GalaxyPosParams, num_type)
+    fs0m = zero_sensitive_float(StarPosParams, NumType)
+    fs1m = zero_sensitive_float(GalaxyPosParams, NumType)
 
     tile_S = length(tile_sources)
-    E_G = zero_sensitive_float(CanonicalParams, num_type, tile_S)
-    var_G = zero_sensitive_float(CanonicalParams, num_type, tile_S)
+    E_G = zero_sensitive_float(CanonicalParams, NumType, tile_S)
+    var_G = zero_sensitive_float(CanonicalParams, NumType, tile_S)
 
     predicted_pixels = copy(tile.pixels)
     # Iterate over pixels that are not NaN.
@@ -866,11 +865,10 @@ function tile_predicted_image{NumType <: Number}(
     tile::ImageTile, mp::ModelParams{NumType})
 
   b = tile.b
-  num_type = typeof(mp.vp[1][1])
   star_mcs, gal_mcs = load_bvn_mixtures(mp, b)
   sbs = [SourceBrightness(mp.vp[s]) for s in mp.S]
 
-  accum = zero_sensitive_float(CanonicalParams, num_type, mp.S)
+  accum = zero_sensitive_float(CanonicalParams, NumType, mp.S)
   tile_sources = mp.tile_sources[b][tile.hh, tile.ww]
 
   tile_predicted_image(tile,
@@ -884,58 +882,19 @@ end
 
 
 @doc """
-Calculate the ELBO only for tiles containing a particular source.
-This can save a lot of computation when using autodifferentiation to get
-the Hessian.  The values of the ELBO and derivatives will be incorrect,
-but if only VariationalParams associated with deriv_source have non-zero
-epsilon, then the DualNumber derivatives will be correct.
-
-Args:
-  - tiled_blob: The TiledBlob
-  - mp_dual: A dual representation of the ModelParams with all zero epsilons.
-  - accum: A dual number sensitive float.
-  - deriv_source: An integer index from 1 to mp.S.  Only tiles containing
-      deriv_source as a source will be calculated.
-
-Returns:
-  - Clears and updates the SensitiveFloat accum in place.
-""" ->
-function elbo_hessian_term!(tiled_blob::TiledBlob,
-                            mp_dual::ModelParams{Dual{Float64}},
-                            accum::SensitiveFloat{CanonicalParams, Dual{Float64}},
-                            deriv_source::Int64)
-  @assert 1 <= deriv_source <= mp_dual.S
-  clear!(accum)
-  for b in 1:5
-    # For now let's just re-calculate these each time.  It's not the
-    # bulk of the computation.
-    star_mcs, gal_mcs = load_bvn_mixtures(mp_dual, b)
-    sbs = SourceBrightness{Dual{Float64}}[
-      SourceBrightness(mp_dual.vp[s]) for s in 1:mp_dual.S]
-    for tile in tiled_blob[b][:]
-      tile_sources = mp_dual.tile_sources[b][tile.hh, tile.ww]
-      if in(deriv_source, tile_sources)
-        tile_likelihood!(tile, tile_sources, mp_dual, sbs, star_mcs, gal_mcs, accum);
-      end
-    end
-  end
-  subtract_kl!(mp_dual, accum)
-end
-
-
-@doc """
 The ELBO likelihood for given brighntess and bvn components.
 """ ->
 function elbo_likelihood!{NumType <: Number}(
-  tiled_image::TiledImage,
+  tiled_image::Array{ImageTile},
   mp::ModelParams{NumType},
   sbs::Vector{SourceBrightness{NumType}},
   star_mcs::Array{BvnComponent{NumType}, 2},
   gal_mcs::Array{GalaxyCacheComponent{NumType}, 4},
   accum::SensitiveFloat{CanonicalParams, NumType})
 
+  @assert maximum(mp.active_sources) <= mp.S
   for tile in tiled_image[:]
-    tile_sources = mp.tile_sources[b][tile.hh, tile.ww]
+    tile_sources = mp.tile_sources[tile.b][tile.hh, tile.ww]
     if length(intersect(tile_sources, mp.active_sources)) > 0
       tile_likelihood!(
         tile, tile_sources, mp, sbs, star_mcs, gal_mcs, accum);
@@ -961,7 +920,7 @@ function elbo_likelihood!{NumType <: Number}(
     sbs = param_msg.sbs_vec[b]
     star_mcs = param_msg.star_mcs_vec[b]
     gal_mcs = param_msg.gal_mcs_vec[b]
-    elbo_likelihood!(tiled_blob[b], sbs, star_mcs, gal_mcs, mp, accum)
+    elbo_likelihood!(tiled_blob[b], mp, sbs, star_mcs, gal_mcs, accum)
   end
 end
 
@@ -980,8 +939,8 @@ function elbo_likelihood!{NumType <: Number}(
   b::Int64, accum::SensitiveFloat{CanonicalParams, NumType})
 
   star_mcs, gal_mcs = load_bvn_mixtures(mp, b)
-  sbs = SourceBrightness{NumType}[ SourceBrightness(mp.vp[s]) for s in 1:mp.S]
-  elbo_likelihood!(tiles, sbs, star_mcs, gal_mcs, mp, accum)
+  sbs = SourceBrightness{NumType}[SourceBrightness(mp.vp[s]) for s in 1:mp.S]
+  elbo_likelihood!(tiles, mp, sbs, star_mcs, gal_mcs, accum)
 end
 
 

--- a/src/ElboDeriv.jl
+++ b/src/ElboDeriv.jl
@@ -472,7 +472,7 @@ function update_parameter_message!{NumType <: Number}(
     param_msg.star_mcs_vec[b], param_msg.gal_mcs_vec[b] =
       load_bvn_mixtures(mp, b);
     param_msg.sbs_vec[b] = SourceBrightness{NumType}[
-      SourceBrightness(mp.vp[s]) for s in mp.S];
+      SourceBrightness(mp.vp[s]) for s in 1:mp.S];
   end
 end
 

--- a/src/ModelInit.jl
+++ b/src/ModelInit.jl
@@ -388,6 +388,7 @@ function initialize_model_params(
   end
   vp = Array{Float64, 1}[init_source(ce) for ce in cat]
   mp = ModelParams(vp, sample_prior())
+  mp.objids = ASCIIString[ cat_entry.objid for cat_entry in cat]
 
   mp.patches = Array(SkyPatch, mp.S, length(blob))
   mp.tile_sources = Array(Array{Array{Int64}}, length(blob))

--- a/src/OptimizeElbo.jl
+++ b/src/OptimizeElbo.jl
@@ -286,7 +286,6 @@ function unpack_hessian_vals(hess_i::@compat(Vector{Tuple{Int64, Int64}}),
 end
 
 
-
 function get_nlopt_unconstrained_bounds(vp::Vector{Vector{Float64}},
                                         omitted_ids::Vector{Int64},
                                         transform::DataTransform)

--- a/src/OptimizeElbo.jl
+++ b/src/OptimizeElbo.jl
@@ -338,11 +338,11 @@ Returns:
   - max_x: The optimal function input
   - ret: The return code of optimize()
 """ ->
-function maximize_f_newton(
+function maximize_f(
   f::Function, tiled_blob::TiledBlob, mp::ModelParams,
   transform::Transform.DataTransform;
   omitted_ids=Int64[], xtol_rel = 1e-7, ftol_abs = 1e-6, verbose=false,
-  max_iters=100, rho_lower=0.25, fast_hessian=false)
+  max_iters=100, rho_lower=0.25, fast_hessian=true)
 
     kept_ids = setdiff(1:length(UnconstrainedParams), omitted_ids)
     optim_obj_wrap =
@@ -407,7 +407,7 @@ Returns:
   - max_x: The optimal function input
   - ret: The return code of optimize()
 """ ->
-function maximize_f(
+function maximize_f_bfgs(
   f::Function, tiled_blob::TiledBlob, mp::ModelParams,
   transform::DataTransform,
   lbs::@compat(Union{Float64, Vector{Float64}}),
@@ -442,17 +442,6 @@ function maximize_f(
     obj_wrapper.state.f_evals, max_f, max_x, ret
 end
 
-
-function maximize_f(
-  f::Function, tiled_blob::TiledBlob, mp::ModelParams, transform::DataTransform;
-    omitted_ids=Int64[], xtol_rel = 1e-7, ftol_abs = 1e-6, verbose = false)
-    # Default to the bounds given in get_nlopt_unconstrained_bounds.
-
-    lbs, ubs = get_nlopt_unconstrained_bounds(mp.vp, omitted_ids, transform)
-    maximize_f(f, tiled_blob, mp, transform, lbs, ubs;
-      omitted_ids=omitted_ids, xtol_rel=xtol_rel,
-      ftol_abs=ftol_abs, verbose = verbose)
-end
 
 function maximize_f(f::Function, tiled_blob::TiledBlob, mp::ModelParams;
     omitted_ids=Int64[], xtol_rel = 1e-7, ftol_abs = 1e-6, verbose = false)

--- a/src/OptimizeElbo.jl
+++ b/src/OptimizeElbo.jl
@@ -208,8 +208,8 @@ type ObjectiveWrapperFunctions
 
             # Vectors of the (source, component) indices for the rows
             # and columns of the Hessian.
-            hess_i = Tuple{Int64, Int64}[]
-            hess_j = Tuple{Int64, Int64}[]
+            hess_i = @compat(Tuple{Int64, Int64}[])
+            hess_j = @compat(Tuple{Int64, Int64}[])
 
             # Values of the hessian in the (hess_i, hess_j) locations.
             hess_val = Float64[]

--- a/src/OptimizeElbo.jl
+++ b/src/OptimizeElbo.jl
@@ -192,7 +192,7 @@ type ObjectiveWrapperFunctions
             end
             print("Done.\n")
             # Assure that the hessian is exactly symmetric.
-            0.5 * (hess + hess')
+            hess[:,:] = 0.5 * (hess + hess')
         end
 
         # Returns the row and column indices and value of a sparse Hessian

--- a/src/OptimizeElbo.jl
+++ b/src/OptimizeElbo.jl
@@ -47,7 +47,8 @@ type ObjectiveWrapperFunctions
     f_grad::Function
     f_grad!::Function
     f_ad_grad::Function
-    f_ad_hessian::Function
+    f_ad_hessian!::Function
+    f_ad_hessian_sparse::Function
 
     state::WrapperState
     transform::DataTransform
@@ -57,7 +58,8 @@ type ObjectiveWrapperFunctions
 
     ObjectiveWrapperFunctions(
       f::Function, mp::ModelParams{Float64}, transform::DataTransform,
-      kept_ids::Array{Int64, 1}, omitted_ids::Array{Int64, 1}) = begin
+      kept_ids::Array{Int64, 1}, omitted_ids::Array{Int64, 1};
+      fast_hessian::Bool=false) = begin
 
         mp_dual = CelesteTypes.convert(ModelParams{DualNumbers.Dual}, mp);
         x_length = length(kept_ids) * mp.S
@@ -151,101 +153,116 @@ type ObjectiveWrapperFunctions
         f_ad_grad = ForwardDiff.forwarddiff_gradient(
           f_value, Float64, fadtype=:dual; n=x_length);
 
-        function f_ad_hessian(x_vec::Array{Float64})
+        # Update <hess> in place with an autodiff hessian.
+        function f_ad_hessian!(x_vec::Array{Float64}, hess::Matrix{Float64})
             @assert length(x_vec) == x_length
             x = reshape(x_vec, x_size)
-            k = length(x)
-            hess = zeros(Float64, k, k);
+            k = length(x_vec)
+            @assert size(hess) == (k, k)
             x_dual = DualNumbers.Dual{Float64}[
               DualNumbers.Dual{Float64}(x[i, j], 0.) for
               i = 1:size(x)[1], j=1:size(x)[2]];
             print("Getting Hessian ($k components): ")
-            for s in 1:size(x)[2], index in 1:size(x)[1]
+            deriv_sources = fast_hessian ? mp.active_sources: collect(1:mp.S)
+            mp_dual.active_sources = deriv_sources
+            for s in deriv_sources
+              if fast_hessian
+                # We only need to calculate the derivatives in tiles where
+                # epsilon != 0.  The values of the derivatives themselves (that
+                # is, the real part of the dual numbers) will be wrong but the
+                # second derivatives with respect to source s will be right.
+                mp_dual.active_sources = [s]
+              end
+              for index in 1:size(x)[1]
                 index == 1 ? print("o"): print(".")
                 original_x = x[index, s]
                 x_dual[index, s] = DualNumbers.Dual(original_x, 1.)
 
-                # Only need to calculate the derivatives in tiles
-                # where epsilon != 0.  The values of the derivatives themselves
-                # (that is, the real part of the dual numbers) will be wrong
-                # but the second derivatives with respect to source s
-                # will be right.
-                mp_dual.active_sources = [s]
                 deriv = f_grad(x_dual[:])
                 # This goes through deriv in column-major order.
                 hess[:, index] =
                   Float64[ ForwardDiff.epsilon(x_val) for x_val in deriv ]
                 x_dual[index, s] = DualNumbers.Dual(original_x, 0.)
+              end
             end
             print("Done.\n")
             # Assure that the hessian is exactly symmetric.
             0.5 * (hess + hess')
         end
 
+        # Returns the row and column indices and value of a sparse Hessian
+        # computed with autodifferentiation.
+        function f_ad_hessian_sparse(x_vec::Array{Float64})
+            @assert length(x_vec) == x_length
+            x = reshape(x_vec, x_size)
+            k = length(x_vec)
+
+            x_dual = DualNumbers.Dual{Float64}[
+              DualNumbers.Dual{Float64}(x[i, j], 0.) for
+              i = 1:size(x)[1], j=1:size(x)[2]];
+            mp_dual.active_sources = collect(1:mp_dual.S)
+
+            # Vectors of the (source, component) indices for the rows
+            # and columns of the Hessian.
+            hess_i = Tuple{Int64, Int64}[]
+            hess_j = Tuple{Int64, Int64}[]
+
+            # Values of the hessian in the (hess_i, hess_j) locations.
+            hess_val = Float64[]
+
+            print("Getting Hessian ($k components): ")
+            deriv_sources = fast_hessian ? mp.active_sources: collect(1:mp.S)
+            mp_dual.active_sources = deriv_sources
+            for s1 in deriv_sources
+              if fast_hessian
+                # We only need to calculate the derivatives in tiles where
+                # epsilon != 0.  The values of the derivatives themselves (that
+                # is, the real part of the dual numbers) will be wrong but the
+                # second derivatives with respect to source s will be right.
+                mp_dual.active_sources = [s]
+              end
+              for index1 in 1:size(x)[1]
+                index1 == 1 ? print("o"): print(".")
+                original_x = x[index1, s]
+                x_dual[index1, s] = DualNumbers.Dual(original_x, 1.)
+                deriv = f_grad(x_dual[:])
+                x_dual[index, s] = DualNumbers.Dual(original_x, 0.)
+
+                # Record the hessian terms.
+                for s2 in deriv_sources, index2=1:size(x)[1]
+                  this_hess_val = DualNumbers.epsilon(deriv[index2, s2])
+                  if (this_hess_val != 0)
+                    push!(hess_i, (s1, index1))
+                    push!(hess_j, (s2, index2))
+                    push!(hess_val, this_hess_val)
+                  end # index2 for
+                end # s2 for
+              end # index for
+            end # s1 for
+            print("Done.\n")
+            hess_i, hess_j, hess_val
+        end
+
         new(f_objective, f_value_grad, f_value_grad!, f_value, f_grad, f_grad!,
-            f_ad_grad, f_ad_hessian,
+            f_ad_grad, f_ad_hessian!, f_ad_hessian_sparse,
             state, transform, mp, kept_ids, omitted_ids)
     end
 end
 
 
-# TODO: redo this with the ModelParams active sources.
-# @doc """
-# Vectors of the row, column, and value of the Hessian entries.
-# The indices are tuples of (source, parameter) which will be
-# linearized later.
-# """ ->
-# function elbo_hessian(tiled_blob::TiledBlob,
-#                       x::Matrix{Float64},
-#                       mp_dual::ModelParams{DualNumbers.Dual{Float64}},
-#                       transform::Transform.DataTransform,
-#                       omitted_ids::Vector{Int64};
-#                       deriv_sources=1:mp_dual.S,
-#                       verbose=false)
-#   k = size(x)[1]
-#   @assert size(x)[2] == length(mp_dual.vp)
-#
-#   hess_i = Tuple{Int64, Int64}[]
-#   hess_j = Tuple{Int64, Int64}[]
-#   hess_val = Float64[]
-#
-#   accum = zero_sensitive_float(CanonicalParams, Dual{Float64}, mp_dual.S);
-#   x_dual = Dual{Float64}[ Dual{Float64}(x[i, j], 0.) for
-#                           i = 1:size(x)[1], j=1:size(x)[2] ];
-#
-#   new_hess_time = time()
-#   for s1 in deriv_sources
-#     verbose && println("Source $s1")
-#     for index1=1:k
-#       verbose && print(".")
-#       original_val = real(x_dual[index1, s1])
-#       @assert epsilon(x_dual[index1, s1]) == 0.
-#       x_dual[index1, s1] = DualNumbers.Dual(original_val, 1.);
-#       transform.array_to_vp!(x_dual, mp_dual.vp, omitted_ids);
-#       ElboDeriv.elbo!(tiled_blob, mp_dual, accum, s1);
-#       accum_trans = transform.transform_sensitive_float(accum, mp_dual);
-#       @assert size(accum_trans.d) == (k, mp_dual.S)
-#       x_dual[index1, s1] = DualNumbers.Dual(original_val, 0.)
-#
-#       # Record the hessian terms.
-#       for s2 in deriv_sources, index2=1:k
-#         this_hess_val = DualNumbers.epsilon(accum_trans.d[index2, s2])
-#         if (this_hess_val != 0)
-#           push!(hess_i, (s1, index1))
-#           push!(hess_j, (s2, index2))
-#           push!(hess_val, this_hess_val)
-#         end
-#       end
-#     end
-#     verbose && println("Done with source $s1.")
-#   end
-#   new_hess_time = time() - new_hess_time
-#
-#   @assert length(hess_i) == length(hess_j) == length(hess_val)
-#   hess_i, hess_j, hess_val, new_hess_time
-# end
+@doc """
+Convert the indices and values of a sparse Hessian matrix to an actual
+sparse matrix.
 
+Args:
+  - hess_i: A vector of (source, component) tuples for the Hessian rows
+  - hess_j: A vector of (source, component) tuples for the Hessian columns
+  - hess_val: The values of the Hessian corresponding to (hess_i, hess_j)
+  - dims: The dimensions of the parameter matrix (#components, #sources)
 
+Returns:
+  - A symmetric sparse matrix corresponding to the inputs.
+""" ->
 function unpack_hessian_vals(hess_i::@compat(Vector{Tuple{Int64, Int64}}),
                              hess_j::@compat(Vector{Tuple{Int64, Int64}}),
                              hess_val::Vector{Float64},
@@ -259,7 +276,9 @@ function unpack_hessian_vals(hess_i::@compat(Vector{Tuple{Int64, Int64}}),
   end
   new_hess_sparse =
     sparse(hess_i_vec, hess_j_vec, hess_val, prod(dims), prod(dims));
-  new_hess = 0.5 * full(new_hess_sparse + new_hess_sparse')
+
+  # Guarantee exact symmetry.
+  new_hess = 0.5 * (new_hess_sparse + new_hess_sparse')
 end
 
 
@@ -320,25 +339,21 @@ function maximize_f_newton(
   f::Function, tiled_blob::TiledBlob, mp::ModelParams,
   transform::Transform.DataTransform;
   omitted_ids=Int64[], xtol_rel = 1e-7, ftol_abs = 1e-6, verbose=false,
-  max_iters=100, rho_lower=0.25)
+  max_iters=100, rho_lower=0.25, fast_hessian=false)
 
     kept_ids = setdiff(1:length(UnconstrainedParams), omitted_ids)
     optim_obj_wrap =
       OptimizeElbo.ObjectiveWrapperFunctions(
-        mp -> f(tiled_blob, mp), mp, transform, kept_ids, omitted_ids);
+        mp -> f(tiled_blob, mp), mp, transform, kept_ids, omitted_ids,
+        fast_hessian=fast_hessian);
 
     # For minimization, which is required by the linesearch algorithm.
     optim_obj_wrap.state.scale = -1.0
     optim_obj_wrap.state.verbose = verbose
 
-    function f_hess_wrapper!(x, new_hess)
-      hess = optim_obj_wrap.f_ad_hessian(x)
-      new_hess[:,:] = hess
-    end
-
     x0 = transform.vp_to_array(mp.vp, omitted_ids);
     d = Optim.TwiceDifferentiableFunction(
-      optim_obj_wrap.f_value, optim_obj_wrap.f_grad!, f_hess_wrapper!)
+      optim_obj_wrap.f_value, optim_obj_wrap.f_grad!, f_ad_hess!)
 
     # TODO: use the Optim version after newton_tr is merged.
     nm_result = newton_tr(d,

--- a/src/SampleData.jl
+++ b/src/SampleData.jl
@@ -34,7 +34,7 @@ end
 
 function sample_ce(pos, is_star::Bool)
     CatalogEntry(pos, is_star, sample_star_fluxes, sample_galaxy_fluxes,
-        0.1, .7, pi/4, 4.)
+        0.1, .7, pi/4, 4., "sample")
 end
 
 
@@ -149,7 +149,7 @@ function gen_n_body_dataset(S::Int64; patch_pixel_radius=20., tile_width=50)
   world_locations = WCS.pixel_to_world(blob0[3].wcs, locations)
 
   S_bodies = CatalogEntry[CatalogEntry(world_locations[s, :][:], true,
-      fluxes, fluxes, 0.1, .7, pi/4, 4.) for s in 1:S];
+      fluxes, fluxes, 0.1, .7, pi/4, 4., string(s)) for s in 1:S];
 
   blob = Synthetic.gen_blob(blob0, S_bodies);
   world_radius_pts =

--- a/src/SkyImages.jl
+++ b/src/SkyImages.jl
@@ -83,7 +83,8 @@ function convert_catalog_to_celeste(
         phi90 *= (pi / 180)
 
         CatalogEntry(x_y, row[1, :is_star], star_fluxes,
-            gal_fluxes, row[1, :frac_dev], fits_ab, phi90, re_pixel)
+            gal_fluxes, row[1, :frac_dev], fits_ab, phi90, re_pixel,
+            row[1, :objid])
     end
 
     CatalogEntry[row_to_ce(df[i, :]) for i in 1:size(df, 1)]

--- a/src/SkyImages.jl
+++ b/src/SkyImages.jl
@@ -31,6 +31,7 @@ Load a stamp catalog.
 function load_stamp_catalog(cat_dir, stamp_id, blob; match_blob=false)
     df = SDSS.load_stamp_catalog_df(cat_dir, stamp_id, blob,
                                     match_blob=match_blob)
+    df[:objid] = [ string(s) for s=1:size(df)[1] ]
     convert_catalog_to_celeste(df, blob, match_blob=match_blob)
 end
 

--- a/test/test_elbo_values.jl
+++ b/test/test_elbo_values.jl
@@ -397,6 +397,26 @@ function test_elbo_hessian_term()
 end
 
 
+function test_active_sources()
+  blob, mp, three_bodies, tiled_blob = gen_three_body_dataset();
+
+  # Change the tile size.
+  tiled_blob, mp = ModelInit.initialize_celeste(
+    blob, three_bodies, tile_width=10, fit_psf=false);
+
+  # To ensure a valid test make sure object 3 is partially overlapping.
+  @assert any(Bool[ (2 in sources) & (3 in sources) for
+                    sources in mp.tile_sources[3]])
+  @assert any(Bool[ !(2 in sources) & (3 in sources) for
+                    sources in mp.tile_sources[3]])
+
+  elbo_all = ElboDeriv.elbo(tiled_blob, mp);
+
+  mp.active_sources = [3];
+  elbo_3 = ElboDeriv.elbo(tiled_blob, mp);
+end
+
+
 ####################################################
 
 test_kl_divergence_values()
@@ -408,3 +428,4 @@ test_tiny_image_tiling()
 test_elbo_with_nan()
 test_elbo_likelihood_flavors()
 test_elbo_hessian_term()
+test_active_sources()

--- a/test/test_elbo_values.jl
+++ b/test/test_elbo_values.jl
@@ -409,11 +409,18 @@ function test_active_sources()
                     sources in mp.tile_sources[3]])
   @assert any(Bool[ !(2 in sources) & (3 in sources) for
                     sources in mp.tile_sources[3]])
+  @assert !any(Bool[ (1 in sources) & (3 in sources) for
+                     sources in mp.tile_sources[3]])
 
+  mp.active_sources = 1:mp.S
   elbo_all = ElboDeriv.elbo(tiled_blob, mp);
 
   mp.active_sources = [3];
   elbo_3 = ElboDeriv.elbo(tiled_blob, mp);
+
+  @test elbo_3.v != elbo_all.v
+  @test_approx_eq elbo_all.d[:,3] elbo_3.d[:,3]
+  @test_approx_eq elbo_3.d[:,1] zeros(size(elbo_3.d)[1])
 end
 
 
@@ -427,5 +434,5 @@ test_coadd_cat_init_is_most_likely()
 test_tiny_image_tiling()
 test_elbo_with_nan()
 test_elbo_likelihood_flavors()
-test_elbo_hessian_term()
+#test_elbo_hessian_term() # TODO: fix this to use the ModelParams
 test_active_sources()

--- a/test/test_elbo_values.jl
+++ b/test/test_elbo_values.jl
@@ -357,46 +357,6 @@ function test_elbo_likelihood_flavors()
 end
 
 
-function test_elbo_hessian_term()
-  # Test that the epsilon parts of dual numbers passed to
-  # elbo_hessian_term are the same.
-
-  blob, mp, body, tiled_blob = gen_three_body_dataset(perturb=true);
-
-  # Break into smaller tiles than is the default.
-  tiled_blob, mp =
-    ModelInit.initialize_celeste(blob, body, tile_width=30);
-  mp_dual = CelesteTypes.convert(ModelParams{DualNumbers.Dual}, mp);
-  transform = Transform.get_mp_transform(mp, loc_width=1.0);
-  omitted_ids = Int64[]
-
-  x = transform.vp_to_array(mp.vp, omitted_ids)
-  x_dual = DualNumbers.Dual{Float64}[
-    DualNumbers.Dual{Float64}(x[i, j], 0.) for i = 1:size(x)[1], j=1:size(x)[2]];
-
-  accum = zero_sensitive_float(CanonicalParams,
-                               DualNumbers.Dual{Float64}, mp_dual.S);
-
-  # Test for all three sournces and a set of parameters.
-  for s1 in 1:mp.S, index1 in [1, 10, 29]
-    original_val = real(x_dual[index1, s1])
-    x_dual[index1, s1] = DualNumbers.Dual(original_val, 1.)
-    transform.array_to_vp!(x_dual, mp_dual.vp, omitted_ids);
-    ElboDeriv.elbo_hessian_term!(tiled_blob, mp_dual, accum, s1);
-    accum_trans = transform.transform_sensitive_float(accum, mp_dual);
-    @assert size(accum_trans.d) == size(x)
-    x_dual[index1, s1] = DualNumbers.Dual(original_val, 0.)
-
-    accum_full = ElboDeriv.elbo(tiled_blob, mp_dual);
-    accum_full_trans = transform.transform_sensitive_float(accum_full, mp_dual);
-
-    # The real parts will not be the same, but the epsilon parts should be.
-    @test_approx_eq(DualNumbers.epsilon(accum_trans.d[:]),
-                    DualNumbers.epsilon(accum_full_trans.d[:]))
-  end
-end
-
-
 function test_active_sources()
   blob, mp, three_bodies, tiled_blob = gen_three_body_dataset();
 
@@ -434,5 +394,4 @@ test_coadd_cat_init_is_most_likely()
 test_tiny_image_tiling()
 test_elbo_with_nan()
 test_elbo_likelihood_flavors()
-#test_elbo_hessian_term() # TODO: fix this to use the ModelParams
 test_active_sources()

--- a/test/test_elbo_values.jl
+++ b/test/test_elbo_values.jl
@@ -200,9 +200,9 @@ end
 
 function test_coadd_cat_init_is_most_likely()  # on a real stamp
     stamp_id = "5.0073-0.0739"
-    blob = SkyImages.load_stamp_blob(dat_dir, stamp_id)
+    blob = SkyImages.load_stamp_blob(dat_dir, stamp_id);
 
-    cat_entries = SkyImages.load_stamp_catalog(dat_dir, "s82-$stamp_id", blob)
+    cat_entries = SkyImages.load_stamp_catalog(dat_dir, "s82-$stamp_id", blob);
     bright(ce) = sum(ce.star_fluxes) > 3 || sum(ce.gal_fluxes) > 3
     cat_entries = filter(bright, cat_entries)
 

--- a/test/test_images.jl
+++ b/test/test_images.jl
@@ -84,7 +84,7 @@ function test_blob()
 
   mp_several =
     ModelInit.initialize_model_params(
-      tiled_blob, blob, [cat_entries[1], cat_entries[obj_index]]);
+      tiled_blob, blob, [cat_entries[1]; cat_entries[obj_index]]);
 
   # The second set of vp is the object of interest
   point_patch_psf = PSF.get_psf_at_point(mp_several.patches[2, test_b].psf);

--- a/test/test_images.jl
+++ b/test/test_images.jl
@@ -22,6 +22,8 @@ function test_blob()
   blob = SkyImages.load_sdss_blob(field_dir, run_num, camcol_num, field_num);
   cat_df = SDSS.load_catalog_df(field_dir, run_num, camcol_num, field_num);
   cat_entries = SkyImages.convert_catalog_to_celeste(cat_df, blob);
+  @test ASCIIString[cat_entry.objid for cat_entry in cat_entries ] ==
+        convert(Vector{ASCIIString}, cat_df[:objid])
   tiled_blob, mp =
     ModelInit.initialize_celeste(blob, cat_entries, patch_radius=1e-6,
                                  fit_psf=false);
@@ -167,7 +169,7 @@ function test_set_patch_size()
   function gal_catalog_from_scale(gal_scale::Float64, flux_scale::Float64)
     CatalogEntry[CatalogEntry(world_location, false,
                               flux_scale * fluxes, flux_scale * fluxes,
-                              0.1, .01, pi/4, gal_scale) ]
+                              0.1, .01, pi/4, gal_scale, "sample") ]
   end
 
   srand(1)

--- a/test/test_optimization.jl
+++ b/test/test_optimization.jl
@@ -113,9 +113,8 @@ function test_objective_wrapper()
     @test_approx_eq(slow_w_hess, w_hess)
 
     hess_i, hess_j, hess_val = wrapper_slow_hess.f_ad_hessian_sparse(x[:]);
-    slow_w_hess_sparse = unpack_hessian_vals(hess_i, hess_j, hess_val, size(x));
+    slow_w_hess_sparse = OptimizeElbo.unpack_hessian_vals(hess_i, hess_j, hess_val, size(x));
     @test_approx_eq(slow_w_hess, full(slow_w_hess_sparse))
-
 end
 
 

--- a/test/test_optimization.jl
+++ b/test/test_optimization.jl
@@ -264,7 +264,7 @@ end
 function test_bad_a_init()
     gal_color_mode = [ 2.47122, 1.832, 4.0, 5.9192, 9.12822]
     ce = CatalogEntry([7.2, 8.3], false, gal_color_mode, gal_color_mode,
-            0.5, .7, pi/4, .5)
+            0.5, .7, pi/4, .5, "test")
 
     blob0 = SkyImages.load_stamp_blob(dat_dir, "164.4311-39.0359")
     for b in 1:5

--- a/test/test_optimization.jl
+++ b/test/test_optimization.jl
@@ -93,8 +93,12 @@ function test_objective_wrapper()
 
     # Just test that the Hessian can be computed and is symmetric.
     println("Testing autodiff Hessian...")
-    w_hess = wrapper.f_ad_hessian(x[:]);
-    @test issym(w_hess)
+    hess = zeros(Float64, length(x), length(x));
+    w_hess = wrapper.f_ad_hessian!(x[:], hess);
+
+    hess_i, hess_j, hess_val = wrapper.f_ad_hessian_sparse(x[:]);
+    w_hess_sparse = unpack_hessian_vals(hess_i, hess_j, hess_val, size(x));
+    @test_approx_eq(w_hess, full(w_hess_sparse))
 end
 
 

--- a/test/test_optimization.jl
+++ b/test/test_optimization.jl
@@ -54,7 +54,12 @@ end
 function test_objective_wrapper()
     omitted_ids = Int64[];
     kept_ids = setdiff(1:length(ids_free), omitted_ids);
-    blob, mp, body, tiled_blob = SampleData.gen_two_body_dataset();
+
+    blob, mp, two_bodies, tiled_blob = SampleData.gen_two_body_dataset();
+    # Change the tile size.
+    tiled_blob, mp = ModelInit.initialize_celeste(
+      blob, two_bodies, tile_width=5, fit_psf=false, patch_radius=10.);
+
     trans = get_mp_transform(mp, loc_width=1.0);
 
     wrapper =
@@ -100,9 +105,7 @@ function test_objective_wrapper()
     w_hess_sparse =
       OptimizeElbo.unpack_hessian_vals(hess_i, hess_j, hess_val, size(x));
     @test_approx_eq(w_hess, full(w_hess_sparse))
-    #plot(w_hess, w_hess_sparse, "k.")
 
-    # TODO: fix these:
     wrapper_slow_hess =
       OptimizeElbo.ObjectiveWrapperFunctions(mp -> ElboDeriv.elbo(tiled_blob, mp),
         mp, trans, kept_ids, omitted_ids, fast_hessian=false);

--- a/test/test_optimization.jl
+++ b/test/test_optimization.jl
@@ -140,7 +140,7 @@ function test_star_optimization_newton()
     function lik_function(tiled_blob::TiledBlob, mp::ModelParams)
       ElboDeriv.elbo_likelihood(tiled_blob, mp)
     end
-    omitted_ids = [ids_free.k[:], ids_free.c2[:], ids_free.r2]
+    omitted_ids = [ids_free.k[:]; ids_free.c2[:]; ids_free.r2]
     OptimizeElbo.maximize_f_newton(
       lik_function, tiled_blob, mp, trans,
       omitted_ids=omitted_ids, verbose=true);
@@ -213,9 +213,17 @@ end
 
 
 function test_galaxy_optimization()
+    # NLOpt fails here.
     blob, mp, body, tiled_blob = gen_sample_galaxy_dataset();
-    trans = get_mp_transform(mp, loc_width=1.0);
-    OptimizeElbo.maximize_likelihood(tiled_blob, mp, trans, xtol_rel=0.0)
+    trans = get_mp_transform(mp, loc_width=3.0);
+
+    function lik_function(tiled_blob::TiledBlob, mp::ModelParams)
+      ElboDeriv.elbo_likelihood(tiled_blob, mp)
+    end
+    omitted_ids = [ids_free.k[:]; ids_free.c2[:]; ids_free.r2]
+    OptimizeElbo.maximize_f_newton(
+      lik_function, tiled_blob, mp, trans,
+      omitted_ids=omitted_ids, verbose=true);
     verify_sample_galaxy(mp.vp[1], [8.5, 9.6])
 end
 

--- a/test/test_optimization.jl
+++ b/test/test_optimization.jl
@@ -405,5 +405,5 @@ test_kappa_finding()
 test_bad_a_init()
 test_star_optimization()
 test_galaxy_optimization()
-test_full_elbo_optimization() # Disabled temporarily for NLOpt failure
-#test_real_stamp_optimization() # Too long-running
+test_full_elbo_optimization()
+test_real_stamp_optimization()

--- a/test/test_optimization.jl
+++ b/test/test_optimization.jl
@@ -190,7 +190,7 @@ function test_two_body_optimization_newton()
     PyPlot.title("BFGS")
 
     PyPlot.subplot(1, 3, 3)
-    PyPlot.imshow(orignal_image)
+    PyPlot.imshow(original_image)
     PyPlot.title("Original")
 
     sum((newton_image .- original_image) .^ 2)
@@ -199,21 +199,11 @@ function test_two_body_optimization_newton()
     # newton beats bfgs on the elbo, though not on the likelihood.
     elbo_function(tiled_blob, mp_bfgs).v
     elbo_function(tiled_blob, mp_newton).v
-
-    # This does not work well.  It keeps taking very small steps.
-    mp_newton_bdiag = deepcopy(mp);
-    newton_bdiag_iter_count = OptimizeElbo.maximize_f_newton(
-      elbo_function, tiled_blob, mp_newton_bdiag, trans,
-      omitted_ids=omitted_ids, verbose=true, block_hessian=true,
-      rho_lower = 0.001);
-
-    elbo_function(tiled_blob, mp_newton_bdiag).v
 end
 
 
-
 function test_galaxy_optimization()
-    # NLOpt fails here.
+    # NLOpt fails here so use newton.
     blob, mp, body, tiled_blob = gen_sample_galaxy_dataset();
     trans = get_mp_transform(mp, loc_width=3.0);
 


### PR DESCRIPTION
I add "active sources" to the ModelParams object to control which tiles get computed in the ElboDeriv.  I add an objid field to the ModelParams as well -- we'll need it eventually to match up results across different frames.  This allowed me to replace my last commit's special Hessian function and make the more efficient behavior the default.

I also made Newton TR the default optimization and moved most of the tests over to using it.  A couple tests still require solving optimization problems on a couple parameters that start at spots of semi-negative curvature, which my TR implementation can't handle.  For now, for the purpose of these two tests (and possible similar debugging tasks), I left BFGS in as an option with `optimize_f_bfgs`.
