### PR TITLE
define DualType before the compiler needs it

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,5 @@
 DataFrames
 Distributions
-DualNumbers
 FITSIO
 ForwardDiff
 JLD

--- a/src/CelesteTypes.jl
+++ b/src/CelesteTypes.jl
@@ -33,7 +33,6 @@ import Base.convert
 import Base.+
 import Distributions
 import FITSIO
-import DualNumbers
 import WCSLIB
 import ForwardDiff
 
@@ -544,18 +543,6 @@ end
 ModelParams{NumType <: Number}(
   vp::VariationalParams{NumType}, pp::PriorParams) = begin
     ModelParams{NumType}(vp, pp)
-end
-
-function convert(::Type{ModelParams{DualNumbers.Dual{Float64}}},
-                 mp::ModelParams{Float64})
-    mp_dual =
-      ModelParams(convert(Array{Array{DualNumbers.Dual{Float64}, 1}, 1}, mp.vp),
-                  mp.pp)
-    mp_dual.patches = mp.patches
-    mp_dual.tile_sources = mp.tile_sources
-    mp_dual.active_sources = mp.active_sources
-    mp_dual.objids = mp.objids
-    mp_dual
 end
 
 function convert(FDType::Type{ForwardDiff.GradientNumber},

--- a/src/ElboDeriv.jl
+++ b/src/ElboDeriv.jl
@@ -2,13 +2,10 @@
 
 module ElboDeriv
 
-VERSION < v"0.4.0-dev" && using Docile
 using CelesteTypes
 import Util
 import SloanDigitalSkySurvey: WCS
 import WCSLIB
-
-using DualNumbers.Dual
 
 Threaded = true
 if VERSION > v"0.5.0-dev"

--- a/src/OptimizeElbo.jl
+++ b/src/OptimizeElbo.jl
@@ -6,12 +6,7 @@ using Transform
 
 import ElboDeriv
 import DataFrames
-import DualNumbers
 import Optim
-
-using DualNumbers.Dual
-using DualNumbers.epsilon
-using DualNumbers.real
 
 export ObjectiveWrapperFunctions, WrapperState
 
@@ -32,9 +27,6 @@ type WrapperState
 end
 
 
-typealias DualType DualNumbers.Dual{Float64}
-
-
 type ObjectiveWrapperFunctions
 
     f_objective::Function
@@ -45,16 +37,12 @@ type ObjectiveWrapperFunctions
     f_grad!::Function
     f_hessian::Function
     f_hessian!::Function
-    # f_ad_grad::Function
-    # f_ad_hessian!::Function
-    # f_ad_hessian_sparse::Function
 
     state::WrapperState
     transform::DataTransform
     mp::ModelParams{Float64}
     kept_ids::Array{Int64}
     omitted_ids::Array{Int64}
-    DualType::DataType
 
     # Caching
     last_sf::SensitiveFloat
@@ -75,7 +63,6 @@ type ObjectiveWrapperFunctions
 
         x_length = length(kept_ids) * transform.active_S
         x_size = (length(kept_ids), transform.active_S)
-        mp_dual = CelesteTypes.convert(ModelParams{DualType}, mp);
         @assert transform.active_sources == mp.active_sources
 
         last_sf =
@@ -107,14 +94,6 @@ type ObjectiveWrapperFunctions
               println(state_df)
               println("\n=======================================\n")
             end
-        end
-
-        function f_objective(x_dual::Vector{DualType})
-            state.f_evals += 1
-            # Evaluate in the constrained space and then unconstrain again.
-            transform.array_to_vp!(reshape(x_dual, x_size), mp_dual.vp, omitted_ids)
-            f_res = f(mp_dual)
-            f_res_trans = transform.transform_sensitive_float(f_res, mp_dual)
         end
 
         function f_objective(x::Vector{Float64})
@@ -191,7 +170,7 @@ type ObjectiveWrapperFunctions
         new(f_objective, f_value_grad, f_value_grad!,
             f_value, f_grad, f_grad!, f_hessian, f_hessian!,
             # f_ad_hessian!, f_ad_hessian_sparse,
-            state, transform, mp, kept_ids, omitted_ids, DualType, last_sf)
+            state, transform, mp, kept_ids, omitted_ids, last_sf)
     end
 end
 

--- a/src/OptimizeElbo.jl
+++ b/src/OptimizeElbo.jl
@@ -32,6 +32,9 @@ type WrapperState
 end
 
 
+typealias DualType DualNumbers.Dual{Float64}
+
+
 type ObjectiveWrapperFunctions
 
     f_objective::Function
@@ -72,7 +75,6 @@ type ObjectiveWrapperFunctions
 
         x_length = length(kept_ids) * transform.active_S
         x_size = (length(kept_ids), transform.active_S)
-        DualType = DualNumbers.Dual{Float64}
         mp_dual = CelesteTypes.convert(ModelParams{DualType}, mp);
         @assert transform.active_sources == mp.active_sources
 

--- a/src/Transform.jl
+++ b/src/Transform.jl
@@ -4,7 +4,6 @@ module Transform
 
 using Celeste
 using CelesteTypes
-import DualNumbers
 
 export DataTransform, ParamBounds, ParamBox, SimplexBox
 export get_mp_transform, generate_valid_parameters
