### PR TITLE
add optimized load_raw_field()

### DIFF
--- a/test/test_images.jl
+++ b/test/test_images.jl
@@ -15,6 +15,22 @@ run_num = "003900"
 camcol_num = "6"
 field_num = "0269"
 
+function test_interp_sky()
+    data = [1.  2.  3.  4.;
+            5.  6.  7.  8.;
+            9. 10. 11. 12]
+    xcoords = [0.1, 2.5]
+    ycoords = [0.5, 2.5, 4.]
+    result = SkyImages.interp_sky(data, xcoords, ycoords)
+    @test size(result) == (2, 3)
+    @test_approx_eq result[1, 1] 1.0
+    @test_approx_eq result[2, 1] 7.0
+    @test_approx_eq result[1, 2] 2.5
+    @test_approx_eq result[2, 2] 8.5
+    @test_approx_eq result[1, 3] 4.0
+    @test_approx_eq result[2, 3] 10.0
+end
+
 function test_blob()
   # A lot of tests are in a single function to avoid having to reload
   # the full image multiple times.
@@ -238,6 +254,7 @@ function test_get_local_sources()
 end
 
 
+test_interp_sky()
 test_blob()
 test_stamp_get_object_psf()
 test_get_tiled_image_source()


### PR DESCRIPTION
... for a 100x speed-up.

Old version:

``` julia
julia> import SloanDigitalSkySurvey.SDSS

julia> @time SDSS.load_raw_field(".", "003900", "6", "0269", 1, 1.);
  8.682727 seconds (71.00 M allocations: 1.636 GB, 28.46% gc time)

julia> @time SDSS.load_raw_field(".", "003900", "6", "0269", 1, 1.);
  7.143706 seconds (68.65 M allocations: 1.535 GB, 43.42% gc time)
```

New version:

``` julia
julia> import Celeste.SkyImages

julia> @time SkyImages.load_raw_field(".", "003900", "6", "0269", 1, 1.);
  0.141113 seconds (87.34 k allocations: 27.344 MB)

julia> @time SkyImages.load_raw_field(".", "003900", "6", "0269", 1, 1.);
  0.056292 seconds (187 allocations: 23.497 MB)
```

Still need to write a test for `interp_sky()`. Hold off on merging until I push that, probably tomorrow.