@@ -119,12 +118,7 @@ function unbox_parameter{NumType <: Number}(param::NumType, param_box::ParamBox)
 
   # exp and the logit functions handle infinities correctly, so
   # parameters can equal the bounds.
-  if isa(param, DualNumbers.Dual)
-    param_val = DualNumbers.realpart(param)
-  else
-    param_val = param
-  end
-  @assert(lower_bound .<= param_val .<= upper_bound,
+  @assert(lower_bound .<= param .<= upper_bound,
           string("unbox_parameter: param outside bounds: ",
                  "$param ($lower_bound, $upper_bound)"))
 

--- a/test/test_derivatives.jl
+++ b/test/test_derivatives.jl
@@ -3,7 +3,6 @@ using CelesteTypes
 using Base.Test
 using SampleData
 import Synthetic
-import DualNumbers
 
 import SkyImages
 import SloanDigitalSkySurvey: SDSS
@@ -164,16 +163,6 @@ function test_real_image()
   hcat(ad_grad, elbo.d[:, 1])
   @test_approx_eq ad_grad elbo.d[:, 1]
   @test_approx_eq ad_hess elbo.h
-end
-
-
-function test_dual_numbers()
-  # Simply check that the likelihood can be used with dual numbers.
-  # Due to the autodiff parts of the KL divergence and transform,
-  # these parts of the ELBO will currently not work with dual numbers.
-  blob, mp, body, tiled_blob = gen_sample_star_dataset();
-  mp_dual = CelesteTypes.forward_diff_model_params(DualNumbers.Dual{Float64}, mp);
-  elbo_dual = ElboDeriv.elbo_likelihood(tiled_blob, mp_dual);
 end
 
 
@@ -1000,5 +989,4 @@ test_elbo()
 test_active_sources()
 test_derivative_flags()
 test_tile_predicted_image()
-test_dual_numbers()
 test_real_image()

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -265,25 +265,6 @@ function test_util_bvn_cov()
     @test_approx_eq util_22 manual_22
 end
 
-
-function test_convert_dual_mp()
-  blob, mp, body, tiled_blob = gen_three_body_dataset(perturb=true);
-  tiled_blob, mp_original =
-    ModelInit.initialize_celeste(blob, body, tile_width=30);
-  mp_dual = CelesteTypes.convert(ModelParams{DualNumbers.Dual{Float64}}, mp);
-
-  # Test the variational parameters.
-  for s in 1:mp.S
-    @test_approx_eq DualNumbers.realpart(mp_dual.vp[s]) mp.vp[s]
-    @test_approx_eq DualNumbers.epsilon(mp_dual.vp[s]) fill(0.0, length(mp.vp[s]))
-  end
-
-  # Test the remaining fields.
-  for field_name in setdiff(fieldnames(mp), [:vp])
-    @test mp_dual.(field_name) == mp.(field_name)
-  end
-end
-
 ####################################################
 
 test_tile_image()
@@ -292,4 +273,3 @@ test_sky_noise_estimates()
 test_local_sources()
 test_local_sources_2()
 test_local_sources_3()
-test_convert_dual_mp()

--- a/test/test_transforms.jl
+++ b/test/test_transforms.jl
@@ -8,7 +8,6 @@ using SampleData
 using Transform
 using Compat
 
-using DualNumbers
 import ModelInit
 
 
@@ -265,10 +264,6 @@ function test_transform_simplex_functions()
 
 		param_free = Transform.unsimplexify_parameter(param, simplex_box)
 		new_param = Transform.simplexify_parameter(param_free, simplex_box)
-		if NumType <: DualNumbers.Dual
-			param = realpart(param)
-			new_param = realpart(new_param)
-		end
 		@test_approx_eq param new_param
 	end
 
@@ -277,7 +272,6 @@ function test_transform_simplex_functions()
 
 		simplex_box = Transform.SimplexBox(lb, this_scale, length(param))
 		simplex_and_unsimplex(param, simplex_box)
-		simplex_and_unsimplex([ Dual(p) for p in param], simplex_box)
 
 		# Test that the edges work.
 		simplex_and_unsimplex(Float64[ lb, 1 - lb ], simplex_box)
@@ -305,10 +299,6 @@ function test_transform_box_functions()
 	function box_and_unbox{NumType <: Number}(param::NumType, param_box::ParamBox)
 		param_free = Transform.unbox_parameter(param, param_box)
 		new_param = Transform.box_parameter(param_free, param_box)
-		if NumType <: DualNumbers.Dual
-			param = realpart(param)
-			new_param = realpart(new_param)
-		end
 		@test_approx_eq param new_param
 	end
 
@@ -317,7 +307,6 @@ function test_transform_box_functions()
 		param = 0.2
 		param_box = Transform.ParamBox(lb, ub, this_scale)
 		box_and_unbox(param, param_box)
-		box_and_unbox(Dual(param), param_box)
 
 		# Test that the edges work.
 		box_and_unbox(lb, param_box)


### PR DESCRIPTION
@kpamnany @rgiordan -- Evidently in Julila 0.5 we can't count on assignment of DualType (at run time) happening before the functions that use it are compiled (at  compile time). That seems reasonable. This PR defines DualType at the module's top level.
