### PR TITLE
Hessian performance julia4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 
 # omit converage files
 *.cov
+
+# Omit memory profiling output
+**/*.mem

--- a/bin/benchmark_elbo_with_hessian.jl
+++ b/bin/benchmark_elbo_with_hessian.jl
@@ -12,7 +12,7 @@ const dat_dir = joinpath(Pkg.dir("Celeste"), "dat")
 srand(1)
 println("Loading data.")
 
-S = 4
+S = 2
 blob, mp, body, tiled_blob =
   SampleData.gen_n_body_dataset(S, tile_width=10);
 
@@ -23,7 +23,10 @@ println("Calculating ELBO.")
 
 # let's time it without any overhead from profiling
 @time elbo = ElboDeriv.elbo(tiled_blob, mp, calculate_hessian=true);
+@time elbo = ElboDeriv.elbo_likelihood(tiled_blob, mp, calculate_hessian=true);
 
 Profile.init(10^8, 0.001)
-@profile elbo = ElboDeriv.elbo(tiled_blob, mp, calculate_hessian=false);
+Profile.clear_malloc_data()
+#@profile elbo = ElboDeriv.elbo(tiled_blob, mp, calculate_hessian=false);
+@profile elbo = ElboDeriv.elbo_likelihood(tiled_blob, mp, calculate_hessian=false);
 Profile.print(format=:flat)

--- a/bin/benchmark_elbo_with_hessian.jl
+++ b/bin/benchmark_elbo_with_hessian.jl
@@ -12,7 +12,7 @@ const dat_dir = joinpath(Pkg.dir("Celeste"), "dat")
 srand(1)
 println("Loading data.")
 
-S = 2
+S = 4
 blob, mp, body, tiled_blob =
   SampleData.gen_n_body_dataset(S, tile_width=10);
 
@@ -23,7 +23,7 @@ println("Calculating ELBO.")
 
 # let's time it without any overhead from profiling
 @time elbo = ElboDeriv.elbo(tiled_blob, mp, calculate_hessian=true);
-@time elbo = ElboDeriv.elbo_likelihood(tiled_blob, mp, calculate_hessian=true);
+@time elbo = ElboDeriv.elbo(tiled_blob, mp, calculate_hessian=true);
 
 Profile.init(10^8, 0.001)
 Profile.clear_malloc_data()

--- a/bin/distributed_benchmark.jl
+++ b/bin/distributed_benchmark.jl
@@ -121,7 +121,7 @@ end;
 # end
 
 # Make sure they match.
-@assert abs(accum.v / accum_par.v - 1) < 1e-6
+@assert abs(accum.v[1] / accum_par.v[1] - 1) < 1e-6
 @assert maximum(abs((accum.d .+ 1e-8) ./ (accum_par.d .+ 1e-8) - 1)) < 1e-6
 
 elbo_times = [ remotecall_fetch(w, () -> elbo_time) for w in workers() ]

--- a/bin/staging/preprocess_image.jl
+++ b/bin/staging/preprocess_image.jl
@@ -4,6 +4,7 @@ using Celeste
 using CelesteTypes
 using SampleData
 import JLD
+import SloanDigitalSkySurvey: SDSS
 
 # field_dir = joinpath(dat_dir, "sample_field")
 # run_num = "003900"

--- a/src/BivariateNormals.jl
+++ b/src/BivariateNormals.jl
@@ -153,7 +153,7 @@ function eval_bvn_log_density{NumType <: Number}(
 
   -0.5 * (
     (x[1] - bvn.the_mean[1]) * elbo_vars.py1[1] +
-    (x[2] - bvn.the_mean[2]) * elbo_vars.py2[2] -
+    (x[2] - bvn.the_mean[2]) * elbo_vars.py2[1] -
     log(bvn.precision[1, 1] * bvn.precision[2, 2] - bvn.precision[1, 2] ^ 2))
 end
 

--- a/src/BivariateNormals.jl
+++ b/src/BivariateNormals.jl
@@ -109,6 +109,38 @@ function eval_bvn_pdf{NumType <: Number}(
 end
 
 
+
+@doc """
+Return quantities related to the pdf of an offset bivariate normal.
+
+Args:
+  - bmc: A bivariate normal component
+  - x: A 2x1 vector containing a mean offset to be applied to bmc
+
+Returns:
+  - py1: The first row of the precision times (x - the_mean)
+  - py2: The second row of the precision times (x - the_mean)
+  - The density of the bivariate normal times the weight.
+""" ->
+function eval_bvn_pdf_in_place!{NumType <: Number}(
+    elbo_vars::ElboIntermediateVariables{NumType},
+    bmc::BvnComponent{NumType}, x::Vector{Float64})
+
+  elbo_vars.py1[1] =
+    bmc.precision[1,1] * (x[1] - bmc.the_mean[1]) +
+    bmc.precision[1,2] * (x[2] - bmc.the_mean[2])
+  elbo_vars.py2[1] =
+    bmc.precision[2,1] * (x[1] - bmc.the_mean[1]) +
+    bmc.precision[2,2] * (x[2] - bmc.the_mean[2])
+  elbo_vars.f_pre[1] =
+    bmc.z * exp(-0.5 * ((x[1] - bmc.the_mean[1]) * elbo_vars.py1[1] +
+                        (x[2] - bmc.the_mean[2]) * elbo_vars.py2[1]))
+
+  true # return type
+end
+
+
+
 ##################
 # Derivatives
 
@@ -221,6 +253,85 @@ function get_bvn_derivs!{NumType <: Number}(
       bvn_xsig_h[x_ind, 2] =
         py1 * bvn.precision[2, x_ind] + py2 * bvn.precision[1, x_ind]
       bvn_xsig_h[x_ind, 3] = py2 * bvn.precision[2, x_ind]
+    end
+  end
+end
+
+
+
+function get_bvn_derivs_in_place!{NumType <: Number}(
+    elbo_vars::ElboIntermediateVariables{NumType},
+    bvn::BvnComponent{NumType},
+    calculate_x_hess::Bool,
+    calculate_sigma_hessian::Bool)
+
+  # Gradient with respect to x.
+  bvn_x_d = elbo_vars.bvn_x_d
+  bvn_x_d[1] = -elbo_vars.py1[1]
+  bvn_x_d[2] = -elbo_vars.py2[1]
+
+  if calculate_x_hess
+    bvn_xx_h = elbo_vars.bvn_xx_h
+    # println("-------------")
+    # println(bvn_xx_h)
+    # println(bvn.precision)
+
+    # Hessian terms involving only x
+    bvn_xx_h[1, 1] = -bvn.precision[1, 1]
+    bvn_xx_h[2, 2] = -bvn.precision[2, 2]
+    bvn_xx_h[1, 2] = bvn_xx_h[2, 1] = -bvn.precision[1 ,2]
+  end
+
+  # The first term is the derivative of -0.5 * x' Sigma^{-1} x
+  # The second term is the derivative of -0.5 * log|Sigma|
+  bvn_sig_d = elbo_vars.bvn_sig_d
+  bvn_sig_d[1] = 0.5 * elbo_vars.py1[1] * elbo_vars.py1[1] - 0.5 * bvn.precision[1, 1]
+  bvn_sig_d[2] = elbo_vars.py1[1] * elbo_vars.py2[1]             - bvn.precision[1, 2]
+  bvn_sig_d[3] = 0.5 * elbo_vars.py2[1] * elbo_vars.py2[1] - 0.5 * bvn.precision[2, 2]
+
+  if calculate_sigma_hessian
+
+    # Hessian calculation for terms containing sigma.
+
+    # Derivatives of py1 and py2 with respect to s11, s12, s22 in that order.
+    # These are used for the hessian calculations.
+    dpy1_dsig = elbo_vars.dpy1_dsig
+    dpy1_dsig[1] = -elbo_vars.py1[1] * bvn.precision[1,1]
+    dpy1_dsig[2] = -elbo_vars.py2[2] * bvn.precision[1,1] - elbo_vars.py1[1] * bvn.precision[1,2]
+    dpy1_dsig[3] = -elbo_vars.py2[1] * bvn.precision[1,2]
+
+    dpy2_dsig = elbo_vars.dpy2_dsig
+    dpy2_dsig[1] = -elbo_vars.py1[1] * bvn.precision[1,2]
+    dpy2_dsig[2] = -elbo_vars.py1[1] * bvn.precision[2,2] - elbo_vars.py2[1] * bvn.precision[1,2]
+    dpy2_dsig[3] = -elbo_vars.py2[1] * bvn.precision[2,2]
+
+    # Hessian terms involving only sigma
+    bvn_sigsig_h = elbo_vars.bvn_sigsig_h
+    for s_ind=1:3
+      # println("=============")
+      # println(bvn_sigsig_h)
+      # println(bvn.dsiginv_dsig)
+      # Differentiate with respect to s_ind second.
+      bvn_sigsig_h[1, s_ind] = #bvn_sigsig_h[s_ind, 1] =
+        elbo_vars.py1[1] * dpy1_dsig[s_ind] - 0.5 * bvn.dsiginv_dsig[1, s_ind]
+
+      # d log|sigma| / dsigma12 is twice lambda12.
+      bvn_sigsig_h[2, s_ind] =
+        elbo_vars.py1[1] * dpy2_dsig[s_ind] + elbo_vars.py2[1] * dpy1_dsig[s_ind] -
+        bvn.dsiginv_dsig[2, s_ind]
+
+      bvn_sigsig_h[3, s_ind] = #bvn_sigsig_h[s_ind, 3] =
+        elbo_vars.py2[1] * dpy2_dsig[s_ind] - 0.5 * bvn.dsiginv_dsig[3, s_ind]
+    end
+
+    # Hessian terms involving both x and sigma.
+    # Note that dpyA / dxB = bvn.precision[A, B]
+    bvn_xsig_h = elbo_vars.bvn_xsig_h
+    for x_ind=1:2
+      bvn_xsig_h[x_ind, 1] = elbo_vars.py1[1] * bvn.precision[1, x_ind]
+      bvn_xsig_h[x_ind, 2] =
+        elbo_vars.py1[1] * bvn.precision[2, x_ind] + elbo_vars.py2[1] * bvn.precision[1, x_ind]
+      bvn_xsig_h[x_ind, 3] = elbo_vars.py2[1] * bvn.precision[2, x_ind]
     end
   end
 end

--- a/src/BivariateNormals.jl
+++ b/src/BivariateNormals.jl
@@ -140,6 +140,19 @@ function eval_bvn_pdf_in_place!{NumType <: Number}(
 end
 
 
+function touch_py1!{NumType <: Number}(elbo_vars::ElboIntermediateVariables{NumType})
+  elbo_vars.py1[1] = 5.0
+
+  true
+end
+
+function touch_bmc{NumType <: Number}(bmc::BvnComponent{NumType})
+  bmc.the_mean[1] * bmc.precision[1, 1]
+
+  true
+end
+
+
 
 ##################
 # Derivatives

--- a/src/BivariateNormals.jl
+++ b/src/BivariateNormals.jl
@@ -310,7 +310,7 @@ function get_bvn_derivs_in_place!{NumType <: Number}(
     # These are used for the hessian calculations.
     dpy1_dsig = elbo_vars.dpy1_dsig
     dpy1_dsig[1] = -elbo_vars.py1[1] * bvn.precision[1,1]
-    dpy1_dsig[2] = -elbo_vars.py2[2] * bvn.precision[1,1] - elbo_vars.py1[1] * bvn.precision[1,2]
+    dpy1_dsig[2] = -elbo_vars.py2[1] * bvn.precision[1,1] - elbo_vars.py1[1] * bvn.precision[1,2]
     dpy1_dsig[3] = -elbo_vars.py2[1] * bvn.precision[1,2]
 
     dpy2_dsig = elbo_vars.dpy2_dsig

--- a/src/BivariateNormals.jl
+++ b/src/BivariateNormals.jl
@@ -71,9 +71,9 @@ Returns:
 function eval_bvn_pdf{NumType <: Number}(
     bmc::BvnComponent{NumType}, x::Vector{Float64})
 
-  z = 1 + 2
-  z2 = 3 + x[1]
-  z3 = 3 + bmc.the_mean[2]
+  # z = 1 + 2
+  # z2 = 3 + x[1]
+  # z3 = 3 + bmc.the_mean[2]
   y1 = x[1] - bmc.the_mean[1]
   y2 = x[2] - bmc.the_mean[2]
   py1 = bmc.precision[1,1] * y1 + bmc.precision[1,2] * y2

--- a/src/BivariateNormals.jl
+++ b/src/BivariateNormals.jl
@@ -74,11 +74,12 @@ function eval_bvn_pdf{NumType <: Number}(
   # z = 1 + 2
   # z2 = 3 + x[1]
   # z3 = 3 + bmc.the_mean[2]
-  y1 = x[1] - bmc.the_mean[1]
-  y2 = x[2] - bmc.the_mean[2]
-  py1 = bmc.precision[1,1] * y1 + bmc.precision[1,2] * y2
-  py2 = bmc.precision[2,1] * y1 + bmc.precision[2,2] * y2
-  c_ytpy = -0.5 * (y1 * py1 + y2 * py2)
+  y = NumType[x[1] - bmc.the_mean[1], x[2] - bmc.the_mean[2]]
+  # y1 = x[1] - bmc.the_mean[1]
+  # y2 = x[2] - bmc.the_mean[2]
+  py1 = bmc.precision[1,1] * y[1] + bmc.precision[1,2] * y[2]
+  py2 = bmc.precision[2,1] * y[1] + bmc.precision[2,2] * y[2]
+  c_ytpy = -0.5 * (y[1] * py1 + y[2] * py2)
   f_denorm = exp(c_ytpy)
   py1, py2, bmc.z * f_denorm
 end

--- a/src/BivariateNormals.jl
+++ b/src/BivariateNormals.jl
@@ -392,7 +392,7 @@ function transform_bvn_derivs!{NumType <: Number}(
         bvn_uu_h[u_id1, u_id2] += inner_term * wcs_jacobian[x_id1, u_id1]
       end
     end
-    bvn_uu_h[2, 1] = bvn_uu_h[1, 2]
+    @inbounds bvn_uu_h[2, 1] = bvn_uu_h[1, 2]
   end
 end
 

--- a/src/BivariateNormals.jl
+++ b/src/BivariateNormals.jl
@@ -146,7 +146,9 @@ end
 This is the function of which get_bvn_derivs!() returns the derivatives.
 It is only used for testing.""" ->
 function eval_bvn_log_density{NumType <: Number}(
+    elbo_vars::ElboIntermediateVariables{NumType},
     bvn::BvnComponent{NumType}, x::Vector{Float64})
+
   eval_bvn_pdf_in_place!(elbo_vars, bvn, x);
 
   -0.5 * (

--- a/src/BivariateNormals.jl
+++ b/src/BivariateNormals.jl
@@ -27,13 +27,13 @@ immutable BvnComponent{NumType <: Number}
       c = 1 ./ (the_det^.5 * 2pi)
 
       if calculate_siginv_deriv
-        # Derivatives of Sigma^{-1} with repsect to sigma.  These are the second
+        # Derivatives of Sigma^{-1} with respect to sigma.  These are the second
         # derivatives of log|Sigma| with respect to sigma.
         # dsiginv_dsig[a, b] is the derivative of sig^{-1}[a] / d sig[b]
-        dsiginv_dsig = zeros(3, 3)
+        dsiginv_dsig = Array(NumType, 3, 3)
 
         precision = the_cov^-1
-
+        
         dsiginv_dsig[1, 1] = -precision[1, 1] ^ 2
         dsiginv_dsig[1, 2] = -2 * precision[1, 1] * precision[1, 2]
         dsiginv_dsig[1, 3] = -precision[1, 2] ^ 2

--- a/src/ElboDeriv.jl
+++ b/src/ElboDeriv.jl
@@ -443,6 +443,12 @@ function accumulate_source_brightness!{NumType <: Number}(
   const use_blas = false
 
   for i in 1:Ia # Stars and galaxies
+    fsm_i = i == 1 ? elbo_vars.fs0m_vec[s] : elbo_vars.fs1m_vec[s]
+    println("========")
+    @time x = fsm_i.v
+    @time y = fsm_i.d[1,1]
+    println("========")
+
     lf = sb.E_l_a[b, i].v * fsm[i].v
     llff = sb.E_ll_a[b, i].v * fsm[i].v^2
 
@@ -491,10 +497,11 @@ function accumulate_source_brightness!{NumType <: Number}(
         # The (bright, bright) block:
         for p0_ind1 in 1:length(p0_bright), p0_ind2 in 1:length(p0_bright)
           # TODO: time consuming **************
-          E_G_s.h[p0_bright[p0_ind1], p0_bright[p0_ind2]] =
-            a[i] * fsm[i].v * sb.E_l_a[b, i].h[p0_ind1, p0_ind2]
-          E_G2_s.h[p0_bright[p0_ind1], p0_bright[p0_ind2]] =
-            a[i] * (fsm[i].v^2) * sb.E_ll_a[b, i].h[p0_ind1, p0_ind2]
+          println("------------")
+          @time x1 = fsm_i.v
+          @time E_G_s.h[p0_bright[p0_ind1], p0_bright[p0_ind2]] = a[i] * sb.E_l_a[b, i].h[p0_ind1, p0_ind2] * x1
+          @time x1 = a[i] * sb.E_ll_a[b, i].h[p0_ind1, p0_ind2]
+          @time E_G2_s.h[p0_bright[p0_ind1], p0_bright[p0_ind2]] = (fsm[i].v^2) * x1
         end
 
         # The (shape, shape) block:

--- a/src/ElboDeriv.jl
+++ b/src/ElboDeriv.jl
@@ -227,6 +227,14 @@ function accum_star_pos!{NumType <: Number}(
     wcs_jacobian::Array{Float64, 2};
     calculate_derivs::Bool=true)
 
+  # Note: if this line is included, then no other line gets memory allocation
+  # attributed to it.
+  foo = zeros(1)
+  #
+  # touch_py1!(elbo_vars)
+  #
+  # foo[1] = touch_bmc(bmc)
+  #
   # Note: evaluating this and passing in may cause a lot of memory allocation?
   #elbo_vars.py1[1], elbo_vars.py2[1], elbo_vars.f_pre[1] = eval_bvn_pdf(bmc, x)
   eval_bvn_pdf_in_place!(elbo_vars, bmc, x)
@@ -261,6 +269,32 @@ function accum_star_pos!{NumType <: Number}(
 
   true # Set return type?
 end
+
+
+function fake_accum_star_pos!{NumType <: Number}(
+    elbo_vars::ElboIntermediateVariables{NumType},
+    s::Int64,
+    bmc::BvnComponent{NumType},
+    x::Vector{Float64},
+    wcs_jacobian::Array{Float64, 2};
+    calculate_derivs::Bool=true)
+
+  touch_py1!(elbo_vars)
+  #
+  foo = zeros(1)
+  foo[1] = touch_bmc(bmc)
+  #
+  # Note: evaluating this and passing in may cause a lot of memory allocation?
+  #elbo_vars.py1[1], elbo_vars.py2[1], elbo_vars.f_pre[1] = eval_bvn_pdf(bmc, x)
+  #eval_bvn_pdf_in_place!(elbo_vars, bmc, x)
+
+  # Note: if this line is included, then no other line gets memory allocation
+  # attributed to it.
+  true # Set return type?
+end
+
+
+
 
 
 @doc """
@@ -399,8 +433,9 @@ function populate_fsm_vecs!{NumType <: Number}(
       elbo_vars.calculate_hessian && elbo_vars.calculate_derivs && active_source
     clear!(elbo_vars.fs0m_vec[s], clear_hessian=calculate_hessian)
     for k = 1:3 # PSF component
+        x = Float64[tile.h_range[h], tile.w_range[w]]
         accum_star_pos!(
-          elbo_vars, s, star_mcs[k, s], Float64[tile.h_range[h], tile.w_range[w]],
+          elbo_vars, s, star_mcs[k, s], x,
           wcs_jacobian, calculate_derivs=active_source)
     end
 

--- a/src/ElboDeriv.jl
+++ b/src/ElboDeriv.jl
@@ -383,9 +383,9 @@ function populate_fsm_vecs!{NumType <: Number}(
     calculate_hessian =
       elbo_vars.calculate_hessian && elbo_vars.calculate_derivs && active_source
     clear!(elbo_vars.fs0m_vec[s], clear_hessian=calculate_hessian)
-    for star_mc in star_mcs[:, s]
+    for k = 1:3 # PSF component
         accum_star_pos!(
-          elbo_vars, s, star_mc, Float64[tile.h_range[h], tile.w_range[w]],
+          elbo_vars, s, star_mcs[k, s], Float64[tile.h_range[h], tile.w_range[w]],
           wcs_jacobian, calculate_derivs=active_source)
     end
 

--- a/src/ElboDeriv.jl
+++ b/src/ElboDeriv.jl
@@ -391,12 +391,16 @@ function populate_fsm_vecs!{NumType <: Number}(
 
     clear!(elbo_vars.fs1m_vec[s], clear_hessian=calculate_hessian)
     for i = 1:2 # Galaxy types
-        for j in 1:[8,6][i] # Galaxy component
-            for k = 1:3 # PSF component
-                accum_galaxy_pos!(
-                  elbo_vars, s, gal_mcs[k, j, i, s], Float64[tile.h_range[h],
-                  tile.w_range[w]], wcs_jacobian,
-                  calculate_derivs=active_source)
+        for j in 1:8 # Galaxy component
+        #for j in 1:[8,6][i] # Galaxy component
+            # If i == 2 then there are only six galaxy components.
+            if (i == 1) || (j <= 6)
+              for k = 1:3 # PSF component
+                  accum_galaxy_pos!(
+                    elbo_vars, s, gal_mcs[k, j, i, s], Float64[tile.h_range[h],
+                    tile.w_range[w]], wcs_jacobian,
+                    calculate_derivs=active_source)
+              end
             end
         end
     end
@@ -745,6 +749,8 @@ function get_expected_pixel_brightness!{NumType <: Number}(
     elbo_vars.E_G.v[1] +=
       tile.constant_background ? tile.epsilon : tile.epsilon_mat[h, w]
   end
+
+  true
 end
 
 

--- a/src/ElboDeriv.jl
+++ b/src/ElboDeriv.jl
@@ -798,10 +798,14 @@ function add_elbo_log_term!{NumType <: Number}(
       calculate_hessian=elbo_vars.calculate_hessian)
 
     # Add to the ELBO.
-    elbo.d += x_nbm * elbo_vars.elbo_log_term.d
+    for ind in 1:length(elbo.d)
+      elbo.d[ind] += x_nbm * elbo_vars.elbo_log_term.d[ind]
+    end
 
     if elbo_vars.calculate_hessian
-      elbo.h += x_nbm * elbo_vars.elbo_log_term.h
+      for ind in 1:length(elbo.h)
+        elbo.h[ind] += x_nbm * elbo_vars.elbo_log_term.h[ind]
+      end
     end
   end
 end

--- a/src/ElboDeriv.jl
+++ b/src/ElboDeriv.jl
@@ -302,7 +302,7 @@ function accum_galaxy_pos!{NumType <: Number}(
 
   if elbo_vars.calculate_derivs && calculate_derivs
 
-    get_bvn_derivs_in_place!(elbo_vars, bmc,
+    get_bvn_derivs_in_place!(elbo_vars, gcc.bmc,
       elbo_vars.calculate_hessian, elbo_vars.calculate_hessian);
 
     # get_bvn_derivs!(
@@ -594,26 +594,11 @@ function accumulate_source_brightness!{NumType <: Number}(
         E_G2_s.h[ids.a[i], p0_shape] = E_G2_s.h[p0_shape, ids.a[i]]'
         E_G_s.h[ids.a[i], p0_shape] = E_G_s.h[p0_shape, ids.a[i]]'
 
-        if use_blas
-          # The (shape, bright) blocks.
-          # BLAS for
-          # E_G_s.h[p0_bright, p0_shape] = a[i] * sb.E_l_a[b, i].d[:, 1] * fsm_i.d'
-          BLAS.gemm!('N', 'T', a[i], sb.E_l_a[b, i].d[:, 1], fsm_i.d,
-                     0.0, E_G_s_hsub.bright_shape)
-
-          # BLAS for
-          # h2_bright_shape =
-          #   2 * a[i] * sb.E_ll_a[b, i].d[:, 1] * fsm_i.v[1] * fsm_i.d'
-          BLAS.gemm!('N', 'T', 2 * a[i] * fsm_i.v[1],
-                     sb.E_ll_a[b, i].d[:, 1], fsm_i.d,
-                     0.0, E_G2_s_hsub.bright_shape)
-        else
-          for ind_b in 1:length(p0_bright), ind_s in 1:length(p0_shape)
-            E_G_s_hsub.bright_shape[ind_b, ind_s] =
-              a[i] * sb.E_l_a[b, i].d[ind_b, 1] * fsm_i.d[ind_s, 1]
-            E_G2_s_hsub.bright_shape[ind_b, ind_s] =
-              2 * a[i] * sb.E_ll_a[b, i].d[ind_b, 1] * fsm_i.v[1] * fsm_i.d[ind_s]
-          end
+        for ind_b in 1:length(p0_bright), ind_s in 1:length(p0_shape)
+          E_G_s_hsub.bright_shape[ind_b, ind_s] =
+            a[i] * sb.E_l_a[b, i].d[ind_b, 1] * fsm_i.d[ind_s, 1]
+          E_G2_s_hsub.bright_shape[ind_b, ind_s] =
+            2 * a[i] * sb.E_ll_a[b, i].d[ind_b, 1] * fsm_i.v[1] * fsm_i.d[ind_s]
         end
         E_G_s.h[p0_bright, p0_shape] = E_G_s_hsub.bright_shape
         E_G_s.h[p0_shape, p0_bright] = E_G_s_hsub.bright_shape'

--- a/src/ElboDeriv.jl
+++ b/src/ElboDeriv.jl
@@ -228,13 +228,13 @@ function accum_star_pos!{NumType <: Number}(
     calculate_derivs::Bool=true)
 
   # Note: evaluating this and passing in may cause a lot of memory allocation?
-  elbo_vars.py1[1], elbo_vars.py2[1], elbo_vars.f_pre[1] = eval_bvn_pdf(bmc, x)
+  #elbo_vars.py1[1], elbo_vars.py2[1], elbo_vars.f_pre[1] = eval_bvn_pdf(bmc, x)
+  eval_bvn_pdf_in_place!(elbo_vars, bmc, x)
 
   # TODO: Also make a version that doesn't calculate any derivatives
   # if the object isn't in active_sources.
-  get_bvn_derivs!(
-    elbo_vars, elbo_vars.py1[1], elbo_vars.py2[1], elbo_vars.f_pre[1],
-    bmc, true, false);
+  get_bvn_derivs_in_place!(
+    elbo_vars, bmc, true, false);
 
   fs0m = elbo_vars.fs0m_vec[s]
   fs0m.v[1] += elbo_vars.f_pre[1]
@@ -258,6 +258,8 @@ function accum_star_pos!{NumType <: Number}(
       end
     end
   end
+
+  true # Set return type?
 end
 
 

--- a/src/ElboKL.jl
+++ b/src/ElboKL.jl
@@ -13,7 +13,7 @@ function subtract_kl_c{NumType <: Number}(
 
   pp_kl_cid = KL.gen_diagmvn_mvn_kl(pp.c_mean[:, d, i], pp.c_cov[:, :, d, i])
   # (v, (d_c1, d_c2)) = pp_kl_cid(vs[ids.c1[:, i]], vs[ids.c2[:, i]])
-  # accum.v -= v * a * k
+  # accum.v[1] -= v * a * k
   -pp_kl_cid(vs[ids.c1[:, i]], vs[ids.c2[:, i]]) * a * k
 
   # accum.d[ids.k[d, i], s] -= a * v
@@ -30,7 +30,7 @@ function subtract_kl_k{NumType <: Number}(
 
     pp_kl_ki = KL.gen_categorical_kl(pp.k[:, i])
     # (v, (d_k,)) = pp_kl_ki(vs[ids.k[:, i]])
-    # accum.v -= v * vs[ids.a[i]]
+    # accum.v[1] -= v * vs[ids.a[i]]
     # accum.d[ids.k[:, i], s] -= d_k .* vs[ids.a[i]]
     # accum.d[ids.a[i], s] -= v
 
@@ -49,7 +49,7 @@ function subtract_kl_r{NumType <: Number}(
     pp_kl_r = KL.gen_normal_kl(pp.r_mean[i], pp.r_var[i])
     # (v, (d_r1, d_r2)) = pp_kl_r(vs[ids.r1[i]], vs[ids.r2[i]])
 
-    # accum.v -= v * a
+    # accum.v[1] -= v * a
     # accum.d[ids.r1[i], s] -= d_r1 .* a
     # accum.d[ids.r2[i], s] -= d_r2 .* a
     # accum.d[ids.a[i], s] -= v
@@ -66,7 +66,7 @@ Subtract the KL divergence from the prior for a
 function subtract_kl_a{NumType <: Number}(vs::Vector{NumType}, pp::PriorParams)
     pp_kl_a = KL.gen_categorical_kl(pp.a)
     # (v, (d_a,)) = pp_kl_a(vs[ids.a])
-    # accum.v -= v
+    # accum.v[1] -= v
     # accum.d[ids.a, s] -= d_a
     -pp_kl_a(vs[ids.a])
 end
@@ -107,14 +107,14 @@ function subtract_kl!{NumType <: Number}(
         ForwardDiff.hessian(subtract_kl_value_wrapper, vp_vec, ForwardDiff.AllResults)
       accum.h += hess
       accum.d += reshape(ForwardDiff.gradient(all_results), P, Sa);
-      accum.v += ForwardDiff.value(all_results)
+      accum.v[1] += ForwardDiff.value(all_results)
     else
       grad, all_results =
         ForwardDiff.gradient(subtract_kl_value_wrapper, vp_vec, ForwardDiff.AllResults)
       accum.d += reshape(grad, P, Sa);
-      accum.v += ForwardDiff.value(all_results)
+      accum.v[1] += ForwardDiff.value(all_results)
     end
   else
-    accum.v += subtract_kl_value_wrapper(vp_vec)
+    accum.v[1] += subtract_kl_value_wrapper(vp_vec)
   end
 end

--- a/src/OptimizeElbo.jl
+++ b/src/OptimizeElbo.jl
@@ -109,7 +109,7 @@ type ObjectiveWrapperFunctions
             # TODO: Add an option to print either the transformed or
             # free parameterizations.
             print_status(mp.vp[mp.active_sources],
-                         f_res.v, f_res.d)
+                         f_res.v[1], f_res.d)
             f_res_trans = transform.transform_sensitive_float(f_res, mp)
 
             # Cache the result.
@@ -127,7 +127,7 @@ type ObjectiveWrapperFunctions
                 svs = [res.d[kept_ids, si] for si in 1:transform.active_S]
                 grad[:] = reduce(vcat, svs)
             end
-            state.scale * res.v, state.scale .* grad
+            state.scale * res.v[1], state.scale .* grad
         end
 
         # The remaining functions are scaled and take matrices.

--- a/src/SensitiveFloat.jl
+++ b/src/SensitiveFloat.jl
@@ -78,7 +78,8 @@ end
 function clear!{ParamType <: CelesteTypes.ParamSet, NumType <: Number}(
   sp::SensitiveFloat{ParamType, NumType}; clear_hessian::Bool=true)
 
-    fill!(sp.v, zero(NumType))
+    #fill!(sp.v, zero(NumType))
+    sp.v[1] = 0
     fill!(sp.d, zero(NumType))
     if clear_hessian
       fill!(sp.h, zero(NumType))
@@ -258,6 +259,7 @@ function add_sources_sf!{ParamType <: CelesteTypes.ParamSet, NumType <: Number}(
         s_all_ind2 = P * (s - 1) + s_ind2
         sf_all.h[s_all_ind2, s_all_ind1] =
           sf_all.h[s_all_ind2, s_all_ind1] + sf_s.h[s_ind2, s_ind1]
+        # TODO: move outside the loop?
         sf_all.h[s_all_ind1, s_all_ind2] = sf_all.h[s_all_ind2, s_all_ind1]
       end
     end

--- a/src/SensitiveFloat.jl
+++ b/src/SensitiveFloat.jl
@@ -40,6 +40,8 @@ function set_hess!{ParamType <: CelesteTypes.ParamSet, NumType <: Number}(
   i != j ?
     sf.h[i, j] = sf.h[j, i] = v:
     sf.h[i, j] = v
+
+    true # Set definite return type
 end
 
 function zero_sensitive_float{ParamType <: CelesteTypes.ParamSet}(
@@ -49,15 +51,29 @@ function zero_sensitive_float{ParamType <: CelesteTypes.ParamSet}(
     v = zeros(NumType, 1)
     d = zeros(NumType, local_P, local_S)
     h = zeros(NumType, local_P * local_S, local_P * local_S)
-    SensitiveFloat{ParamType, NumType}(
-      v, d, h, getids(ParamType))
+    SensitiveFloat{ParamType, NumType}(v, d, h, getids(ParamType))
 end
+
 
 function zero_sensitive_float{ParamType <: CelesteTypes.ParamSet}(
   ::Type{ParamType}, NumType::DataType)
     # Default to a single source.
     zero_sensitive_float(ParamType, NumType, 1)
 end
+
+
+# If no type is specified, default to using Float64.
+function zero_sensitive_float{ParamType <: CelesteTypes.ParamSet}(
+  param_arg::Type{ParamType}, local_S::Int64)
+    zero_sensitive_float(param_arg, Float64, local_S)
+end
+
+
+function zero_sensitive_float{ParamType <: CelesteTypes.ParamSet}(
+  param_arg::Type{ParamType})
+    zero_sensitive_float(param_arg, Float64, 1)
+end
+
 
 function clear!{ParamType <: CelesteTypes.ParamSet, NumType <: Number}(
   sp::SensitiveFloat{ParamType, NumType}; clear_hessian::Bool=true)
@@ -67,17 +83,8 @@ function clear!{ParamType <: CelesteTypes.ParamSet, NumType <: Number}(
     if clear_hessian
       fill!(sp.h, zero(NumType))
     end
-end
 
-# If no type is specified, default to using Float64.
-function zero_sensitive_float{ParamType <: CelesteTypes.ParamSet}(
-  param_arg::Type{ParamType}, local_S::Int64)
-    zero_sensitive_float(param_arg, Float64, local_S)
-end
-
-function zero_sensitive_float{ParamType <: CelesteTypes.ParamSet}(
-  param_arg::Type{ParamType})
-    zero_sensitive_float(param_arg, Float64, 1)
+    true # Set definite return type
 end
 
 
@@ -107,6 +114,8 @@ function combine_sfs_hessian!{ParamType <: CelesteTypes.ParamSet,
       sf_result.h[ind2, ind1] = sf_result.h[ind1, ind2]
     end
   end
+
+  true # Set definite return type
 end
 
 
@@ -144,6 +153,8 @@ function combine_sfs!{ParamType <: CelesteTypes.ParamSet,
   end
 
   sf_result.v[1] = v
+
+  true # Set definite return type
 end
 
 
@@ -163,6 +174,8 @@ function combine_sfs!{ParamType <: CelesteTypes.ParamSet,
     calculate_hessian::Bool=true)
 
   combine_sfs!(sf1, sf2, sf1, v, g_d, g_h, calculate_hessian=calculate_hessian)
+
+  true # Set definite return type
 end
 
 # Decalare outside to avoid allocating memory.
@@ -183,6 +196,8 @@ function multiply_sfs!{ParamType <: CelesteTypes.ParamSet, NumType <: Number}(
   #const g_h = NumType[0 1; 1 0]
 
   combine_sfs!(sf1, sf2, v, g_d, multiply_sfs_hess, calculate_hessian=calculate_hessian)
+
+  true # Set definite return type
 end
 
 
@@ -208,6 +223,8 @@ function add_scaled_sfs!{ParamType <: CelesteTypes.ParamSet, NumType <: Number}(
       sf1.h[ind2, ind1] = sf1.h[ind1, ind2]
     end
   end
+
+  true # Set definite return type
 end
 
 
@@ -245,4 +262,6 @@ function add_sources_sf!{ParamType <: CelesteTypes.ParamSet, NumType <: Number}(
       end
     end
   end
+
+  true # Set definite return type
 end

--- a/src/SensitiveFloat.jl
+++ b/src/SensitiveFloat.jl
@@ -179,7 +179,7 @@ function multiply_sfs!{ParamType <: CelesteTypes.ParamSet, NumType <: Number}(
     calculate_hessian::Bool=true)
 
   v = sf1.v[1] * sf2.v[1]
-  g_d = NumType[sf2.v, sf1.v]
+  g_d = NumType[sf2.v[1], sf1.v[1]]
   #const g_h = NumType[0 1; 1 0]
 
   combine_sfs!(sf1, sf2, v, g_d, multiply_sfs_hess, calculate_hessian=calculate_hessian)

--- a/src/SensitiveFloat.jl
+++ b/src/SensitiveFloat.jl
@@ -76,10 +76,16 @@ end
 
 
 function clear!{ParamType <: CelesteTypes.ParamSet, NumType <: Number}(
-  sp::SensitiveFloat{ParamType, NumType}; clear_hessian::Bool=true)
+  sp::SensitiveFloat{ParamType, NumType})
 
-    #fill!(sp.v, zero(NumType))
-    sp.v[1] = 0
+  clear!(sp, true)
+end
+
+
+function clear!{ParamType <: CelesteTypes.ParamSet, NumType <: Number}(
+  sp::SensitiveFloat{ParamType, NumType}, clear_hessian::Bool)
+
+    fill!(sp.v, zero(NumType))
     fill!(sp.d, zero(NumType))
     if clear_hessian
       fill!(sp.h, zero(NumType))
@@ -207,8 +213,8 @@ Update sf1 in place with (sf1 + scale * sf2).
 """ ->
 function add_scaled_sfs!{ParamType <: CelesteTypes.ParamSet, NumType <: Number}(
     sf1::SensitiveFloat{ParamType, NumType},
-    sf2::SensitiveFloat{ParamType, NumType};
-    scale::Float64=1.0, calculate_hessian::Bool=true)
+    sf2::SensitiveFloat{ParamType, NumType},
+    scale::Float64, calculate_hessian::Bool)
 
   sf1.v[1] = sf1.v[1] + scale * sf2.v[1]
 
@@ -236,7 +242,7 @@ sensitive to source s.
 function add_sources_sf!{ParamType <: CelesteTypes.ParamSet, NumType <: Number}(
     sf_all::SensitiveFloat{ParamType, NumType},
     sf_s::SensitiveFloat{ParamType, NumType},
-    s::Int64; calculate_hessian::Bool=true)
+    s::Int64, calculate_hessian::Bool)
 
   # TODO: This line, too, allocates a lot of memory.  Why?
   sf_all.v[1] = sf_all.v[1] + sf_s.v[1]

--- a/src/SkyImages.jl
+++ b/src/SkyImages.jl
@@ -79,6 +79,7 @@ function load_raw_field(field_dir, run_num, camcol_num, field_num, b, gain)
     b_letter = band_letters[b]
 
     fname = "$field_dir/frame-$b_letter-$run_num-$camcol_num-$field_num.fits"
+    @assert(isfile(fname), "Cannot find $(fname)")
     f = FITSIO.FITS(fname)
 
     # This is the sky-subtracted and calibrated image.
@@ -365,6 +366,7 @@ function load_sdss_blob(field_dir, run_num, camcol_num, field_num;
 
     # Read gain for each band from "photoField" file.
     pf_fname = "$field_dir/photoField-$run_num-$camcol_num.fits"
+    @assert(isfile(pf_fname), "Cannot find $(pf_fname)")
     gains = load_sdss_field_gains(pf_fname, parse(Int, field_num))
 
     blob = Array(Image, 5)
@@ -374,10 +376,10 @@ function load_sdss_blob(field_dir, run_num, camcol_num, field_num;
             load_raw_field(field_dir, run_num, camcol_num,
                            field_num, b, gains[b])
 
-
         letter = band_letters[b]
         mask_fname = joinpath(field_dir,
                               "fpM-$run_num-$letter$camcol_num-$field_num.fit")
+        @assert(isfile(mask_fname), "Cannot find mask file $(mask_fname)")
 
         print("masking image... ")
         mask_xranges, mask_yranges = load_sdss_mask(mask_fname, mask_planes)
@@ -408,6 +410,7 @@ function load_sdss_blob(field_dir, run_num, camcol_num, field_num;
         # Load and fit the psf.
         print("reading psf... ")
         psf_fname = "$field_dir/psField-$run_num-$camcol_num-$field_num.fit"
+        @assert(isfile(psf_fname), "Cannot find mask file $(psf_fname)")
         raw_psf_comp = load_sdss_psf(psf_fname, b)
         println("done.")
 

--- a/src/SourceBrightness.jl
+++ b/src/SourceBrightness.jl
@@ -48,23 +48,23 @@ SourceBrightness{NumType <: Number}(
           E_l_a[b, i] = zero_sensitive_float(BrightnessParams, NumType)
       end
 
-      E_l_a[3, i].v = exp(r1[i] + 0.5 * r2[i])
-      E_l_a[4, i].v = exp(c1[3, i] + .5 * c2[3, i])
-      E_l_a[5, i].v = exp(c1[4, i] + .5 * c2[4, i])
-      E_l_a[2, i].v = exp(-c1[2, i] + .5 * c2[2, i])
-      E_l_a[1, i].v = exp(-c1[1, i] + .5 * c2[1, i])
+      E_l_a[3, i].v[1] = exp(r1[i] + 0.5 * r2[i])
+      E_l_a[4, i].v[1] = exp(c1[3, i] + .5 * c2[3, i])
+      E_l_a[5, i].v[1] = exp(c1[4, i] + .5 * c2[4, i])
+      E_l_a[2, i].v[1] = exp(-c1[2, i] + .5 * c2[2, i])
+      E_l_a[1, i].v[1] = exp(-c1[1, i] + .5 * c2[1, i])
 
       if calculate_derivs
         # band 3 is the reference band, relative to which the colors are
         # specified.
         # It is denoted r_s and has a lognormal expectation.
         E_l_a[3, i].d[bids.r1] = E_l_a[3, i].v
-        E_l_a[3, i].d[bids.r2] = E_l_a[3, i].v * .5
+        E_l_a[3, i].d[bids.r2] = E_l_a[3, i].v[1] * .5
 
         if calculate_hessian
           set_hess!(E_l_a[3, i], bids.r1, bids.r1, E_l_a[3, i].v)
-          set_hess!(E_l_a[3, i], bids.r1, bids.r2, E_l_a[3, i].v * 0.5)
-          set_hess!(E_l_a[3, i], bids.r2, bids.r2, E_l_a[3, i].v * 0.25)
+          set_hess!(E_l_a[3, i], bids.r1, bids.r2, E_l_a[3, i].v[1] * 0.5)
+          set_hess!(E_l_a[3, i], bids.r2, bids.r2, E_l_a[3, i].v[1] * 0.25)
         end
 
         # The remaining indices involve c_s and have lognormal
@@ -72,11 +72,11 @@ SourceBrightness{NumType <: Number}(
 
         # band 4 = band 3 * color 3.
         E_l_a[4, i].d[bids.c1[3]] = E_l_a[4, i].v
-        E_l_a[4, i].d[bids.c2[3]] = E_l_a[4, i].v * .5
+        E_l_a[4, i].d[bids.c2[3]] = E_l_a[4, i].v[1] * .5
         if calculate_hessian
           set_hess!(E_l_a[4, i], bids.c1[3], bids.c1[3], E_l_a[4, i].v)
-          set_hess!(E_l_a[4, i], bids.c1[3], bids.c2[3], E_l_a[4, i].v * 0.5)
-          set_hess!(E_l_a[4, i], bids.c2[3], bids.c2[3], E_l_a[4, i].v * 0.25)
+          set_hess!(E_l_a[4, i], bids.c1[3], bids.c2[3], E_l_a[4, i].v[1] * 0.5)
+          set_hess!(E_l_a[4, i], bids.c2[3], bids.c2[3], E_l_a[4, i].v[1] * 0.25)
         end
         multiply_sfs!(
           E_l_a[4, i], E_l_a[3, i], ids1=ids_color_3, ids2=ids_band_3,
@@ -84,45 +84,45 @@ SourceBrightness{NumType <: Number}(
 
         # Band 5 = band 4 * color 4.
         E_l_a[5, i].d[bids.c1[4]] = E_l_a[5, i].v
-        E_l_a[5, i].d[bids.c2[4]] = E_l_a[5, i].v * .5
+        E_l_a[5, i].d[bids.c2[4]] = E_l_a[5, i].v[1] * .5
         if calculate_hessian
           set_hess!(E_l_a[5, i], bids.c1[4], bids.c1[4], E_l_a[5, i].v)
-          set_hess!(E_l_a[5, i], bids.c1[4], bids.c2[4], E_l_a[5, i].v * 0.5)
-          set_hess!(E_l_a[5, i], bids.c2[4], bids.c2[4], E_l_a[5, i].v * 0.25)
+          set_hess!(E_l_a[5, i], bids.c1[4], bids.c2[4], E_l_a[5, i].v[1] * 0.5)
+          set_hess!(E_l_a[5, i], bids.c2[4], bids.c2[4], E_l_a[5, i].v[1] * 0.25)
         end
         multiply_sfs!(E_l_a[5, i], E_l_a[4, i],
                       ids1=ids_color_4, ids2=union(ids_band_3, ids_color_3),
                       calculate_hessian=calculate_hessian)
 
         # Band 2 = band 3 * color 2.
-        E_l_a[2, i].d[bids.c1[2]] = E_l_a[2, i].v * -1.
-        E_l_a[2, i].d[bids.c2[2]] = E_l_a[2, i].v * .5
+        E_l_a[2, i].d[bids.c1[2]] = E_l_a[2, i].v[1] * -1.
+        E_l_a[2, i].d[bids.c2[2]] = E_l_a[2, i].v[1] * .5
         if calculate_hessian
           set_hess!(E_l_a[2, i], bids.c1[2], bids.c1[2], E_l_a[2, i].v)
-          set_hess!(E_l_a[2, i], bids.c1[2], bids.c2[2], E_l_a[2, i].v * -0.5)
-          set_hess!(E_l_a[2, i], bids.c2[2], bids.c2[2], E_l_a[2, i].v * 0.25)
+          set_hess!(E_l_a[2, i], bids.c1[2], bids.c2[2], E_l_a[2, i].v[1] * -0.5)
+          set_hess!(E_l_a[2, i], bids.c2[2], bids.c2[2], E_l_a[2, i].v[1] * 0.25)
         end
         multiply_sfs!(
           E_l_a[2, i], E_l_a[3, i], ids1=ids_color_2, ids2=ids_band_3,
           calculate_hessian=calculate_hessian)
 
         # Band 1 = band 2 * color 1.
-        E_l_a[1, i].d[bids.c1[1]] = E_l_a[1, i].v * -1.
-        E_l_a[1, i].d[bids.c2[1]] = E_l_a[1, i].v * .5
+        E_l_a[1, i].d[bids.c1[1]] = E_l_a[1, i].v[1] * -1.
+        E_l_a[1, i].d[bids.c2[1]] = E_l_a[1, i].v[1] * .5
         if calculate_hessian
           set_hess!(E_l_a[1, i], bids.c1[1], bids.c1[1], E_l_a[1, i].v)
-          set_hess!(E_l_a[1, i], bids.c1[1], bids.c2[1], E_l_a[1, i].v * -0.5)
-          set_hess!(E_l_a[1, i], bids.c2[1], bids.c2[1], E_l_a[1, i].v * 0.25)
+          set_hess!(E_l_a[1, i], bids.c1[1], bids.c2[1], E_l_a[1, i].v[1] * -0.5)
+          set_hess!(E_l_a[1, i], bids.c2[1], bids.c2[1], E_l_a[1, i].v[1] * 0.25)
         end
         multiply_sfs!(E_l_a[1, i], E_l_a[2, i],
                       ids1=ids_color_1, ids2=union(ids_band_3, ids_color_2),
                       calculate_hessian=calculate_hessian)
       else
         # Simply update the values if not calculating derivatives.
-        E_l_a[4, i].v *= E_l_a[3, i].v
-        E_l_a[5, i].v *= E_l_a[4, i].v
-        E_l_a[2, i].v *= E_l_a[3, i].v
-        E_l_a[1, i].v *= E_l_a[2, i].v
+        E_l_a[4, i].v[1] *= E_l_a[3, i].v
+        E_l_a[5, i].v[1] *= E_l_a[4, i].v
+        E_l_a[2, i].v[1] *= E_l_a[3, i].v
+        E_l_a[1, i].v[1] *= E_l_a[2, i].v
       end # Derivs
 
       ################################
@@ -132,11 +132,11 @@ SourceBrightness{NumType <: Number}(
           E_ll_a[b, i] = zero_sensitive_float(BrightnessParams, NumType)
       end
 
-      E_ll_a[3, i].v = exp(2 * r1[i] + 2 * r2[i])
-      E_ll_a[4, i].v = exp(2 * c1[3, i] + 2 * c2[3, i])
-      E_ll_a[5, i].v = exp(2 * c1[4, i] + 2 * c2[4, i])
-      E_ll_a[2, i].v = exp(-2 * c1[2, i] + 2 * c2[2, i])
-      E_ll_a[1, i].v = exp(-2 * c1[1, i] + 2 * c2[1, i])
+      E_ll_a[3, i].v[1] = exp(2 * r1[i] + 2 * r2[i])
+      E_ll_a[4, i].v[1] = exp(2 * c1[3, i] + 2 * c2[3, i])
+      E_ll_a[5, i].v[1] = exp(2 * c1[4, i] + 2 * c2[4, i])
+      E_ll_a[2, i].v[1] = exp(-2 * c1[2, i] + 2 * c2[2, i])
+      E_ll_a[1, i].v[1] = exp(-2 * c1[1, i] + 2 * c2[1, i])
 
       if calculate_derivs
         # Band 3, the reference band.
@@ -151,13 +151,13 @@ SourceBrightness{NumType <: Number}(
         end
 
         # Band 4 = band 3 * color 3.
-        E_ll_a[4, i].d[bids.c1[3]] = E_ll_a[4, i].v * 2.
-        E_ll_a[4, i].d[bids.c2[3]] = E_ll_a[4, i].v * 2.
+        E_ll_a[4, i].d[bids.c1[3]] = E_ll_a[4, i].v[1] * 2.
+        E_ll_a[4, i].d[bids.c2[3]] = E_ll_a[4, i].v[1] * 2.
         if calculate_hessian
           for hess_ids in [(bids.c1[3], bids.c1[3]),
                            (bids.c1[3], bids.c2[3]),
                            (bids.c2[3], bids.c2[3])]
-            set_hess!(E_ll_a[4, i], hess_ids..., E_ll_a[4, i].v * 4.0)
+            set_hess!(E_ll_a[4, i], hess_ids..., E_ll_a[4, i].v[1] * 4.0)
           end
         end
         multiply_sfs!(E_ll_a[4, i], E_ll_a[3, i],
@@ -166,13 +166,13 @@ SourceBrightness{NumType <: Number}(
 
         # Band 5 = band 4 * color 4.
         tmp4 = exp(2 * c1[4, i] + 2 * c2[4, i])
-        E_ll_a[5, i].d[bids.c1[4]] = E_ll_a[5, i].v * 2.
-        E_ll_a[5, i].d[bids.c2[4]] = E_ll_a[5, i].v * 2.
+        E_ll_a[5, i].d[bids.c1[4]] = E_ll_a[5, i].v[1] * 2.
+        E_ll_a[5, i].d[bids.c2[4]] = E_ll_a[5, i].v[1] * 2.
         if calculate_hessian
           for hess_ids in [(bids.c1[4], bids.c1[4]),
                            (bids.c1[4], bids.c2[4]),
                            (bids.c2[4], bids.c2[4])]
-            set_hess!(E_ll_a[5, i], hess_ids..., E_ll_a[5, i].v * 4.0)
+            set_hess!(E_ll_a[5, i], hess_ids..., E_ll_a[5, i].v[1] * 4.0)
           end
         end
         multiply_sfs!(E_ll_a[5, i], E_ll_a[4, i],
@@ -181,40 +181,40 @@ SourceBrightness{NumType <: Number}(
 
         # Band 2 = band 3 * color 2
         tmp2 = exp(-2 * c1[2, i] + 2 * c2[2, i])
-        E_ll_a[2, i].d[bids.c1[2]] = E_ll_a[2, i].v * -2.
-        E_ll_a[2, i].d[bids.c2[2]] = E_ll_a[2, i].v * 2.
+        E_ll_a[2, i].d[bids.c1[2]] = E_ll_a[2, i].v[1] * -2.
+        E_ll_a[2, i].d[bids.c2[2]] = E_ll_a[2, i].v[1] * 2.
         if calculate_hessian
           for hess_ids in [(bids.c1[2], bids.c1[2]),
                            (bids.c2[2], bids.c2[2])]
-            set_hess!(E_ll_a[2, i], hess_ids..., E_ll_a[2, i].v * 4.0)
+            set_hess!(E_ll_a[2, i], hess_ids..., E_ll_a[2, i].v[1] * 4.0)
           end
           set_hess!(E_ll_a[2, i], bids.c1[2], bids.c2[2],
-                    E_ll_a[2, i].v * -4.0)
+                    E_ll_a[2, i].v[1] * -4.0)
         end
         multiply_sfs!(E_ll_a[2, i], E_ll_a[3, i],
                       ids1=ids_color_2, ids2=ids_band_3,
                       calculate_hessian=calculate_hessian)
 
         # Band 1 = band 2 * color 1
-        E_ll_a[1, i].d[bids.c1[1]] = E_ll_a[1, i].v * -2.
-        E_ll_a[1, i].d[bids.c2[1]] = E_ll_a[1, i].v * 2.
+        E_ll_a[1, i].d[bids.c1[1]] = E_ll_a[1, i].v[1] * -2.
+        E_ll_a[1, i].d[bids.c2[1]] = E_ll_a[1, i].v[1] * 2.
         if calculate_hessian
           for hess_ids in [(bids.c1[1], bids.c1[1]),
                            (bids.c2[1], bids.c2[1])]
-            set_hess!(E_ll_a[1, i], hess_ids..., E_ll_a[1, i].v * 4.0)
+            set_hess!(E_ll_a[1, i], hess_ids..., E_ll_a[1, i].v[1] * 4.0)
           end
           set_hess!(E_ll_a[1, i], bids.c1[1], bids.c2[1],
-                    E_ll_a[1, i].v * -4.0)
+                    E_ll_a[1, i].v[1] * -4.0)
         end
         multiply_sfs!(E_ll_a[1, i], E_ll_a[2, i],
                       ids1=ids_color_1, ids2=union(ids_band_3, ids_color_2),
                       calculate_hessian=calculate_hessian)
       else
         # Simply update the values if not calculating derivatives.
-        E_ll_a[4, i].v *= E_ll_a[3, i].v
-        E_ll_a[5, i].v *= E_ll_a[4, i].v
-        E_ll_a[2, i].v *= E_ll_a[3, i].v
-        E_ll_a[1, i].v *= E_ll_a[2, i].v
+        E_ll_a[4, i].v[1] *= E_ll_a[3, i].v
+        E_ll_a[5, i].v[1] *= E_ll_a[4, i].v
+        E_ll_a[2, i].v[1] *= E_ll_a[3, i].v
+        E_ll_a[1, i].v[1] *= E_ll_a[2, i].v
       end # calculate_derivs
   end
 
@@ -234,9 +234,9 @@ Returns:
 """ ->
 function get_brightness{NumType <: Number}(mp::ModelParams{NumType})
     brightness = [SourceBrightness(mp.vp[s]) for s in mp.S];
-    brightness_vals = [ Float64[b.E_l_a[i, j].v for
+    brightness_vals = [ Float64[b.E_l_a[i, j].v[1] for
         i=1:size(b.E_l_a, 1), j=1:size(b.E_l_a, 2)] for b in brightness]
-    brightness_squares = [ Float64[b.E_l_a[i, j].v for
+    brightness_squares = [ Float64[b.E_l_a[i, j].v[1] for
         i=1:size(b.E_ll_a, 1), j=1:size(b.E_ll_a, 2)] for b in brightness]
 
     brightness_vals, brightness_squares

--- a/src/SourceBrightness.jl
+++ b/src/SourceBrightness.jl
@@ -58,11 +58,11 @@ SourceBrightness{NumType <: Number}(
         # band 3 is the reference band, relative to which the colors are
         # specified.
         # It is denoted r_s and has a lognormal expectation.
-        E_l_a[3, i].d[bids.r1] = E_l_a[3, i].v
+        E_l_a[3, i].d[bids.r1] = E_l_a[3, i].v[1]
         E_l_a[3, i].d[bids.r2] = E_l_a[3, i].v[1] * .5
 
         if calculate_hessian
-          set_hess!(E_l_a[3, i], bids.r1, bids.r1, E_l_a[3, i].v)
+          set_hess!(E_l_a[3, i], bids.r1, bids.r1, E_l_a[3, i].v[1])
           set_hess!(E_l_a[3, i], bids.r1, bids.r2, E_l_a[3, i].v[1] * 0.5)
           set_hess!(E_l_a[3, i], bids.r2, bids.r2, E_l_a[3, i].v[1] * 0.25)
         end
@@ -71,10 +71,10 @@ SourceBrightness{NumType <: Number}(
         # expectations times E_c_3.
 
         # band 4 = band 3 * color 3.
-        E_l_a[4, i].d[bids.c1[3]] = E_l_a[4, i].v
+        E_l_a[4, i].d[bids.c1[3]] = E_l_a[4, i].v[1]
         E_l_a[4, i].d[bids.c2[3]] = E_l_a[4, i].v[1] * .5
         if calculate_hessian
-          set_hess!(E_l_a[4, i], bids.c1[3], bids.c1[3], E_l_a[4, i].v)
+          set_hess!(E_l_a[4, i], bids.c1[3], bids.c1[3], E_l_a[4, i].v[1])
           set_hess!(E_l_a[4, i], bids.c1[3], bids.c2[3], E_l_a[4, i].v[1] * 0.5)
           set_hess!(E_l_a[4, i], bids.c2[3], bids.c2[3], E_l_a[4, i].v[1] * 0.25)
         end
@@ -83,10 +83,10 @@ SourceBrightness{NumType <: Number}(
           calculate_hessian=calculate_hessian)
 
         # Band 5 = band 4 * color 4.
-        E_l_a[5, i].d[bids.c1[4]] = E_l_a[5, i].v
+        E_l_a[5, i].d[bids.c1[4]] = E_l_a[5, i].v[1]
         E_l_a[5, i].d[bids.c2[4]] = E_l_a[5, i].v[1] * .5
         if calculate_hessian
-          set_hess!(E_l_a[5, i], bids.c1[4], bids.c1[4], E_l_a[5, i].v)
+          set_hess!(E_l_a[5, i], bids.c1[4], bids.c1[4], E_l_a[5, i].v[1])
           set_hess!(E_l_a[5, i], bids.c1[4], bids.c2[4], E_l_a[5, i].v[1] * 0.5)
           set_hess!(E_l_a[5, i], bids.c2[4], bids.c2[4], E_l_a[5, i].v[1] * 0.25)
         end
@@ -98,7 +98,7 @@ SourceBrightness{NumType <: Number}(
         E_l_a[2, i].d[bids.c1[2]] = E_l_a[2, i].v[1] * -1.
         E_l_a[2, i].d[bids.c2[2]] = E_l_a[2, i].v[1] * .5
         if calculate_hessian
-          set_hess!(E_l_a[2, i], bids.c1[2], bids.c1[2], E_l_a[2, i].v)
+          set_hess!(E_l_a[2, i], bids.c1[2], bids.c1[2], E_l_a[2, i].v[1])
           set_hess!(E_l_a[2, i], bids.c1[2], bids.c2[2], E_l_a[2, i].v[1] * -0.5)
           set_hess!(E_l_a[2, i], bids.c2[2], bids.c2[2], E_l_a[2, i].v[1] * 0.25)
         end
@@ -110,7 +110,7 @@ SourceBrightness{NumType <: Number}(
         E_l_a[1, i].d[bids.c1[1]] = E_l_a[1, i].v[1] * -1.
         E_l_a[1, i].d[bids.c2[1]] = E_l_a[1, i].v[1] * .5
         if calculate_hessian
-          set_hess!(E_l_a[1, i], bids.c1[1], bids.c1[1], E_l_a[1, i].v)
+          set_hess!(E_l_a[1, i], bids.c1[1], bids.c1[1], E_l_a[1, i].v[1])
           set_hess!(E_l_a[1, i], bids.c1[1], bids.c2[1], E_l_a[1, i].v[1] * -0.5)
           set_hess!(E_l_a[1, i], bids.c2[1], bids.c2[1], E_l_a[1, i].v[1] * 0.25)
         end
@@ -119,10 +119,10 @@ SourceBrightness{NumType <: Number}(
                       calculate_hessian=calculate_hessian)
       else
         # Simply update the values if not calculating derivatives.
-        E_l_a[4, i].v[1] *= E_l_a[3, i].v
-        E_l_a[5, i].v[1] *= E_l_a[4, i].v
-        E_l_a[2, i].v[1] *= E_l_a[3, i].v
-        E_l_a[1, i].v[1] *= E_l_a[2, i].v
+        E_l_a[4, i].v[1] *= E_l_a[3, i].v[1]
+        E_l_a[5, i].v[1] *= E_l_a[4, i].v[1]
+        E_l_a[2, i].v[1] *= E_l_a[3, i].v[1]
+        E_l_a[1, i].v[1] *= E_l_a[2, i].v[1]
       end # Derivs
 
       ################################
@@ -140,13 +140,13 @@ SourceBrightness{NumType <: Number}(
 
       if calculate_derivs
         # Band 3, the reference band.
-        E_ll_a[3, i].d[bids.r1] = 2 * E_ll_a[3, i].v
-        E_ll_a[3, i].d[bids.r2] = 2 * E_ll_a[3, i].v
+        E_ll_a[3, i].d[bids.r1] = 2 * E_ll_a[3, i].v[1]
+        E_ll_a[3, i].d[bids.r2] = 2 * E_ll_a[3, i].v[1]
         if calculate_hessian
           for hess_ids in [(bids.r1, bids.r1),
                            (bids.r1, bids.r2),
                            (bids.r2, bids.r2)]
-            set_hess!(E_ll_a[3, i], hess_ids..., 4.0 * E_ll_a[3, i].v)
+            set_hess!(E_ll_a[3, i], hess_ids..., 4.0 * E_ll_a[3, i].v[1])
           end
         end
 
@@ -211,10 +211,10 @@ SourceBrightness{NumType <: Number}(
                       calculate_hessian=calculate_hessian)
       else
         # Simply update the values if not calculating derivatives.
-        E_ll_a[4, i].v[1] *= E_ll_a[3, i].v
-        E_ll_a[5, i].v[1] *= E_ll_a[4, i].v
-        E_ll_a[2, i].v[1] *= E_ll_a[3, i].v
-        E_ll_a[1, i].v[1] *= E_ll_a[2, i].v
+        E_ll_a[4, i].v[1] *= E_ll_a[3, i].v[1]
+        E_ll_a[5, i].v[1] *= E_ll_a[4, i].v[1]
+        E_ll_a[2, i].v[1] *= E_ll_a[3, i].v[1]
+        E_ll_a[1, i].v[1] *= E_ll_a[2, i].v[1]
       end # calculate_derivs
   end
 

--- a/src/Transform.jl
+++ b/src/Transform.jl
@@ -741,7 +741,7 @@ DataTransform(
   		zero_sensitive_float(UnconstrainedParams, NumType, active_S);
 
   	sf_d_vec = sf.d[:];
-  	sf_free.v[1] = sf.v
+  	sf_free.v[1] = sf.v[1]
   	sf_free.d =
       reshape(transform_derivatives.dparam_dfree' * sf_d_vec,
               length(UnconstrainedParams), active_S);

--- a/src/Transform.jl
+++ b/src/Transform.jl
@@ -741,7 +741,7 @@ DataTransform(
   		zero_sensitive_float(UnconstrainedParams, NumType, active_S);
 
   	sf_d_vec = sf.d[:];
-  	sf_free.v = sf.v
+  	sf_free.v[1] = sf.v
   	sf_free.d =
       reshape(transform_derivatives.dparam_dfree' * sf_d_vec,
               length(UnconstrainedParams), active_S);

--- a/test/compare_celeste_versions.jl
+++ b/test/compare_celeste_versions.jl
@@ -1,0 +1,633 @@
+# Compare the new Celeste version to an old version in another repo.
+
+# To track memory, use:
+# julia --track-allocation=user
+
+#include("test/debug_with_master.jl");
+#using Debug
+
+# blob, mp, bodies, tiled_blob = Debug.SampleData.gen_two_body_dataset();
+# @time debug_elbo = Debug.ElboDeriv.elbo(tiled_blob, mp);
+
+using Celeste
+using CelesteTypes
+using Base.Test
+using SampleData
+import Synthetic
+
+profile_n = 0
+
+blob, mp, bodies, tiled_blob = gen_two_body_dataset();
+mp.active_sources = [2];
+@time elbo = ElboDeriv.elbo(tiled_blob, mp);
+elbo.v
+size(elbo.d)
+
+mp.active_sources = [1, 2];
+@time elbo = ElboDeriv.elbo(tiled_blob, mp);
+elbo.v
+size(elbo.d)
+
+
+
+println(elbo.d[1, 1])
+@test_approx_eq elbo.v debug_elbo.v
+@test_approx_eq elbo.d debug_elbo.d
+
+
+
+
+##########
+@time ElboDeriv.elbo_likelihood(tiled_blob, mp, calculate_derivs=false);
+@time ElboDeriv.elbo_likelihood(tiled_blob, mp, calculate_hessian=false);
+@time ElboDeriv.elbo_likelihood(tiled_blob, mp);
+
+Profile.clear_malloc_data()
+Profile.clear()
+@profile for i = 1:profile_n
+  println(".")
+  ElboDeriv.elbo_likelihood(tiled_blob, mp, calculate_hessian=true);
+  #Debug.ElboDeriv.elbo_likelihood(tiled_blob, mp);
+end
+#Profile.print()
+
+# To see memory, quit and run
+using Coverage
+res = analyze_malloc("src");
+pn = 40; [ println(res[end - (pn - i)]) for i=1:pn ];
+
+
+
+# Checking if the ELBO is different between the two versions.
+#include("src/ElboDeriv.jl")
+
+
+blob, mp, bodies, tiled_blob = Debug.SampleData.gen_two_body_dataset();
+@time debug_elbo = Debug.ElboDeriv.elbo(tiled_blob, mp);
+
+
+@time Debug.ElboDeriv.elbo(tiled_blob, mp);
+#@time ElboDeriv.elbo_likelihood(tiled_blob, mp);
+@time ElboDeriv.elbo(tiled_blob, mp, calculate_derivs=false);
+@time ElboDeriv.elbo(tiled_blob, mp, calculate_hessian=false);
+@time ElboDeriv.elbo(tiled_blob, mp);
+
+Profile.clear_malloc_data()
+Profile.clear()
+@profile for i = 1:profile_n
+  #ElboDeriv.elbo_likelihood(tiled_blob, mp, calculate_hessian=false);
+  Debug.ElboDeriv.elbo_likelihood(tiled_blob, mp);
+end
+#Profile.print(format=:tree, sortedby = :count)
+
+# To see memory, quit and run
+using Coverage
+res = analyze_malloc("src")
+#res = analyze_malloc("/home/rgiordan/Documents/git_repos/debugging_branch_Celeste.jl/CelesteDebug.jl/src");
+pn = 40; [ println(res[end - (pn - i)]) for i=1:pn ];
+
+
+
+
+
+function evaluate_their_elbo()
+  blob, mp, bodies, tiled_blob = Debug.SampleData.gen_two_body_dataset();
+  Debug.ElboDeriv.elbo(tiled_blob, mp)
+end
+
+function evaluate_our_elbo()
+  blob, mp, bodies, tiled_blob = gen_two_body_dataset();
+  ElboDeriv.elbo(tiled_blob, mp)
+end
+
+their_elbo = evaluate_their_elbo();
+our_elbo = evaluate_our_elbo();
+
+@test_approx_eq our_elbo.v their_elbo.v
+
+
+
+# Deeper checks:
+# fsXm looks good.
+b = 1
+x = [10., 9.]
+wcs_jacobian = eye(Float64, 2);
+
+function get_their_fs0m()
+  blob, mp, bodies, tiled_blob = Debug.SampleData.gen_two_body_dataset();
+
+  star_mcs, gal_mcs = Debug.ElboDeriv.load_bvn_mixtures(mp, b);
+  fs0m = zero_sensitive_float(StarPosParams, Float64);
+  Debug.ElboDeriv.accum_star_pos!(star_mcs[1], x, fs0m, wcs_jacobian);
+  fs0m
+end
+
+function get_our_fs0m()
+  blob, mp, bodies, tiled_blob = gen_two_body_dataset();
+
+  s = 1
+  star_mcs, gal_mcs = ElboDeriv.load_bvn_mixtures(mp, b);
+  elbo_vars = ElboDeriv.ElboIntermediateVariables(Float64, 1, 1);
+  ElboDeriv.accum_star_pos!(elbo_vars, s, star_mcs[1], x, wcs_jacobian);
+  elbo_vars.fs0m_vec[s]
+end
+
+@time their_fs0m = get_their_fs0m();
+@time our_fs0m = get_our_fs0m();
+
+@test_approx_eq their_fs0m.v our_fs0m.v
+@test_approx_eq their_fs0m.d our_fs0m.d
+
+
+function get_their_fs1m()
+  blob, mp, bodies, tiled_blob = Debug.SampleData.gen_two_body_dataset();
+
+  star_mcs, gal_mcs = Debug.ElboDeriv.load_bvn_mixtures(mp, b);
+  fs1m = zero_sensitive_float(GalaxyPosParams, Float64);
+  Debug.ElboDeriv.accum_galaxy_pos!(gal_mcs[1], x, fs1m, wcs_jacobian);
+  fs1m
+end
+
+function get_our_fs1m()
+  blob, mp, bodies, tiled_blob = gen_two_body_dataset();
+
+  s = 1
+  star_mcs, gal_mcs = ElboDeriv.load_bvn_mixtures(mp, b);
+  elbo_vars = ElboDeriv.ElboIntermediateVariables(Float64, 1, 1);
+  ElboDeriv.accum_galaxy_pos!(elbo_vars, s, gal_mcs[1], x, wcs_jacobian);
+  elbo_vars.fs1m_vec[s]
+end
+
+@time their_fs1m = get_their_fs1m();
+@time our_fs1m = get_our_fs1m();
+
+@test_approx_eq their_fs1m.v our_fs1m.v
+@test_approx_eq their_fs1m.d our_fs1m.d
+
+
+# Check the brightnesses.  Looks good.
+
+blob, mp, bodies, tiled_blob = gen_two_body_dataset();
+@time their_sbs = [Debug.ElboDeriv.SourceBrightness(mp.vp[s]) for s in 1:mp.S];
+@time our_sbs = ElboDeriv.load_source_brightnesses(mp);
+
+for s=1:length(our_sbs), b=1:5, i=1:2
+  @test_approx_eq our_sbs[s].E_l_a[b, i].v their_sbs[s].E_l_a[b, i].v
+  @test_approx_eq our_sbs[s].E_l_a[b, i].d their_sbs[s].E_l_a[b, i].d
+  @test_approx_eq our_sbs[s].E_ll_a[b, i].v their_sbs[s].E_ll_a[b, i].v
+  @test_approx_eq our_sbs[s].E_ll_a[b, i].d their_sbs[s].E_ll_a[b, i].d
+end
+
+
+##################################
+# Check a pixel accumlation.
+s = 2
+b = 1
+h = 10
+w = 10
+wcs_jacobian = Float64[1 0; 0 1]
+
+function their_accumulate_pixel_stats()
+  blob, mp, bodies, tiled_blob = Debug.SampleData.gen_two_body_dataset();
+  tile = tiled_blob[b][1,1];
+
+  #zsf = Debug.CelesteTypes.zero_sensitive_float;
+  zsf = zero_sensitive_float;
+
+  star_mcs, gal_mcs = Debug.ElboDeriv.load_bvn_mixtures(mp, b);
+  # I don't understand this:
+  # fs0m = zsf(Debug.CelesteTypes.StarPosParams, Float64);
+  # fs1m = zsf(Debug.CelesteTypes.GalaxyPosParams, Float64);
+  # E_G = zsf(Debug.CelesteTypes.CanonicalParams, Float64, mp.S);
+  # var_G = zsf(Debug.CelesteTypes.CanonicalParams, Float64, mp.S);
+  fs0m = zsf(CelesteTypes.StarPosParams, Float64);
+  fs1m = zsf(CelesteTypes.GalaxyPosParams, Float64);
+  E_G = zsf(CelesteTypes.CanonicalParams, Float64, mp.S);
+  var_G = zsf(CelesteTypes.CanonicalParams, Float64, mp.S);
+
+  sbs = [Debug.ElboDeriv.SourceBrightness(mp.vp[s]) for s in 1:mp.S];
+
+  m_pos = Float64[tile.h_range[h], tile.w_range[w]]
+  Debug.ElboDeriv.accum_pixel_source_stats!(
+      sbs[s], star_mcs, gal_mcs,
+      mp.vp[s], s, s, m_pos, b, fs0m, fs1m, E_G, var_G, wcs_jacobian)
+
+  deepcopy(E_G), deepcopy(var_G)
+end
+
+
+function our_accumulate_pixel_stats()
+  blob, mp, bodies, tiled_blob = gen_two_body_dataset();
+  tile = tiled_blob[b][1,1];
+  tile_sources = mp.tile_sources[b][1,1]
+
+  star_mcs, gal_mcs = ElboDeriv.load_bvn_mixtures(mp, b);
+  sbs = ElboDeriv.load_source_brightnesses(mp);
+  elbo_vars = ElboDeriv.ElboIntermediateVariables(Float64, mp.S, mp.S);
+  @time ElboDeriv.populate_fsm_vecs!(
+    elbo_vars, mp, tile_sources, tile, h, w, sbs, gal_mcs, star_mcs);
+  clear!(elbo_vars.E_G);
+  clear!(elbo_vars.var_G);
+
+  ElboDeriv.accumulate_source_brightness!(elbo_vars, mp, sbs, s, b);
+  deepcopy(elbo_vars.E_G), deepcopy(elbo_vars.var_G)
+end
+
+
+
+#@time their_E_G, their_var_G = their_accumulate_pixel_stats();
+@time our_E_G, our_var_G = our_accumulate_pixel_stats();
+
+@test_approx_eq their_E_G.v our_E_G.v
+@test_approx_eq their_E_G.d our_E_G.d
+
+@test_approx_eq their_var_G.v our_E_G2.v - (our_E_G.v ^ 2)
+
+################################
+# It might be in the accumulation of E_G2 across multiple sources.
+
+s = 1
+b = 1
+h = 10
+w = 10
+wcs_jacobian = Float64[1 0; 0 1]
+
+
+function their_expected_pixel_brightness()
+  blob, mp, bodies, tiled_blob = Debug.SampleData.gen_two_body_dataset();
+  tile = tiled_blob[b][1,1];
+
+  zsf = zero_sensitive_float;
+
+  star_mcs, gal_mcs = Debug.ElboDeriv.load_bvn_mixtures(mp, b);
+
+  accum = zsf(CelesteTypes.CanonicalParams, Float64, mp.S);
+  fs0m = zsf(CelesteTypes.StarPosParams, Float64);
+  fs1m = zsf(CelesteTypes.GalaxyPosParams, Float64);
+  E_G = zsf(CelesteTypes.CanonicalParams, Float64, mp.S);
+  var_G = zsf(CelesteTypes.CanonicalParams, Float64, mp.S);
+
+  sbs = Debug.ElboDeriv.SourceBrightness{Float64}[
+    Debug.ElboDeriv.SourceBrightness(mp.vp[s]) for s in 1:mp.S];
+
+  m_pos = Float64[tile.h_range[h], tile.w_range[w]]
+
+  this_pixel = tile.pixels[h, w]
+  iota = Debug.ElboDeriv.expected_pixel_brightness!(
+    h, w, sbs, star_mcs, gal_mcs, tile, E_G, var_G,
+    mp, mp.active_sources, fs0m, fs1m,
+    include_epsilon=true);
+  deepcopy(E_G), deepcopy(var_G)
+end
+
+
+
+function our_expected_pixel_brightness()
+  blob, mp, bodies, tiled_blob = gen_two_body_dataset();
+  tile = tiled_blob[b][1,1];
+  tile_sources = mp.tile_sources[b][1,1];
+
+  star_mcs, gal_mcs = ElboDeriv.load_bvn_mixtures(mp, b);
+  sbs = ElboDeriv.load_source_brightnesses(mp);
+  elbo_vars = ElboDeriv.ElboIntermediateVariables(Float64, mp.S, mp.S);
+  ElboDeriv.populate_fsm_vecs!(
+    elbo_vars, mp, tile_sources, tile, h, w, sbs, gal_mcs, star_mcs);
+
+  this_pixel = tile.pixels[h, w]
+  ElboDeriv.get_expected_pixel_brightness!(
+    elbo_vars, h, w, sbs, star_mcs, gal_mcs, tile,
+    mp, tile_sources, include_epsilon=true)
+
+  deepcopy(elbo_vars.E_G), deepcopy(elbo_vars.var_G)
+end
+
+#their_E_G, their_var_G = their_expected_pixel_brightness();
+@time our_E_G, our_var_G = our_expected_pixel_brightness();
+
+@test_approx_eq their_E_G.v our_E_G.v
+@test_approx_eq their_var_G.v our_var_G.v
+
+
+
+
+
+##################################
+# test accum_pixel_ret!
+
+s = 1
+b = 1
+h = 10
+w = 10
+wcs_jacobian = Float64[1 0; 0 1]
+
+
+function their_accum_pixel_ret()
+  blob, mp, bodies, tiled_blob = Debug.SampleData.gen_two_body_dataset();
+  tile = tiled_blob[b][1,1];
+
+  zsf = zero_sensitive_float;
+
+  star_mcs, gal_mcs = Debug.ElboDeriv.load_bvn_mixtures(mp, b);
+
+  accum = zsf(CelesteTypes.CanonicalParams, Float64, mp.S);
+  fs0m = zsf(CelesteTypes.StarPosParams, Float64);
+  fs1m = zsf(CelesteTypes.GalaxyPosParams, Float64);
+  E_G = zsf(CelesteTypes.CanonicalParams, Float64, mp.S);
+  var_G = zsf(CelesteTypes.CanonicalParams, Float64, mp.S);
+
+  sbs = Debug.ElboDeriv.SourceBrightness{Float64}[
+    Debug.ElboDeriv.SourceBrightness(mp.vp[s]) for s in 1:mp.S];
+
+  m_pos = Float64[tile.h_range[h], tile.w_range[w]]
+
+  this_pixel = tile.pixels[h, w]
+  iota = Debug.ElboDeriv.expected_pixel_brightness!(
+    h, w, sbs, star_mcs, gal_mcs, tile, E_G, var_G,
+    mp, mp.active_sources, fs0m, fs1m,
+    include_epsilon=true);
+
+  Debug.ElboDeriv.accum_pixel_ret!(
+    mp.active_sources, this_pixel, iota, E_G, var_G, accum);
+  deepcopy(accum)
+end
+
+
+
+function our_accum_pixel_ret()
+  blob, mp, bodies, tiled_blob = gen_two_body_dataset();
+  tile = tiled_blob[b][1,1];
+  tile_sources = mp.tile_sources[b][1,1];
+
+  star_mcs, gal_mcs = ElboDeriv.load_bvn_mixtures(mp, b);
+  sbs = ElboDeriv.load_source_brightnesses(mp);
+  elbo_vars = ElboDeriv.ElboIntermediateVariables(Float64, mp.S, mp.S);
+  ElboDeriv.populate_fsm_vecs!(
+    elbo_vars, mp, tile_sources, tile, h, w, sbs, gal_mcs, star_mcs);
+  clear!(elbo_vars.E_G);
+  clear!(elbo_vars.var_G);
+
+  this_pixel = tile.pixels[h, w]
+  ElboDeriv.get_expected_pixel_brightness!(
+    elbo_vars, h, w, sbs, star_mcs, gal_mcs, tile,
+    mp, tile_sources, include_epsilon=true)
+
+
+  println(elbo_vars.elbo.v)
+  iota = tile.constant_background ? tile.iota : tile.iota_vec[h]
+  ElboDeriv.add_elbo_log_term!(elbo_vars, this_pixel, iota)
+  println("Log term: ", elbo_vars.elbo.v)
+  CelesteTypes.add_scaled_sfs!(elbo_vars.elbo, elbo_vars.E_G, scale=-iota)
+  println(elbo_vars.elbo.v)
+
+  deepcopy(elbo_vars.elbo)
+end
+
+#their_accum = their_accum_pixel_ret();
+@time our_accum = our_accum_pixel_ret();
+
+@test_approx_eq their_accum.v our_accum.v
+
+
+############################
+############################
+# Check each step
+
+
+using Celeste
+using CelesteTypes
+using Base.Test
+using SampleData
+import Synthetic
+
+include("src/ElboDeriv.jl")
+
+s = 1
+b = 1
+h = 10
+w = 10
+blob, mp, bodies, tiled_blob = gen_two_body_dataset();
+tile = tiled_blob[b][1,1];
+tile_sources = mp.tile_sources[b][1,1];
+
+#@time elbo = ElboDeriv.elbo(tiled_blob, mp);
+
+@time star_mcs, gal_mcs = ElboDeriv.load_bvn_mixtures(mp, b);
+@time sbs = ElboDeriv.load_source_brightnesses(mp);
+@time elbo_vars = ElboDeriv.ElboIntermediateVariables(Float64, mp.S, mp.S);
+@time ElboDeriv.populate_fsm_vecs!(
+  elbo_vars, mp, tile_sources, tile, h, w, sbs, gal_mcs, star_mcs);
+clear!(elbo_vars.E_G);
+clear!(elbo_vars.var_G);
+
+this_pixel = tile.pixels[h, w]
+
+ElboDeriv.get_expected_pixel_brightness!(
+  elbo_vars, h, w, sbs, star_mcs, gal_mcs, tile,
+  mp, tile_sources, include_epsilon=true);
+
+
+
+Profile.clear_malloc_data()
+Profile.clear()
+profile_n = 50
+@profile for i = 1:profile_n
+  print(".")
+  ElboDeriv.get_expected_pixel_brightness!(
+    elbo_vars, h, w, sbs, star_mcs, gal_mcs, tile,
+    mp, tile_sources, include_epsilon=true);
+end
+println("Done.")
+
+
+@time ElboDeriv.populate_fsm_vecs!(
+  elbo_vars, mp, tile_sources, tile, h, w, sbs, gal_mcs, star_mcs)
+
+# # This combines the sources into a single brightness value for the pixel.
+@time ElboDeriv.combine_pixel_sources!(elbo_vars, mp, tile_sources, tile, sbs);
+
+# Dig into combine_pixel_sources/.  We expect 31k of allocations.
+clear!(elbo_vars.E_G,
+  clear_hessian=elbo_vars.calculate_hessian && elbo_vars.calculate_derivs);
+clear!(elbo_vars.var_G,
+  clear_hessian=elbo_vars.calculate_hessian && elbo_vars.calculate_derivs);
+
+# This would get run twice.
+s = tile_sources[1]
+@time active_source = s in mp.active_sources
+@time calculate_hessian =
+  elbo_vars.calculate_hessian && elbo_vars.calculate_derivs &&
+  active_source
+# It's all in here:
+@time ElboDeriv.accumulate_source_brightness!(elbo_vars, mp, sbs, s, tile.b)
+@time sa = findfirst(mp.active_sources, s)[1]
+@time ElboDeriv.add_sources_sf!(elbo_vars.E_G, elbo_vars.E_G_s, sa,
+  calculate_hessian=calculate_hessian);
+@time ElboDeriv.add_sources_sf!(elbo_vars.var_G, elbo_vars.var_G_s, sa,
+  calculate_hessian=calculate_hessian);
+
+
+# Dig into accumulate_source_brightness!
+
+# E[G] and E{G ^ 2} for a single source
+E_G_s = elbo_vars.E_G_s;
+E_G2_s = elbo_vars.E_G2_s;
+
+clear_hessian = elbo_vars.calculate_hessian && elbo_vars.calculate_derivs
+clear!(E_G_s, clear_hessian=clear_hessian)
+clear!(E_G2_s, clear_hessian=clear_hessian);
+
+@time a = mp.vp[s][ids.a]
+@time fsm = (elbo_vars.fs0m_vec[s], elbo_vars.fs1m_vec[s]);
+@time sb = sbs[s];
+
+active_source = (s in mp.active_sources)
+
+for i in 1:Ia # Stars and galaxies
+  @time lf = sb.E_l_a[b, i].v * fsm[i].v
+  @time llff = sb.E_ll_a[b, i].v * fsm[i].v^2
+
+  @time E_G_s.v += a[i] * lf
+  @time E_G2_s.v += a[i] * llff
+
+  # Only calculate derivatives for active sources.
+  if active_source && elbo_vars.calculate_derivs
+    ######################
+    # Gradients.
+
+    @time E_G_s.d[ids.a[i], 1] += lf
+    @time E_G2_s.d[ids.a[i], 1] += llff
+
+    @time p0_shape = shape_standard_alignment[i]
+    @time p0_bright = brightness_standard_alignment[i]
+    @time u_ind = i == 1 ? star_ids.u : gal_ids.u
+
+    # Derivatives with respect to the spatial parameters
+    #a_fd = a[i] * fsm[i].d[:, 1]
+    for p0_shape_ind in 1:length(p0_shape)
+      @time E_G_s.d[p0_shape[p0_shape_ind], 1] +=
+        sb.E_l_a[b, i].v * a[i] * fsm[i].d[p0_shape_ind, 1]
+      @time E_G2_s.d[p0_shape[p0_shape_ind], 1] +=
+        sb.E_ll_a[b, i].v * 2 * fsm[i].v * a[i] * fsm[i].d[p0_shape_ind, 1]
+    end
+
+    # Derivatives with respect to the brightness parameters.
+    for p0_bright_ind in 1:length(p0_bright)
+      @time E_G_s.d[p0_bright[p0_bright_ind], 1] +=
+        a[i] * fsm[i].v * sb.E_l_a[b, i].d[p0_bright_ind, 1]
+      @time E_G2_s.d[p0_bright[p0_bright_ind], 1] +=
+        a[i] * (fsm[i].v^2) * sb.E_ll_a[b, i].d[p0_bright_ind, 1]
+    end
+
+    if elbo_vars.calculate_hessian
+      ######################
+      # Hessians.
+      println("Hessian")
+      # Data structures to accumulate certain submatrices of the Hessian.
+      @time E_G_s_hsub = elbo_vars.E_G_s_hsub_vec[i];
+      @time E_G2_s_hsub = elbo_vars.E_G2_s_hsub_vec[i];
+
+      # The (a, a) block of the hessian is zero.
+
+      # The (bright, bright) block:
+      for p0_ind1 in 1:length(p0_bright), p0_ind2 in 1:length(p0_bright)
+        # TODO: time consuming **************
+        @time E_G_s.h[p0_bright[p0_ind1], p0_bright[p0_ind2]] =
+          a[i] * fsm[i].v * sb.E_l_a[b, i].h[p0_ind1, p0_ind2]
+        @time E_G2_s.h[p0_bright[p0_ind1], p0_bright[p0_ind2]] =
+          a[i] * (fsm[i].v^2) * sb.E_ll_a[b, i].h[p0_ind1, p0_ind2]
+      end
+
+      # The (shape, shape) block:
+      println("shape shape:")
+      @time E_G_s_hsub.shape_shape = a[i] * sb.E_l_a[b, i].v * fsm[i].h;
+
+      @time p1, p2 = size(E_G_s_hsub.shape_shape);
+      for ind1 = 1:p1, ind2 = 1:p2
+        @time E_G2_s_hsub.shape_shape[ind1, ind2] =
+          2 * a[i] * sb.E_ll_a[b, i].v * (
+            fsm[i].v * fsm[i].h[ind1, ind2] +
+            fsm[i].d[ind1, 1] * fsm[i].d[ind2, 1])
+      end
+
+      # The u_u submatrix of this assignment will be overwritten after
+      # the loop.
+      for p0_ind1 in 1:length(p0_shape), p0_ind2 in 1:length(p0_shape)
+        @time E_G_s.h[p0_shape[p0_ind1], p0_shape[p0_ind2]] =
+          a[i] * sb.E_l_a[b, i].v * fsm[i].h[p0_ind1, p0_ind2]
+        @time E_G2_s.h[p0_shape[p0_ind1], p0_shape[p0_ind2]] =
+          E_G2_s_hsub.shape_shape[p0_ind1, p0_ind2];
+      end
+
+      # Since the u_u submatrix is not disjoint between different i, accumulate
+      # it separate and add it at the end.
+      @time E_G_s_hsub.u_u = E_G_s_hsub.shape_shape[u_ind, u_ind];
+      @time E_G2_s_hsub.u_u = E_G2_s_hsub.shape_shape[u_ind, u_ind];
+
+      # All other terms are disjoint between different i and don't involve
+      # addition, so we can just assign their values (which is efficient in
+      # native julia).
+
+      # The (a, bright) blocks:
+      for p0_ind in 1:length(p0_bright)
+        @time E_G_s.h[p0_bright[p0_ind], ids.a[i]] =
+          fsm[i].v * sb.E_l_a[b, i].d[p0_ind, 1]
+        @time E_G2_s.h[p0_bright[p0_ind], ids.a[i]] =
+          (fsm[i].v ^ 2) * sb.E_ll_a[b, i].d[p0_ind, 1]
+      end
+      @time E_G2_s.h[ids.a[i], p0_bright] = E_G2_s.h[p0_bright, ids.a[i]]';
+      @time E_G_s.h[ids.a[i], p0_bright] = E_G_s.h[p0_bright, ids.a[i]]';
+
+      # The (a, shape) blocks.
+      for p0_ind in 1:length(p0_shape)
+        @time E_G_s.h[p0_shape[p0_ind], ids.a[i]] =
+          sb.E_l_a[b, i].v * fsm[i].d[p0_ind, 1]
+        @time E_G2_s.h[p0_shape[p0_ind], ids.a[i]] =
+          sb.E_ll_a[b, i].v * 2 * fsm[i].v * fsm[i].d[p0_ind, 1]
+      end
+      @time E_G2_s.h[ids.a[i], p0_shape] = E_G2_s.h[p0_shape, ids.a[i]]';
+      @time E_G_s.h[ids.a[i], p0_shape] = E_G_s.h[p0_shape, ids.a[i]]';
+
+      for ind_b in 1:length(p0_bright), ind_s in 1:length(p0_shape)
+        @time E_G_s_hsub.bright_shape[ind_b, ind_s] =
+          a[i] * sb.E_l_a[b, i].d[ind_b, 1] * fsm[i].d[ind_s, 1]
+        @time E_G2_s_hsub.bright_shape[ind_b, ind_s] =
+          2 * a[i] * sb.E_ll_a[b, i].d[ind_b, 1] * fsm[i].v * fsm[i].d[ind_s]
+      end
+
+      @time E_G_s.h[p0_bright, p0_shape] = E_G_s_hsub.bright_shape;
+      @time E_G_s.h[p0_shape, p0_bright] = E_G_s_hsub.bright_shape';
+      @time E_G2_s.h[p0_bright, p0_shape] = E_G2_s_hsub.bright_shape;
+      @time E_G2_s.h[p0_shape, p0_bright] = E_G2_s_hsub.bright_shape';
+    end # if calculate hessian
+  end # if calculate derivatives
+end # i loop
+
+if elbo_vars.calculate_hessian
+  # Accumulate the u Hessian.  u is the only parameter that is shared between
+  # different values of i.
+  # E_G_u_u_hess = zeros(2, 2);
+  # E_G2_u_u_hess = zeros(2, 2);
+
+  # For each value in 1:Ia, written this way for speed.
+  @assert Ia == 2
+  @time begin
+    E_G_u_u_hess =
+      elbo_vars.E_G_s_hsub_vec[1].u_u +
+      elbo_vars.E_G_s_hsub_vec[2].u_u
+  end
+
+  @time begin
+     E_G2_u_u_hess =
+      elbo_vars.E_G2_s_hsub_vec[1].u_u +
+      elbo_vars.E_G2_s_hsub_vec[2].u_u
+  end
+
+  # for i = 1:Ia
+  #   E_G_u_u_hess += elbo_vars.E_G_s_hsub_vec[i].u_u
+  #   E_G2_u_u_hess += elbo_vars.E_G2_s_hsub_vec[i].u_u
+  # end
+  @time E_G_s.h[ids.u, ids.u] = E_G_u_u_hess;
+  @time E_G2_s.h[ids.u, ids.u] = E_G2_u_u_hess;
+end
+
+@time ElboDeriv.calculate_var_G_s!(elbo_vars, active_source)

--- a/test/compare_celeste_versions.jl
+++ b/test/compare_celeste_versions.jl
@@ -31,7 +31,7 @@ size(elbo.d)
 
 
 println(elbo.d[1, 1])
-@test_approx_eq elbo.v debug_elbo.v
+@test_approx_eq elbo.v[1] debug_elbo.v
 @test_approx_eq elbo.d debug_elbo.d
 
 
@@ -103,7 +103,7 @@ end
 their_elbo = evaluate_their_elbo();
 our_elbo = evaluate_our_elbo();
 
-@test_approx_eq our_elbo.v their_elbo.v
+@test_approx_eq our_elbo.v[1] their_elbo.v
 
 
 
@@ -135,7 +135,7 @@ end
 @time their_fs0m = get_their_fs0m();
 @time our_fs0m = get_our_fs0m();
 
-@test_approx_eq their_fs0m.v our_fs0m.v
+@test_approx_eq their_fs0m.v[1] our_fs0m.v
 @test_approx_eq their_fs0m.d our_fs0m.d
 
 
@@ -161,7 +161,7 @@ end
 @time their_fs1m = get_their_fs1m();
 @time our_fs1m = get_our_fs1m();
 
-@test_approx_eq their_fs1m.v our_fs1m.v
+@test_approx_eq their_fs1m.v[1] our_fs1m.v
 @test_approx_eq their_fs1m.d our_fs1m.d
 
 
@@ -172,9 +172,9 @@ blob, mp, bodies, tiled_blob = gen_two_body_dataset();
 @time our_sbs = ElboDeriv.load_source_brightnesses(mp);
 
 for s=1:length(our_sbs), b=1:5, i=1:2
-  @test_approx_eq our_sbs[s].E_l_a[b, i].v their_sbs[s].E_l_a[b, i].v
+  @test_approx_eq our_sbs[s].E_l_a[b, i].v[1] their_sbs[s].E_l_a[b, i].v
   @test_approx_eq our_sbs[s].E_l_a[b, i].d their_sbs[s].E_l_a[b, i].d
-  @test_approx_eq our_sbs[s].E_ll_a[b, i].v their_sbs[s].E_ll_a[b, i].v
+  @test_approx_eq our_sbs[s].E_ll_a[b, i].v[1] their_sbs[s].E_ll_a[b, i].v
   @test_approx_eq our_sbs[s].E_ll_a[b, i].d their_sbs[s].E_ll_a[b, i].d
 end
 
@@ -238,10 +238,10 @@ end
 #@time their_E_G, their_var_G = their_accumulate_pixel_stats();
 @time our_E_G, our_var_G = our_accumulate_pixel_stats();
 
-@test_approx_eq their_E_G.v our_E_G.v
+@test_approx_eq their_E_G.v[1] our_E_G.v
 @test_approx_eq their_E_G.d our_E_G.d
 
-@test_approx_eq their_var_G.v our_E_G2.v - (our_E_G.v ^ 2)
+@test_approx_eq their_var_G.v[1] our_E_G2.v[1] - (our_E_G.v[1] ^ 2)
 
 ################################
 # It might be in the accumulation of E_G2 across multiple sources.
@@ -304,8 +304,8 @@ end
 #their_E_G, their_var_G = their_expected_pixel_brightness();
 @time our_E_G, our_var_G = our_expected_pixel_brightness();
 
-@test_approx_eq their_E_G.v our_E_G.v
-@test_approx_eq their_var_G.v our_var_G.v
+@test_approx_eq their_E_G.v[1] our_E_G.v
+@test_approx_eq their_var_G.v[1] our_var_G.v
 
 
 
@@ -385,7 +385,7 @@ end
 #their_accum = their_accum_pixel_ret();
 @time our_accum = our_accum_pixel_ret();
 
-@test_approx_eq their_accum.v our_accum.v
+@test_approx_eq their_accum.v[1] our_accum.v
 
 
 ############################
@@ -483,11 +483,11 @@ clear!(E_G2_s, clear_hessian=clear_hessian);
 active_source = (s in mp.active_sources)
 
 for i in 1:Ia # Stars and galaxies
-  @time lf = sb.E_l_a[b, i].v * fsm[i].v
-  @time llff = sb.E_ll_a[b, i].v * fsm[i].v^2
+  @time lf = sb.E_l_a[b, i].v[1] * fsm[i].v
+  @time llff = sb.E_ll_a[b, i].v[1] * fsm[i].v^2
 
-  @time E_G_s.v += a[i] * lf
-  @time E_G2_s.v += a[i] * llff
+  @time E_G_s.v[1] += a[i] * lf
+  @time E_G2_s.v[1] += a[i] * llff
 
   # Only calculate derivatives for active sources.
   if active_source && elbo_vars.calculate_derivs
@@ -505,15 +505,15 @@ for i in 1:Ia # Stars and galaxies
     #a_fd = a[i] * fsm[i].d[:, 1]
     for p0_shape_ind in 1:length(p0_shape)
       @time E_G_s.d[p0_shape[p0_shape_ind], 1] +=
-        sb.E_l_a[b, i].v * a[i] * fsm[i].d[p0_shape_ind, 1]
+        sb.E_l_a[b, i].v[1] * a[i] * fsm[i].d[p0_shape_ind, 1]
       @time E_G2_s.d[p0_shape[p0_shape_ind], 1] +=
-        sb.E_ll_a[b, i].v * 2 * fsm[i].v * a[i] * fsm[i].d[p0_shape_ind, 1]
+        sb.E_ll_a[b, i].v[1] * 2 * fsm[i].v[1] * a[i] * fsm[i].d[p0_shape_ind, 1]
     end
 
     # Derivatives with respect to the brightness parameters.
     for p0_bright_ind in 1:length(p0_bright)
       @time E_G_s.d[p0_bright[p0_bright_ind], 1] +=
-        a[i] * fsm[i].v * sb.E_l_a[b, i].d[p0_bright_ind, 1]
+        a[i] * fsm[i].v[1] * sb.E_l_a[b, i].d[p0_bright_ind, 1]
       @time E_G2_s.d[p0_bright[p0_bright_ind], 1] +=
         a[i] * (fsm[i].v^2) * sb.E_ll_a[b, i].d[p0_bright_ind, 1]
     end
@@ -532,20 +532,20 @@ for i in 1:Ia # Stars and galaxies
       for p0_ind1 in 1:length(p0_bright), p0_ind2 in 1:length(p0_bright)
         # TODO: time consuming **************
         @time E_G_s.h[p0_bright[p0_ind1], p0_bright[p0_ind2]] =
-          a[i] * fsm[i].v * sb.E_l_a[b, i].h[p0_ind1, p0_ind2]
+          a[i] * fsm[i].v[1] * sb.E_l_a[b, i].h[p0_ind1, p0_ind2]
         @time E_G2_s.h[p0_bright[p0_ind1], p0_bright[p0_ind2]] =
           a[i] * (fsm[i].v^2) * sb.E_ll_a[b, i].h[p0_ind1, p0_ind2]
       end
 
       # The (shape, shape) block:
       println("shape shape:")
-      @time E_G_s_hsub.shape_shape = a[i] * sb.E_l_a[b, i].v * fsm[i].h;
+      @time E_G_s_hsub.shape_shape = a[i] * sb.E_l_a[b, i].v[1] * fsm[i].h;
 
       @time p1, p2 = size(E_G_s_hsub.shape_shape);
       for ind1 = 1:p1, ind2 = 1:p2
         @time E_G2_s_hsub.shape_shape[ind1, ind2] =
-          2 * a[i] * sb.E_ll_a[b, i].v * (
-            fsm[i].v * fsm[i].h[ind1, ind2] +
+          2 * a[i] * sb.E_ll_a[b, i].v[1] * (
+            fsm[i].v[1] * fsm[i].h[ind1, ind2] +
             fsm[i].d[ind1, 1] * fsm[i].d[ind2, 1])
       end
 
@@ -553,7 +553,7 @@ for i in 1:Ia # Stars and galaxies
       # the loop.
       for p0_ind1 in 1:length(p0_shape), p0_ind2 in 1:length(p0_shape)
         @time E_G_s.h[p0_shape[p0_ind1], p0_shape[p0_ind2]] =
-          a[i] * sb.E_l_a[b, i].v * fsm[i].h[p0_ind1, p0_ind2]
+          a[i] * sb.E_l_a[b, i].v[1] * fsm[i].h[p0_ind1, p0_ind2]
         @time E_G2_s.h[p0_shape[p0_ind1], p0_shape[p0_ind2]] =
           E_G2_s_hsub.shape_shape[p0_ind1, p0_ind2];
       end
@@ -570,9 +570,9 @@ for i in 1:Ia # Stars and galaxies
       # The (a, bright) blocks:
       for p0_ind in 1:length(p0_bright)
         @time E_G_s.h[p0_bright[p0_ind], ids.a[i]] =
-          fsm[i].v * sb.E_l_a[b, i].d[p0_ind, 1]
+          fsm[i].v[1] * sb.E_l_a[b, i].d[p0_ind, 1]
         @time E_G2_s.h[p0_bright[p0_ind], ids.a[i]] =
-          (fsm[i].v ^ 2) * sb.E_ll_a[b, i].d[p0_ind, 1]
+          (fsm[i].v[1] ^ 2) * sb.E_ll_a[b, i].d[p0_ind, 1]
       end
       @time E_G2_s.h[ids.a[i], p0_bright] = E_G2_s.h[p0_bright, ids.a[i]]';
       @time E_G_s.h[ids.a[i], p0_bright] = E_G_s.h[p0_bright, ids.a[i]]';
@@ -580,9 +580,9 @@ for i in 1:Ia # Stars and galaxies
       # The (a, shape) blocks.
       for p0_ind in 1:length(p0_shape)
         @time E_G_s.h[p0_shape[p0_ind], ids.a[i]] =
-          sb.E_l_a[b, i].v * fsm[i].d[p0_ind, 1]
+          sb.E_l_a[b, i].v[1] * fsm[i].d[p0_ind, 1]
         @time E_G2_s.h[p0_shape[p0_ind], ids.a[i]] =
-          sb.E_ll_a[b, i].v * 2 * fsm[i].v * fsm[i].d[p0_ind, 1]
+          sb.E_ll_a[b, i].v[1] * 2 * fsm[i].v[1] * fsm[i].d[p0_ind, 1]
       end
       @time E_G2_s.h[ids.a[i], p0_shape] = E_G2_s.h[p0_shape, ids.a[i]]';
       @time E_G_s.h[ids.a[i], p0_shape] = E_G_s.h[p0_shape, ids.a[i]]';
@@ -591,7 +591,7 @@ for i in 1:Ia # Stars and galaxies
         @time E_G_s_hsub.bright_shape[ind_b, ind_s] =
           a[i] * sb.E_l_a[b, i].d[ind_b, 1] * fsm[i].d[ind_s, 1]
         @time E_G2_s_hsub.bright_shape[ind_b, ind_s] =
-          2 * a[i] * sb.E_ll_a[b, i].d[ind_b, 1] * fsm[i].v * fsm[i].d[ind_s]
+          2 * a[i] * sb.E_ll_a[b, i].d[ind_b, 1] * fsm[i].v[1] * fsm[i].d[ind_s]
       end
 
       @time E_G_s.h[p0_bright, p0_shape] = E_G_s_hsub.bright_shape;

--- a/test/compare_celeste_versions.jl
+++ b/test/compare_celeste_versions.jl
@@ -1,0 +1,628 @@
+# Compare the new Celeste version to an old version in another repo.
+
+# To track memory, use:
+# julia --track-allocation=user
+
+#include("test/debug_with_master.jl");
+#using Debug
+
+# blob, mp, bodies, tiled_blob = Debug.SampleData.gen_two_body_dataset();
+# @time debug_elbo = Debug.ElboDeriv.elbo(tiled_blob, mp);
+
+using Celeste
+using CelesteTypes
+using Base.Test
+using SampleData
+import Synthetic
+
+profile_n = 0
+
+blob, mp, bodies, tiled_blob = gen_two_body_dataset();
+mp.active_sources = [2];
+@time elbo = ElboDeriv.elbo(tiled_blob, mp);
+elbo.v
+size(elbo.d)
+
+mp.active_sources = [1, 2];
+@time elbo = ElboDeriv.elbo(tiled_blob, mp);
+elbo.v
+size(elbo.d)
+
+
+
+println(elbo.d[1, 1])
+@test_approx_eq elbo.v debug_elbo.v
+@test_approx_eq elbo.d debug_elbo.d
+
+
+
+
+##########
+@time ElboDeriv.elbo_likelihood(tiled_blob, mp, calculate_derivs=false);
+@time ElboDeriv.elbo_likelihood(tiled_blob, mp, calculate_hessian=false);
+@time ElboDeriv.elbo_likelihood(tiled_blob, mp);
+
+Profile.clear_malloc_data()
+Profile.clear()
+@profile for i = 1:profile_n
+  println(".")
+  ElboDeriv.elbo_likelihood(tiled_blob, mp, calculate_hessian=true);
+  #Debug.ElboDeriv.elbo_likelihood(tiled_blob, mp);
+end
+#Profile.print()
+
+# To see memory, quit and run
+using Coverage
+res = analyze_malloc("src");
+pn = 40; [ println(res[end - (pn - i)]) for i=1:pn ];
+
+
+
+# Checking if the ELBO is different between the two versions.
+#include("src/ElboDeriv.jl")
+
+
+blob, mp, bodies, tiled_blob = Debug.SampleData.gen_two_body_dataset();
+@time debug_elbo = Debug.ElboDeriv.elbo(tiled_blob, mp);
+
+
+@time Debug.ElboDeriv.elbo(tiled_blob, mp);
+#@time ElboDeriv.elbo_likelihood(tiled_blob, mp);
+@time ElboDeriv.elbo(tiled_blob, mp, calculate_derivs=false);
+@time ElboDeriv.elbo(tiled_blob, mp, calculate_hessian=false);
+@time ElboDeriv.elbo(tiled_blob, mp);
+
+Profile.clear_malloc_data()
+Profile.clear()
+@profile for i = 1:profile_n
+  #ElboDeriv.elbo_likelihood(tiled_blob, mp, calculate_hessian=false);
+  Debug.ElboDeriv.elbo_likelihood(tiled_blob, mp);
+end
+#Profile.print(format=:tree, sortedby = :count)
+
+# To see memory, quit and run
+using Coverage
+res = analyze_malloc("src")
+#res = analyze_malloc("/home/rgiordan/Documents/git_repos/debugging_branch_Celeste.jl/CelesteDebug.jl/src");
+pn = 40; [ println(res[end - (pn - i)]) for i=1:pn ];
+
+
+
+
+
+function evaluate_their_elbo()
+  blob, mp, bodies, tiled_blob = Debug.SampleData.gen_two_body_dataset();
+  Debug.ElboDeriv.elbo(tiled_blob, mp)
+end
+
+function evaluate_our_elbo()
+  blob, mp, bodies, tiled_blob = gen_two_body_dataset();
+  ElboDeriv.elbo(tiled_blob, mp)
+end
+
+their_elbo = evaluate_their_elbo();
+our_elbo = evaluate_our_elbo();
+
+@test_approx_eq our_elbo.v their_elbo.v
+
+
+
+# Deeper checks:
+# fsXm looks good.
+b = 1
+x = [10., 9.]
+wcs_jacobian = eye(Float64, 2);
+
+function get_their_fs0m()
+  blob, mp, bodies, tiled_blob = Debug.SampleData.gen_two_body_dataset();
+
+  star_mcs, gal_mcs = Debug.ElboDeriv.load_bvn_mixtures(mp, b);
+  fs0m = zero_sensitive_float(StarPosParams, Float64);
+  Debug.ElboDeriv.accum_star_pos!(star_mcs[1], x, fs0m, wcs_jacobian);
+  fs0m
+end
+
+function get_our_fs0m()
+  blob, mp, bodies, tiled_blob = gen_two_body_dataset();
+
+  s = 1
+  star_mcs, gal_mcs = ElboDeriv.load_bvn_mixtures(mp, b);
+  elbo_vars = ElboDeriv.ElboIntermediateVariables(Float64, 1, 1);
+  ElboDeriv.accum_star_pos!(elbo_vars, s, star_mcs[1], x, wcs_jacobian);
+  elbo_vars.fs0m_vec[s]
+end
+
+@time their_fs0m = get_their_fs0m();
+@time our_fs0m = get_our_fs0m();
+
+@test_approx_eq their_fs0m.v our_fs0m.v
+@test_approx_eq their_fs0m.d our_fs0m.d
+
+
+function get_their_fs1m()
+  blob, mp, bodies, tiled_blob = Debug.SampleData.gen_two_body_dataset();
+
+  star_mcs, gal_mcs = Debug.ElboDeriv.load_bvn_mixtures(mp, b);
+  fs1m = zero_sensitive_float(GalaxyPosParams, Float64);
+  Debug.ElboDeriv.accum_galaxy_pos!(gal_mcs[1], x, fs1m, wcs_jacobian);
+  fs1m
+end
+
+function get_our_fs1m()
+  blob, mp, bodies, tiled_blob = gen_two_body_dataset();
+
+  s = 1
+  star_mcs, gal_mcs = ElboDeriv.load_bvn_mixtures(mp, b);
+  elbo_vars = ElboDeriv.ElboIntermediateVariables(Float64, 1, 1);
+  ElboDeriv.accum_galaxy_pos!(elbo_vars, s, gal_mcs[1], x, wcs_jacobian);
+  elbo_vars.fs1m_vec[s]
+end
+
+@time their_fs1m = get_their_fs1m();
+@time our_fs1m = get_our_fs1m();
+
+@test_approx_eq their_fs1m.v our_fs1m.v
+@test_approx_eq their_fs1m.d our_fs1m.d
+
+
+# Check the brightnesses.  Looks good.
+
+blob, mp, bodies, tiled_blob = gen_two_body_dataset();
+@time their_sbs = [Debug.ElboDeriv.SourceBrightness(mp.vp[s]) for s in 1:mp.S];
+@time our_sbs = ElboDeriv.load_source_brightnesses(mp);
+
+for s=1:length(our_sbs), b=1:5, i=1:2
+  @test_approx_eq our_sbs[s].E_l_a[b, i].v their_sbs[s].E_l_a[b, i].v
+  @test_approx_eq our_sbs[s].E_l_a[b, i].d their_sbs[s].E_l_a[b, i].d
+  @test_approx_eq our_sbs[s].E_ll_a[b, i].v their_sbs[s].E_ll_a[b, i].v
+  @test_approx_eq our_sbs[s].E_ll_a[b, i].d their_sbs[s].E_ll_a[b, i].d
+end
+
+
+##################################
+# Check a pixel accumlation.
+s = 2
+b = 1
+h = 10
+w = 10
+wcs_jacobian = Float64[1 0; 0 1]
+
+function their_accumulate_pixel_stats()
+  blob, mp, bodies, tiled_blob = Debug.SampleData.gen_two_body_dataset();
+  tile = tiled_blob[b][1,1];
+
+  #zsf = Debug.CelesteTypes.zero_sensitive_float;
+  zsf = zero_sensitive_float;
+
+  star_mcs, gal_mcs = Debug.ElboDeriv.load_bvn_mixtures(mp, b);
+  # I don't understand this:
+  # fs0m = zsf(Debug.CelesteTypes.StarPosParams, Float64);
+  # fs1m = zsf(Debug.CelesteTypes.GalaxyPosParams, Float64);
+  # E_G = zsf(Debug.CelesteTypes.CanonicalParams, Float64, mp.S);
+  # var_G = zsf(Debug.CelesteTypes.CanonicalParams, Float64, mp.S);
+  fs0m = zsf(CelesteTypes.StarPosParams, Float64);
+  fs1m = zsf(CelesteTypes.GalaxyPosParams, Float64);
+  E_G = zsf(CelesteTypes.CanonicalParams, Float64, mp.S);
+  var_G = zsf(CelesteTypes.CanonicalParams, Float64, mp.S);
+
+  sbs = [Debug.ElboDeriv.SourceBrightness(mp.vp[s]) for s in 1:mp.S];
+
+  m_pos = Float64[tile.h_range[h], tile.w_range[w]]
+  Debug.ElboDeriv.accum_pixel_source_stats!(
+      sbs[s], star_mcs, gal_mcs,
+      mp.vp[s], s, s, m_pos, b, fs0m, fs1m, E_G, var_G, wcs_jacobian)
+
+  deepcopy(E_G), deepcopy(var_G)
+end
+
+
+function our_accumulate_pixel_stats()
+  blob, mp, bodies, tiled_blob = gen_two_body_dataset();
+  tile = tiled_blob[b][1,1];
+  tile_sources = mp.tile_sources[b][1,1]
+
+  star_mcs, gal_mcs = ElboDeriv.load_bvn_mixtures(mp, b);
+  sbs = ElboDeriv.load_source_brightnesses(mp);
+  elbo_vars = ElboDeriv.ElboIntermediateVariables(Float64, mp.S, mp.S);
+  @time ElboDeriv.populate_fsm_vecs!(
+    elbo_vars, mp, tile_sources, tile, h, w, sbs, gal_mcs, star_mcs);
+  clear!(elbo_vars.E_G);
+  clear!(elbo_vars.var_G);
+
+  ElboDeriv.accumulate_source_brightness!(elbo_vars, mp, sbs, s, b);
+  deepcopy(elbo_vars.E_G), deepcopy(elbo_vars.var_G)
+end
+
+
+
+#@time their_E_G, their_var_G = their_accumulate_pixel_stats();
+@time our_E_G, our_var_G = our_accumulate_pixel_stats();
+
+@test_approx_eq their_E_G.v our_E_G.v
+@test_approx_eq their_E_G.d our_E_G.d
+
+@test_approx_eq their_var_G.v our_E_G2.v - (our_E_G.v ^ 2)
+
+################################
+# It might be in the accumulation of E_G2 across multiple sources.
+
+s = 1
+b = 1
+h = 10
+w = 10
+wcs_jacobian = Float64[1 0; 0 1]
+
+
+function their_expected_pixel_brightness()
+  blob, mp, bodies, tiled_blob = Debug.SampleData.gen_two_body_dataset();
+  tile = tiled_blob[b][1,1];
+
+  zsf = zero_sensitive_float;
+
+  star_mcs, gal_mcs = Debug.ElboDeriv.load_bvn_mixtures(mp, b);
+
+  accum = zsf(CelesteTypes.CanonicalParams, Float64, mp.S);
+  fs0m = zsf(CelesteTypes.StarPosParams, Float64);
+  fs1m = zsf(CelesteTypes.GalaxyPosParams, Float64);
+  E_G = zsf(CelesteTypes.CanonicalParams, Float64, mp.S);
+  var_G = zsf(CelesteTypes.CanonicalParams, Float64, mp.S);
+
+  sbs = Debug.ElboDeriv.SourceBrightness{Float64}[
+    Debug.ElboDeriv.SourceBrightness(mp.vp[s]) for s in 1:mp.S];
+
+  m_pos = Float64[tile.h_range[h], tile.w_range[w]]
+
+  this_pixel = tile.pixels[h, w]
+  iota = Debug.ElboDeriv.expected_pixel_brightness!(
+    h, w, sbs, star_mcs, gal_mcs, tile, E_G, var_G,
+    mp, mp.active_sources, fs0m, fs1m,
+    include_epsilon=true);
+  deepcopy(E_G), deepcopy(var_G)
+end
+
+
+
+function our_expected_pixel_brightness()
+  blob, mp, bodies, tiled_blob = gen_two_body_dataset();
+  tile = tiled_blob[b][1,1];
+  tile_sources = mp.tile_sources[b][1,1];
+
+  star_mcs, gal_mcs = ElboDeriv.load_bvn_mixtures(mp, b);
+  sbs = ElboDeriv.load_source_brightnesses(mp);
+  elbo_vars = ElboDeriv.ElboIntermediateVariables(Float64, mp.S, mp.S);
+  ElboDeriv.populate_fsm_vecs!(
+    elbo_vars, mp, tile_sources, tile, h, w, sbs, gal_mcs, star_mcs);
+
+  this_pixel = tile.pixels[h, w]
+  ElboDeriv.get_expected_pixel_brightness!(
+    elbo_vars, h, w, sbs, star_mcs, gal_mcs, tile,
+    mp, tile_sources, include_epsilon=true)
+
+  deepcopy(elbo_vars.E_G), deepcopy(elbo_vars.var_G)
+end
+
+#their_E_G, their_var_G = their_expected_pixel_brightness();
+@time our_E_G, our_var_G = our_expected_pixel_brightness();
+
+@test_approx_eq their_E_G.v our_E_G.v
+@test_approx_eq their_var_G.v our_var_G.v
+
+
+
+
+
+##################################
+# test accum_pixel_ret!
+
+s = 1
+b = 1
+h = 10
+w = 10
+wcs_jacobian = Float64[1 0; 0 1]
+
+
+function their_accum_pixel_ret()
+  blob, mp, bodies, tiled_blob = Debug.SampleData.gen_two_body_dataset();
+  tile = tiled_blob[b][1,1];
+
+  zsf = zero_sensitive_float;
+
+  star_mcs, gal_mcs = Debug.ElboDeriv.load_bvn_mixtures(mp, b);
+
+  accum = zsf(CelesteTypes.CanonicalParams, Float64, mp.S);
+  fs0m = zsf(CelesteTypes.StarPosParams, Float64);
+  fs1m = zsf(CelesteTypes.GalaxyPosParams, Float64);
+  E_G = zsf(CelesteTypes.CanonicalParams, Float64, mp.S);
+  var_G = zsf(CelesteTypes.CanonicalParams, Float64, mp.S);
+
+  sbs = Debug.ElboDeriv.SourceBrightness{Float64}[
+    Debug.ElboDeriv.SourceBrightness(mp.vp[s]) for s in 1:mp.S];
+
+  m_pos = Float64[tile.h_range[h], tile.w_range[w]]
+
+  this_pixel = tile.pixels[h, w]
+  iota = Debug.ElboDeriv.expected_pixel_brightness!(
+    h, w, sbs, star_mcs, gal_mcs, tile, E_G, var_G,
+    mp, mp.active_sources, fs0m, fs1m,
+    include_epsilon=true);
+
+  Debug.ElboDeriv.accum_pixel_ret!(
+    mp.active_sources, this_pixel, iota, E_G, var_G, accum);
+  deepcopy(accum)
+end
+
+
+
+function our_accum_pixel_ret()
+  blob, mp, bodies, tiled_blob = gen_two_body_dataset();
+  tile = tiled_blob[b][1,1];
+  tile_sources = mp.tile_sources[b][1,1];
+
+  star_mcs, gal_mcs = ElboDeriv.load_bvn_mixtures(mp, b);
+  sbs = ElboDeriv.load_source_brightnesses(mp);
+  elbo_vars = ElboDeriv.ElboIntermediateVariables(Float64, mp.S, mp.S);
+  ElboDeriv.populate_fsm_vecs!(
+    elbo_vars, mp, tile_sources, tile, h, w, sbs, gal_mcs, star_mcs);
+  clear!(elbo_vars.E_G);
+  clear!(elbo_vars.var_G);
+
+  this_pixel = tile.pixels[h, w]
+  ElboDeriv.get_expected_pixel_brightness!(
+    elbo_vars, h, w, sbs, star_mcs, gal_mcs, tile,
+    mp, tile_sources, include_epsilon=true)
+
+
+  println(elbo_vars.elbo.v)
+  iota = tile.constant_background ? tile.iota : tile.iota_vec[h]
+  ElboDeriv.add_elbo_log_term!(elbo_vars, this_pixel, iota)
+  println("Log term: ", elbo_vars.elbo.v)
+  CelesteTypes.add_scaled_sfs!(elbo_vars.elbo, elbo_vars.E_G, scale=-iota)
+  println(elbo_vars.elbo.v)
+
+  deepcopy(elbo_vars.elbo)
+end
+
+#their_accum = their_accum_pixel_ret();
+@time our_accum = our_accum_pixel_ret();
+
+@test_approx_eq their_accum.v our_accum.v
+
+
+############################
+############################
+# Check each step
+
+
+using Celeste
+using CelesteTypes
+using Base.Test
+using SampleData
+import Synthetic
+
+s = 1
+b = 1
+h = 10
+w = 10
+blob, mp, bodies, tiled_blob = gen_two_body_dataset();
+tile = tiled_blob[b][1,1];
+tile_sources = mp.tile_sources[b][1,1];
+
+@time elbo = ElboDeriv.elbo(tiled_blob, mp);
+
+@time star_mcs, gal_mcs = ElboDeriv.load_bvn_mixtures(mp, b);
+@time sbs = ElboDeriv.load_source_brightnesses(mp);
+@time elbo_vars = ElboDeriv.ElboIntermediateVariables(Float64, mp.S, mp.S);
+@time ElboDeriv.populate_fsm_vecs!(
+  elbo_vars, mp, tile_sources, tile, h, w, sbs, gal_mcs, star_mcs);
+clear!(elbo_vars.E_G);
+clear!(elbo_vars.var_G);
+
+this_pixel = tile.pixels[h, w]
+
+Profile.clear_malloc_data()
+Profile.clear()
+profile_n = 50
+@profile for i = 1:profile_n
+  print(".")
+  ElboDeriv.get_expected_pixel_brightness!(
+    elbo_vars, h, w, sbs, star_mcs, gal_mcs, tile,
+    mp, tile_sources, include_epsilon=true)
+end
+println("Done.")
+
+@time ElboDeriv.get_expected_pixel_brightness!(
+  elbo_vars, h, w, sbs, star_mcs, gal_mcs, tile,
+  mp, tile_sources, include_epsilon=true)
+
+@time ElboDeriv.populate_fsm_vecs!(
+  elbo_vars, mp, tile_sources, tile, h, w, sbs, gal_mcs, star_mcs)
+
+# # This combines the sources into a single brightness value for the pixel.
+@time ElboDeriv.combine_pixel_sources!(elbo_vars, mp, tile_sources, tile, sbs);
+
+# Dig into combine_pixel_sources/.  We expect 31k of allocations.
+clear!(elbo_vars.E_G,
+  clear_hessian=elbo_vars.calculate_hessian && elbo_vars.calculate_derivs);
+clear!(elbo_vars.var_G,
+  clear_hessian=elbo_vars.calculate_hessian && elbo_vars.calculate_derivs);
+
+# This would get run twice.
+s = tile_sources[1]
+@time active_source = s in mp.active_sources
+@time calculate_hessian =
+  elbo_vars.calculate_hessian && elbo_vars.calculate_derivs &&
+  active_source
+# It's all in here:
+@time ElboDeriv.accumulate_source_brightness!(elbo_vars, mp, sbs, s, tile.b)
+@time sa = findfirst(mp.active_sources, s)[1]
+@time ElboDeriv.add_sources_sf!(elbo_vars.E_G, elbo_vars.E_G_s, sa,
+  calculate_hessian=calculate_hessian);
+@time ElboDeriv.add_sources_sf!(elbo_vars.var_G, elbo_vars.var_G_s, sa,
+  calculate_hessian=calculate_hessian);
+
+
+# Dig into accumulate_source_brightness!
+
+# E[G] and E{G ^ 2} for a single source
+E_G_s = elbo_vars.E_G_s;
+E_G2_s = elbo_vars.E_G2_s;
+
+clear_hessian = elbo_vars.calculate_hessian && elbo_vars.calculate_derivs
+clear!(E_G_s, clear_hessian=clear_hessian)
+clear!(E_G2_s, clear_hessian=clear_hessian);
+
+@time a = mp.vp[s][ids.a]
+@time fsm = (elbo_vars.fs0m_vec[s], elbo_vars.fs1m_vec[s]);
+@time sb = sbs[s];
+
+active_source = (s in mp.active_sources)
+
+for i in 1:Ia # Stars and galaxies
+  @time lf = sb.E_l_a[b, i].v * fsm[i].v
+  @time llff = sb.E_ll_a[b, i].v * fsm[i].v^2
+
+  @time E_G_s.v += a[i] * lf
+  @time E_G2_s.v += a[i] * llff
+
+  # Only calculate derivatives for active sources.
+  if active_source && elbo_vars.calculate_derivs
+    ######################
+    # Gradients.
+
+    @time E_G_s.d[ids.a[i], 1] += lf
+    @time E_G2_s.d[ids.a[i], 1] += llff
+
+    @time p0_shape = shape_standard_alignment[i]
+    @time p0_bright = brightness_standard_alignment[i]
+    @time u_ind = i == 1 ? star_ids.u : gal_ids.u
+
+    # Derivatives with respect to the spatial parameters
+    #a_fd = a[i] * fsm[i].d[:, 1]
+    for p0_shape_ind in 1:length(p0_shape)
+      @time E_G_s.d[p0_shape[p0_shape_ind], 1] +=
+        sb.E_l_a[b, i].v * a[i] * fsm[i].d[p0_shape_ind, 1]
+      @time E_G2_s.d[p0_shape[p0_shape_ind], 1] +=
+        sb.E_ll_a[b, i].v * 2 * fsm[i].v * a[i] * fsm[i].d[p0_shape_ind, 1]
+    end
+
+    # Derivatives with respect to the brightness parameters.
+    for p0_bright_ind in 1:length(p0_bright)
+      @time E_G_s.d[p0_bright[p0_bright_ind], 1] +=
+        a[i] * fsm[i].v * sb.E_l_a[b, i].d[p0_bright_ind, 1]
+      @time E_G2_s.d[p0_bright[p0_bright_ind], 1] +=
+        a[i] * (fsm[i].v^2) * sb.E_ll_a[b, i].d[p0_bright_ind, 1]
+    end
+
+    if elbo_vars.calculate_hessian
+      ######################
+      # Hessians.
+      println("Hessian")
+      # Data structures to accumulate certain submatrices of the Hessian.
+      @time E_G_s_hsub = elbo_vars.E_G_s_hsub_vec[i];
+      @time E_G2_s_hsub = elbo_vars.E_G2_s_hsub_vec[i];
+
+      # The (a, a) block of the hessian is zero.
+
+      # The (bright, bright) block:
+      for p0_ind1 in 1:length(p0_bright), p0_ind2 in 1:length(p0_bright)
+        # TODO: time consuming **************
+        @time E_G_s.h[p0_bright[p0_ind1], p0_bright[p0_ind2]] =
+          a[i] * fsm[i].v * sb.E_l_a[b, i].h[p0_ind1, p0_ind2]
+        @time E_G2_s.h[p0_bright[p0_ind1], p0_bright[p0_ind2]] =
+          a[i] * (fsm[i].v^2) * sb.E_ll_a[b, i].h[p0_ind1, p0_ind2]
+      end
+
+      # The (shape, shape) block:
+      println("shape shape:")
+      @time E_G_s_hsub.shape_shape = a[i] * sb.E_l_a[b, i].v * fsm[i].h;
+
+      @time p1, p2 = size(E_G_s_hsub.shape_shape);
+      for ind1 = 1:p1, ind2 = 1:p2
+        @time E_G2_s_hsub.shape_shape[ind1, ind2] =
+          2 * a[i] * sb.E_ll_a[b, i].v * (
+            fsm[i].v * fsm[i].h[ind1, ind2] +
+            fsm[i].d[ind1, 1] * fsm[i].d[ind2, 1])
+      end
+
+      # The u_u submatrix of this assignment will be overwritten after
+      # the loop.
+      for p0_ind1 in 1:length(p0_shape), p0_ind2 in 1:length(p0_shape)
+        @time E_G_s.h[p0_shape[p0_ind1], p0_shape[p0_ind2]] =
+          a[i] * sb.E_l_a[b, i].v * fsm[i].h[p0_ind1, p0_ind2]
+        @time E_G2_s.h[p0_shape[p0_ind1], p0_shape[p0_ind2]] =
+          E_G2_s_hsub.shape_shape[p0_ind1, p0_ind2];
+      end
+
+      # Since the u_u submatrix is not disjoint between different i, accumulate
+      # it separate and add it at the end.
+      @time E_G_s_hsub.u_u = E_G_s_hsub.shape_shape[u_ind, u_ind];
+      @time E_G2_s_hsub.u_u = E_G2_s_hsub.shape_shape[u_ind, u_ind];
+
+      # All other terms are disjoint between different i and don't involve
+      # addition, so we can just assign their values (which is efficient in
+      # native julia).
+
+      # The (a, bright) blocks:
+      for p0_ind in 1:length(p0_bright)
+        @time E_G_s.h[p0_bright[p0_ind], ids.a[i]] =
+          fsm[i].v * sb.E_l_a[b, i].d[p0_ind, 1]
+        @time E_G2_s.h[p0_bright[p0_ind], ids.a[i]] =
+          (fsm[i].v ^ 2) * sb.E_ll_a[b, i].d[p0_ind, 1]
+      end
+      @time E_G2_s.h[ids.a[i], p0_bright] = E_G2_s.h[p0_bright, ids.a[i]]';
+      @time E_G_s.h[ids.a[i], p0_bright] = E_G_s.h[p0_bright, ids.a[i]]';
+
+      # The (a, shape) blocks.
+      for p0_ind in 1:length(p0_shape)
+        @time E_G_s.h[p0_shape[p0_ind], ids.a[i]] =
+          sb.E_l_a[b, i].v * fsm[i].d[p0_ind, 1]
+        @time E_G2_s.h[p0_shape[p0_ind], ids.a[i]] =
+          sb.E_ll_a[b, i].v * 2 * fsm[i].v * fsm[i].d[p0_ind, 1]
+      end
+      @time E_G2_s.h[ids.a[i], p0_shape] = E_G2_s.h[p0_shape, ids.a[i]]';
+      @time E_G_s.h[ids.a[i], p0_shape] = E_G_s.h[p0_shape, ids.a[i]]';
+
+      for ind_b in 1:length(p0_bright), ind_s in 1:length(p0_shape)
+        @time E_G_s_hsub.bright_shape[ind_b, ind_s] =
+          a[i] * sb.E_l_a[b, i].d[ind_b, 1] * fsm[i].d[ind_s, 1]
+        @time E_G2_s_hsub.bright_shape[ind_b, ind_s] =
+          2 * a[i] * sb.E_ll_a[b, i].d[ind_b, 1] * fsm[i].v * fsm[i].d[ind_s]
+      end
+
+      @time E_G_s.h[p0_bright, p0_shape] = E_G_s_hsub.bright_shape;
+      @time E_G_s.h[p0_shape, p0_bright] = E_G_s_hsub.bright_shape';
+      @time E_G2_s.h[p0_bright, p0_shape] = E_G2_s_hsub.bright_shape;
+      @time E_G2_s.h[p0_shape, p0_bright] = E_G2_s_hsub.bright_shape';
+    end # if calculate hessian
+  end # if calculate derivatives
+end # i loop
+
+if elbo_vars.calculate_hessian
+  # Accumulate the u Hessian.  u is the only parameter that is shared between
+  # different values of i.
+  # E_G_u_u_hess = zeros(2, 2);
+  # E_G2_u_u_hess = zeros(2, 2);
+
+  # For each value in 1:Ia, written this way for speed.
+  @assert Ia == 2
+  @time begin
+    E_G_u_u_hess =
+      elbo_vars.E_G_s_hsub_vec[1].u_u +
+      elbo_vars.E_G_s_hsub_vec[2].u_u
+  end
+
+  @time begin
+     E_G2_u_u_hess =
+      elbo_vars.E_G2_s_hsub_vec[1].u_u +
+      elbo_vars.E_G2_s_hsub_vec[2].u_u
+  end
+
+  # for i = 1:Ia
+  #   E_G_u_u_hess += elbo_vars.E_G_s_hsub_vec[i].u_u
+  #   E_G2_u_u_hess += elbo_vars.E_G2_s_hsub_vec[i].u_u
+  # end
+  @time E_G_s.h[ids.u, ids.u] = E_G_u_u_hess;
+  @time E_G2_s.h[ids.u, ids.u] = E_G2_u_u_hess;
+end
+
+@time ElboDeriv.calculate_var_G_s!(elbo_vars, active_source)

--- a/test/compare_celeste_versions.jl
+++ b/test/compare_celeste_versions.jl
@@ -417,16 +417,17 @@ this_pixel = tile.pixels[h, w]
 # 20.9 MB
 @time elbo = ElboDeriv.elbo(tiled_blob, mp);
 
-# 4.8 MB, 1.63s with --track-allocation on
-@time elbo_lik = ElboDeriv.elbo_likelihood(tiled_blob, mp);
-@time elbo_lik = ElboDeriv.elbo_likelihood(tiled_blob, mp);
 
+# 4.8 MB, 1.63s with --track-allocation on
+# 0.630015 seconds (74.72 k allocations: 4.701 MB)  with no tracking
+@time elbo_lik = ElboDeriv.elbo_likelihood(tiled_blob, mp);
+@time elbo_lik = ElboDeriv.elbo_likelihood(tiled_blob, mp);
 
 # These startup processes don't use much memory or time.
 @time star_mcs, gal_mcs = ElboDeriv.load_bvn_mixtures(mp, b);
 @time sbs = ElboDeriv.load_source_brightnesses(mp);
 @time elbo_vars = ElboDeriv.ElboIntermediateVariables(Float64, mp.S, mp.S);
-
+elbo_vars_array = [ elbo_vars ]
 # Very little memory allocation now
 @time ElboDeriv.get_expected_pixel_brightness!(
   elbo_vars, h, w, sbs, star_mcs, gal_mcs, tile,
@@ -465,24 +466,6 @@ end
 
 
 ##################
-
-
-sa = findfirst(mp.active_sources, s)
-@code_warntype CelesteTypes.add_sources_sf!(elbo_vars.E_G, elbo_vars.E_G_s, sa,
-        calculate_hessian=calculate_hessian)
-
-@code_warntype ElboDeriv.eval_bvn_pdf(star_mcs[1,1], [0., 0.])
-
-
-bmc = star_mcs[1,1];
-py1, py2, f = ElboDeriv.eval_bvn_pdf(bmc, x)
-
-# TODO: Also make a version that doesn't calculate any derivatives
-# if the object isn't in active_sources.
-@code_warntype ElboDeriv.get_bvn_derivs!(elbo_vars, py1, py2, f, bmc, true, false);
-
-
-
 
 
 

--- a/test/compare_celeste_versions.jl
+++ b/test/compare_celeste_versions.jl
@@ -115,7 +115,7 @@ function get_their_fs0m()
 
   star_mcs, gal_mcs = Debug.ElboDeriv.load_bvn_mixtures(mp, b);
   fs0m = zero_sensitive_float(StarPosParams, Float64);
-  Debug.ElboDeriv.accum_star_pos!(star_mcs[1], x, fs0m, wcs_jacobian);
+  Debug.ElboDeriv.accum_star_pos!(star_mcs[1], x, fs0m, wcs_jacobian, true);
   fs0m
 end
 
@@ -125,7 +125,7 @@ function get_our_fs0m()
   s = 1
   star_mcs, gal_mcs = ElboDeriv.load_bvn_mixtures(mp, b);
   elbo_vars = ElboDeriv.ElboIntermediateVariables(Float64, 1, 1);
-  ElboDeriv.accum_star_pos!(elbo_vars, s, star_mcs[1], x, wcs_jacobian);
+  ElboDeriv.accum_star_pos!(elbo_vars, s, star_mcs[1], x, wcs_jacobian, true);
   elbo_vars.fs0m_vec[s]
 end
 
@@ -141,7 +141,7 @@ function get_their_fs1m()
 
   star_mcs, gal_mcs = Debug.ElboDeriv.load_bvn_mixtures(mp, b);
   fs1m = zero_sensitive_float(GalaxyPosParams, Float64);
-  Debug.ElboDeriv.accum_galaxy_pos!(gal_mcs[1], x, fs1m, wcs_jacobian);
+  Debug.ElboDeriv.accum_galaxy_pos!(gal_mcs[1], x, fs1m, wcs_jacobian, true);
   fs1m
 end
 
@@ -151,7 +151,7 @@ function get_our_fs1m()
   s = 1
   star_mcs, gal_mcs = ElboDeriv.load_bvn_mixtures(mp, b);
   elbo_vars = ElboDeriv.ElboIntermediateVariables(Float64, 1, 1);
-  ElboDeriv.accum_galaxy_pos!(elbo_vars, s, gal_mcs[1], x, wcs_jacobian);
+  ElboDeriv.accum_galaxy_pos!(elbo_vars, s, gal_mcs[1], x, wcs_jacobian, true);
   elbo_vars.fs1m_vec[s]
 end
 
@@ -518,21 +518,17 @@ function profile_stuff()
 
   x = deepcopy(Float64[tile.h_range[h], tile.w_range[w]])
   bmc = deepcopy(star_mcs[1, s])
-  ElboDeriv.accum_star_pos!(
-    elbo_vars, s, bmc, x,
-    wcs_jacobian, calculate_derivs=true)
+  ElboDeriv.accum_star_pos!(elbo_vars, s, bmc, x, wcs_jacobian, true)
 
   # Setting the keyword allocates memory!!!
-  ElboDeriv.fake_accum_star_pos_v2!(elbo_vars, s, bmc, x, wcs_jacobian, true)
+  #ElboDeriv.fake_accum_star_pos_v2!(elbo_vars, s, bmc, x, wcs_jacobian, true)
 
   println("Beginning profiler.")
   Profile.clear_malloc_data()
   Profile.clear()
   for i=1:5000
-    ElboDeriv.fake_accum_star_pos_v2!(elbo_vars, s, bmc, x, wcs_jacobian, true)
-    # ElboDeriv.accum_star_pos!(
-    #   elbo_vars, s, bmc, x,
-    #   wcs_jacobian, calculate_derivs=true)
+    #ElboDeriv.fake_accum_star_pos_v2!(elbo_vars, s, bmc, x, wcs_jacobian, true)
+    ElboDeriv.accum_star_pos!(elbo_vars, s, bmc, x, wcs_jacobian, true)
   end
 end
 

--- a/test/compare_celeste_versions.jl
+++ b/test/compare_celeste_versions.jl
@@ -475,11 +475,24 @@ sa = findfirst(mp.active_sources, s)
 @code_warntype ElboDeriv.eval_bvn_pdf(star_mcs[1,1], [0., 0.])
 
 
+bmc = star_mcs[1,1];
+py1, py2, f = ElboDeriv.eval_bvn_pdf(bmc, x)
+
+# TODO: Also make a version that doesn't calculate any derivatives
+# if the object isn't in active_sources.
+@code_warntype ElboDeriv.get_bvn_derivs!(elbo_vars, py1, py2, f, bmc, true, false);
+
+
+
 Profile.clear_malloc_data()
 Profile.clear()
 @profile for i=1:5000
-  ElboDeriv.populate_fsm_vecs!(
-    elbo_vars, mp, tile_sources, tile, h, w, sbs, gal_mcs, star_mcs)
+  ElboDeriv.accum_star_pos!(
+    elbo_vars, s, star_mcs[1, s], Float64[tile.h_range[h], tile.w_range[w]],
+    wcs_jacobian, calculate_derivs=true)
+
+  # ElboDeriv.populate_fsm_vecs!(
+  #   elbo_vars, mp, tile_sources, tile, h, w, sbs, gal_mcs, star_mcs)
 
   # ElboDeriv.get_expected_pixel_brightness!(
   #   elbo_vars, h, w, sbs, star_mcs, gal_mcs, tile,

--- a/test/compare_celeste_versions.jl
+++ b/test/compare_celeste_versions.jl
@@ -515,7 +515,11 @@ function profile_stuff()
   star_mcs, gal_mcs = ElboDeriv.load_bvn_mixtures(mp, b);
   sbs = ElboDeriv.load_source_brightnesses(mp);
   elbo_vars = ElboDeriv.ElboIntermediateVariables(Float64, mp.S, mp.S);
+  ElboDeriv.populate_fsm_vecs!(
+    elbo_vars, mp, tile_sources, tile, h, w, sbs, gal_mcs, star_mcs)
+
   ElboDeriv.combine_pixel_sources!(elbo_vars, mp, tile_sources, tile, sbs);
+
 
   println("Beginning profiler.")
   Profile.clear_malloc_data()
@@ -530,5 +534,5 @@ profile_stuff()
 
 using Coverage
 res = analyze_malloc("src");
-pn = 10; [ println(res[end - (pn - i)]) for i=1:pn ];
+pn = 20; [ println(res[end - (pn - i)]) for i=1:pn ];
 sum([r.bytes for r in res]) / 1e6

--- a/test/compare_celeste_versions.jl
+++ b/test/compare_celeste_versions.jl
@@ -522,13 +522,14 @@ function profile_stuff()
     elbo_vars, s, bmc, x,
     wcs_jacobian, calculate_derivs=true)
 
+  # Setting the keyword allocates memory!!!
+  ElboDeriv.fake_accum_star_pos_v2!(elbo_vars, s, bmc, x, wcs_jacobian, true)
+
   println("Beginning profiler.")
   Profile.clear_malloc_data()
   Profile.clear()
   for i=1:5000
-    ElboDeriv.fake_accum_star_pos!(
-      elbo_vars, s, bmc, x,
-      wcs_jacobian)
+    ElboDeriv.fake_accum_star_pos_v2!(elbo_vars, s, bmc, x, wcs_jacobian, true)
     # ElboDeriv.accum_star_pos!(
     #   elbo_vars, s, bmc, x,
     #   wcs_jacobian, calculate_derivs=true)
@@ -540,5 +541,5 @@ profile_stuff()
 
 using Coverage
 res = analyze_malloc("src");
-pn = 40; [ println(res[end - (pn - i)]) for i=1:pn ];
+pn = 10; [ println(res[end - (pn - i)]) for i=1:pn ];
 sum([r.bytes for r in res]) / 1e6

--- a/test/compare_celeste_versions.jl
+++ b/test/compare_celeste_versions.jl
@@ -20,18 +20,18 @@ profile_n = 0
 blob, mp, bodies, tiled_blob = gen_two_body_dataset();
 mp.active_sources = [2];
 @time elbo = ElboDeriv.elbo(tiled_blob, mp);
-elbo.v
+elbo.v[1]
 size(elbo.d)
 
 mp.active_sources = [1, 2];
 @time elbo = ElboDeriv.elbo(tiled_blob, mp);
-elbo.v
+elbo.v[1]
 size(elbo.d)
 
 
 
 println(elbo.d[1, 1])
-@test_approx_eq elbo.v[1] debug_elbo.v
+@test_approx_eq elbo.v[1] debug_elbo.v[1]
 @test_approx_eq elbo.d debug_elbo.d
 
 
@@ -103,7 +103,7 @@ end
 their_elbo = evaluate_their_elbo();
 our_elbo = evaluate_our_elbo();
 
-@test_approx_eq our_elbo.v[1] their_elbo.v
+@test_approx_eq our_elbo.v[1] their_elbo.v[1]
 
 
 
@@ -135,7 +135,7 @@ end
 @time their_fs0m = get_their_fs0m();
 @time our_fs0m = get_our_fs0m();
 
-@test_approx_eq their_fs0m.v[1] our_fs0m.v
+@test_approx_eq their_fs0m.v[1] our_fs0m.v[1]
 @test_approx_eq their_fs0m.d our_fs0m.d
 
 
@@ -161,7 +161,7 @@ end
 @time their_fs1m = get_their_fs1m();
 @time our_fs1m = get_our_fs1m();
 
-@test_approx_eq their_fs1m.v[1] our_fs1m.v
+@test_approx_eq their_fs1m.v[1] our_fs1m.v[1]
 @test_approx_eq their_fs1m.d our_fs1m.d
 
 
@@ -172,9 +172,9 @@ blob, mp, bodies, tiled_blob = gen_two_body_dataset();
 @time our_sbs = ElboDeriv.load_source_brightnesses(mp);
 
 for s=1:length(our_sbs), b=1:5, i=1:2
-  @test_approx_eq our_sbs[s].E_l_a[b, i].v[1] their_sbs[s].E_l_a[b, i].v
+  @test_approx_eq our_sbs[s].E_l_a[b, i].v[1] their_sbs[s].E_l_a[b, i].v[1]
   @test_approx_eq our_sbs[s].E_l_a[b, i].d their_sbs[s].E_l_a[b, i].d
-  @test_approx_eq our_sbs[s].E_ll_a[b, i].v[1] their_sbs[s].E_ll_a[b, i].v
+  @test_approx_eq our_sbs[s].E_ll_a[b, i].v[1] their_sbs[s].E_ll_a[b, i].v[1]
   @test_approx_eq our_sbs[s].E_ll_a[b, i].d their_sbs[s].E_ll_a[b, i].d
 end
 
@@ -238,7 +238,7 @@ end
 #@time their_E_G, their_var_G = their_accumulate_pixel_stats();
 @time our_E_G, our_var_G = our_accumulate_pixel_stats();
 
-@test_approx_eq their_E_G.v[1] our_E_G.v
+@test_approx_eq their_E_G.v[1] our_E_G.v[1]
 @test_approx_eq their_E_G.d our_E_G.d
 
 @test_approx_eq their_var_G.v[1] our_E_G2.v[1] - (our_E_G.v[1] ^ 2)
@@ -304,8 +304,8 @@ end
 #their_E_G, their_var_G = their_expected_pixel_brightness();
 @time our_E_G, our_var_G = our_expected_pixel_brightness();
 
-@test_approx_eq their_E_G.v[1] our_E_G.v
-@test_approx_eq their_var_G.v[1] our_var_G.v
+@test_approx_eq their_E_G.v[1] our_E_G.v[1]
+@test_approx_eq their_var_G.v[1] our_var_G.v[1]
 
 
 
@@ -372,12 +372,12 @@ function our_accum_pixel_ret()
     mp, tile_sources, include_epsilon=true)
 
 
-  println(elbo_vars.elbo.v)
+  println(elbo_vars.elbo.v[1])
   iota = tile.constant_background ? tile.iota : tile.iota_vec[h]
   ElboDeriv.add_elbo_log_term!(elbo_vars, this_pixel, iota)
-  println("Log term: ", elbo_vars.elbo.v)
+  println("Log term: ", elbo_vars.elbo.v[1])
   CelesteTypes.add_scaled_sfs!(elbo_vars.elbo, elbo_vars.E_G, scale=-iota)
-  println(elbo_vars.elbo.v)
+  println(elbo_vars.elbo.v[1])
 
   deepcopy(elbo_vars.elbo)
 end
@@ -385,7 +385,7 @@ end
 #their_accum = their_accum_pixel_ret();
 @time our_accum = our_accum_pixel_ret();
 
-@test_approx_eq their_accum.v[1] our_accum.v
+@test_approx_eq their_accum.v[1] our_accum.v[1]
 
 
 ############################
@@ -483,8 +483,8 @@ clear!(E_G2_s, clear_hessian=clear_hessian);
 active_source = (s in mp.active_sources)
 
 for i in 1:Ia # Stars and galaxies
-  @time lf = sb.E_l_a[b, i].v[1] * fsm[i].v
-  @time llff = sb.E_ll_a[b, i].v[1] * fsm[i].v^2
+  @time lf = sb.E_l_a[b, i].v[1] * fsm[i].v[1]
+  @time llff = sb.E_ll_a[b, i].v[1] * fsm[i].v[1]^2
 
   @time E_G_s.v[1] += a[i] * lf
   @time E_G2_s.v[1] += a[i] * llff
@@ -515,7 +515,7 @@ for i in 1:Ia # Stars and galaxies
       @time E_G_s.d[p0_bright[p0_bright_ind], 1] +=
         a[i] * fsm[i].v[1] * sb.E_l_a[b, i].d[p0_bright_ind, 1]
       @time E_G2_s.d[p0_bright[p0_bright_ind], 1] +=
-        a[i] * (fsm[i].v^2) * sb.E_ll_a[b, i].d[p0_bright_ind, 1]
+        a[i] * (fsm[i].v[1]^2) * sb.E_ll_a[b, i].d[p0_bright_ind, 1]
     end
 
     if elbo_vars.calculate_hessian
@@ -534,7 +534,7 @@ for i in 1:Ia # Stars and galaxies
         @time E_G_s.h[p0_bright[p0_ind1], p0_bright[p0_ind2]] =
           a[i] * fsm[i].v[1] * sb.E_l_a[b, i].h[p0_ind1, p0_ind2]
         @time E_G2_s.h[p0_bright[p0_ind1], p0_bright[p0_ind2]] =
-          a[i] * (fsm[i].v^2) * sb.E_ll_a[b, i].h[p0_ind1, p0_ind2]
+          a[i] * (fsm[i].v[1]^2) * sb.E_ll_a[b, i].h[p0_ind1, p0_ind2]
       end
 
       # The (shape, shape) block:

--- a/test/compare_celeste_versions.jl
+++ b/test/compare_celeste_versions.jl
@@ -35,6 +35,7 @@ println(elbo.d[1, 1])
 ##########
 #@time ElboDeriv.elbo_likelihood(tiled_blob, mp, calculate_derivs=false);
 #@time ElboDeriv.elbo_likelihood(tiled_blob, mp, calculate_hessian=false);
+# 3.206593 seconds (1.04 M allocations: 70.450 MB, 0.95% gc time)
 @time ElboDeriv.elbo_likelihood(tiled_blob, mp);
 
 profile_n = 1

--- a/test/compare_celeste_versions.jl
+++ b/test/compare_celeste_versions.jl
@@ -499,7 +499,7 @@ iota = tile.constant_background ? tile.iota : tile.iota_vec[h];
 
 @time ElboDeriv.accum_galaxy_pos!(elbo_vars, s, gal_mcs[1], x, wcs_jacobian);
 
-# # This combines the sources into a single brightness value for the pixel.
+# This combines the sources into a single brightness value for the pixel.
 # 12.4 / 38.6
 @time ElboDeriv.combine_pixel_sources!(elbo_vars, mp, tile_sources, tile, sbs);
 

--- a/test/debug_with_master.jl
+++ b/test/debug_with_master.jl
@@ -1,0 +1,14 @@
+module Debug
+  # A path to a different github client on the master branch.
+  git_repo_loc = "/home/rgiordan/Documents/git_repos"
+  master_path =
+    joinpath(git_repo_loc, "debugging_branch_Celeste.jl/CelesteDebug.jl")
+  push!(LOAD_PATH, joinpath(master_path, "src"))
+
+  include(joinpath(master_path, "src/Celeste.jl"))
+  include(joinpath(master_path, "src/CelesteTypes.jl"))
+  include(joinpath(master_path, "src/SampleData.jl"))
+  include(joinpath(master_path, "src/KL.jl"))
+  include(joinpath(master_path, "src/ElboDeriv.jl"))
+
+end

--- a/test/test_derivatives.jl
+++ b/test/test_derivatives.jl
@@ -121,7 +121,7 @@ function test_real_image()
     end
     local_elbo = ElboDeriv.elbo(
       very_trimmed_tiled_blob, mp_local, calculate_derivs=false)
-    local_elbo.v
+    local_elbo.v[1]
   end
 
   vp_vec = trimmed_mp.vp[s];
@@ -145,6 +145,8 @@ function test_dual_numbers()
   blob, mp, body, tiled_blob = gen_sample_star_dataset();
   mp_dual = CelesteTypes.forward_diff_model_params(DualNumbers.Dual{Float64}, mp);
   elbo_dual = ElboDeriv.elbo_likelihood(tiled_blob, mp_dual);
+
+  true
 end
 
 
@@ -515,7 +517,7 @@ function test_fs1m_derivatives()
     star_mcs, gal_mcs = ElboDeriv.load_bvn_mixtures(mp, b);
     clear!(elbo_vars.fs1m_vec[s]);
     ElboDeriv.accum_galaxy_pos!(
-      elbo_vars, s, gal_mcs[gcc_ind...], x, patch.wcs_jacobian);
+      elbo_vars, s, gal_mcs[gcc_ind...], x, patch.wcs_jacobian, true);
     fs1m = deepcopy(elbo_vars.fs1m_vec[s]);
 
     # Two sanity checks.
@@ -571,7 +573,7 @@ function test_fs0m_derivatives()
       star_mcs, gal_mcs = ElboDeriv.load_bvn_mixtures(mp_fd, b);
       elbo_vars_fd = ElboDeriv.ElboIntermediateVariables(T, 1, 1);
       ElboDeriv.accum_star_pos!(
-        elbo_vars_fd, s, star_mcs[bmc_ind...], x, patch.wcs_jacobian);
+        elbo_vars_fd, s, star_mcs[bmc_ind...], x, patch.wcs_jacobian, true);
       elbo_vars_fd.fs0m_vec[s].v
     end
 
@@ -588,7 +590,7 @@ function test_fs0m_derivatives()
     clear!(elbo_vars.fs0m_vec[s])
     star_mcs, gal_mcs = ElboDeriv.load_bvn_mixtures(mp, b);
     ElboDeriv.accum_star_pos!(
-      elbo_vars, s, star_mcs[bmc_ind...], x, patch.wcs_jacobian);
+      elbo_vars, s, star_mcs[bmc_ind...], x, patch.wcs_jacobian, true);
     fs0m = deepcopy(elbo_vars.fs0m_vec[s])
 
     test_with_autodiff(f_wrap_star, par_star, fs0m)
@@ -892,6 +894,7 @@ function test_brightness_hessian()
     println("Testing brightness $(squares_string) for band $b, type $i")
     function wrap_source_brightness{NumType <: Number}(
         vp::Vector{NumType}, calculate_derivs::Bool)
+
       sb = ElboDeriv.SourceBrightness(vp, calculate_derivs=calculate_derivs);
       if squares
         return deepcopy(sb.E_ll_a[b, i])
@@ -906,7 +909,7 @@ function test_brightness_hessian()
       for b_i in 1:length(brightness_standard_alignment[i])
         vp[brightness_standard_alignment[i][b_i]] = bright_vp[b_i]
       end
-      wrap_source_brightness(vp, false).v
+      wrap_source_brightness(vp, false).v[1]
     end
 
     bright_vp = mp.vp[1][brightness_standard_alignment[i]];

--- a/test/test_derivatives.jl
+++ b/test/test_derivatives.jl
@@ -523,7 +523,7 @@ function test_fs1m_derivatives()
     # Two sanity checks.
     gcc = gal_mcs[gcc_ind...];
     clear!(elbo_vars.fs1m_vec[s]);
-    v = ElboDeriv.eval_bvn_log_density(gcc.bmc, x);
+    v = ElboDeriv.eval_bvn_log_density(elbo_vars, gcc.bmc, x);
     gc = galaxy_prototypes[gcc_ind[3]][gcc_ind[2]]
     pc = mp.patches[s, b].psf[gcc_ind[1]]
 
@@ -640,7 +640,7 @@ function test_bvn_derivatives()
   par = wrap(x, sigma);
 
   # Sanity check
-  @test_approx_eq ElboDeriv.eval_bvn_log_density(bvn, x) f_wrap(par)
+  @test_approx_eq ElboDeriv.eval_bvn_log_density(elbo_vars, bvn, x) f_wrap(par)
 
   ad_grad = ForwardDiff.gradient(f_wrap, par);
   @test_approx_eq elbo_vars.bvn_x_d ad_grad[x_ids]

--- a/test/test_derivatives.jl
+++ b/test/test_derivatives.jl
@@ -499,8 +499,8 @@ function test_fs1m_derivatives()
 
       # Raw:
       gcc = gal_mcs[gcc_ind...];
-      py1, py2, f_pre = ElboDeriv.eval_bvn_pdf(gcc.bmc, x)
-      f_pre * gcc.e_dev_i
+      ElboDeriv.eval_bvn_pdf_in_place!(elbo_vars, gcc.bmc, x)
+      elbo_vars.f_pre[1] * gcc.e_dev_i
     end
 
     function mp_to_par_gal(mp::ModelParams{Float64})
@@ -789,9 +789,9 @@ function test_galaxy_cache_component()
             e_dev_dir, e_dev_i_fd, gp, psf,
             u_pix, e_axis, e_angle, e_scale, false, false);
 
-    py1, py2, f_pre = ElboDeriv.eval_bvn_pdf(gcc.bmc, x);
+    ElboDeriv.eval_bvn_pdf_in_place!(elbo_vars_fd, gcc.bmc, x);
 
-    log(f_pre)
+    log(elbo_vars_fd.f_pre[1])
   end
 
   function wrap_par{T <: Number}(

--- a/test/test_derivatives.jl
+++ b/test/test_derivatives.jl
@@ -288,8 +288,8 @@ function test_tile_likelihood()
     if ElboDerivs.Threaded
       for i in 2:nthreads()
         CelesteTypes.add_scaled_sfs!(
-          elbo_vars_array[1].elbo, elbo_vars_array[i].elbo,
-          calculate_hessian=elbo_vars_array[1].calculate_hessian &&
+          elbo_vars_array[1].elbo, elbo_vars_array[i].elbo, 1.0,
+          elbo_vars_array[1].calculate_hessian &&
             elbo_vars_array[1].calculate_derivs)
       end
     end

--- a/test/test_derivatives.jl
+++ b/test/test_derivatives.jl
@@ -228,7 +228,7 @@ function test_elbo()
   function wrap_elbo{NumType <: Number}(vp_vec::Vector{NumType})
     mp_local = unwrap_vp_vector(vp_vec, mp)
     elbo = ElboDeriv.elbo(tiled_blob, mp_local, calculate_derivs=false)
-    elbo.v
+    elbo.v[1]
   end
 
   mp.active_sources = [1];
@@ -298,7 +298,7 @@ function test_tile_likelihood()
 
   function tile_lik_value_wrapper{NumType <: Number}(x::Vector{NumType})
     mp_local = unwrap_vp_vector(x, mp)
-    tile_lik_wrapper_fun(mp_local, false).v
+    tile_lik_wrapper_fun(mp_local, false).v[1]
   end
 
   elbo = tile_lik_wrapper_fun(mp, true);
@@ -345,7 +345,7 @@ function test_add_log_term()
 
     function ad_wrapper_fun{NumType <: Number}(x::Vector{NumType})
       mp_local = unwrap_vp_vector(x, mp)
-      add_log_term_wrapper_fun(mp_local, false).v
+      add_log_term_wrapper_fun(mp_local, false).v[1]
     end
 
     x = wrap_vp_vector(mp, true);
@@ -391,7 +391,7 @@ function test_combine_pixel_sources()
     function wrapper_fun{NumType <: Number}(x::Vector{NumType})
       mp_local = unwrap_vp_vector(x, mp)
       elbo_vars_local = e_g_wrapper_fun(mp_local, calculate_derivs=false)
-      test_var ? elbo_vars_local.var_G.v[1] : elbo_vars_local.E_G.v
+      test_var ? elbo_vars_local.var_G.v[1] : elbo_vars_local.E_G.v[1]
     end
 
     x = wrap_vp_vector(mp, true)
@@ -442,7 +442,7 @@ function test_e_g_s_functions()
       mp_local = CelesteTypes.forward_diff_model_params(NumType, mp);
       mp_local.vp[s] = x
       elbo_vars_local = e_g_wrapper_fun(mp_local, calculate_derivs=false)
-      test_var ? elbo_vars_local.var_G_s.v[1] : elbo_vars_local.E_G_s.v
+      test_var ? elbo_vars_local.var_G_s.v[1] : elbo_vars_local.E_G_s.v[1]
     end
 
     x = mp.vp[s];
@@ -487,6 +487,7 @@ function test_fs1m_derivatives()
     function f_wrap_gal{T <: Number}(par::Vector{T})
       # This uses mp, x, wcs_jacobian, and gcc_ind from the enclosing namespace.
       mp_fd = CelesteTypes.forward_diff_model_params(T, mp);
+      elbo_vars_fd = ElboDeriv.ElboIntermediateVariables(T, 1, 1);
 
       # Make sure par is as long as the galaxy parameters.
       @assert length(par) == length(shape_standard_alignment[2])
@@ -499,8 +500,8 @@ function test_fs1m_derivatives()
 
       # Raw:
       gcc = gal_mcs[gcc_ind...];
-      ElboDeriv.eval_bvn_pdf_in_place!(elbo_vars, gcc.bmc, x)
-      elbo_vars.f_pre[1] * gcc.e_dev_i
+      ElboDeriv.eval_bvn_pdf_in_place!(elbo_vars_fd, gcc.bmc, x)
+      elbo_vars_fd.f_pre[1] * gcc.e_dev_i
     end
 
     function mp_to_par_gal(mp::ModelParams{Float64})
@@ -574,7 +575,7 @@ function test_fs0m_derivatives()
       elbo_vars_fd = ElboDeriv.ElboIntermediateVariables(T, 1, 1);
       ElboDeriv.accum_star_pos!(
         elbo_vars_fd, s, star_mcs[bmc_ind...], x, patch.wcs_jacobian, true);
-      elbo_vars_fd.fs0m_vec[s].v
+      elbo_vars_fd.fs0m_vec[s].v[1]
     end
 
     function mp_to_par_star(mp::ModelParams{Float64})

--- a/test/test_derivatives.jl
+++ b/test/test_derivatives.jl
@@ -174,12 +174,12 @@ function test_derivative_flags()
   elbo = ElboDeriv.elbo(tiled_blob, mp);
 
   elbo_noderiv = ElboDeriv.elbo(tiled_blob, mp; calculate_derivs=false);
-  @test_approx_eq elbo.v elbo_noderiv.v
+  @test_approx_eq elbo.v[1] elbo_noderiv.v
   @test_approx_eq elbo_noderiv.d zeros(size(elbo_noderiv.d))
   @test_approx_eq elbo_noderiv.h zeros(size(elbo_noderiv.h))
 
   elbo_nohess = ElboDeriv.elbo(tiled_blob, mp; calculate_hessian=false);
-  @test_approx_eq elbo.v elbo_nohess.v
+  @test_approx_eq elbo.v[1] elbo_nohess.v
   @test_approx_eq elbo.d elbo_nohess.d
   @test_approx_eq elbo_noderiv.h zeros(size(elbo_noderiv.h))
 end
@@ -205,8 +205,8 @@ function test_active_sources()
   mp.active_sources = [2]
   elbo_lik_2 = ElboDeriv.elbo_likelihood(tiled_blob, mp);
 
-  @test_approx_eq elbo_lik_12.v elbo_lik_1.v
-  @test_approx_eq elbo_lik_12.v elbo_lik_2.v
+  @test_approx_eq elbo_lik_12.v[1] elbo_lik_1.v
+  @test_approx_eq elbo_lik_12.v[1] elbo_lik_2.v
 
   @test_approx_eq elbo_lik_12.d[:, 1] elbo_lik_1.d[:, 1]
   @test_approx_eq elbo_lik_12.d[:, 2] elbo_lik_2.d[:, 1]
@@ -389,7 +389,7 @@ function test_combine_pixel_sources()
     function wrapper_fun{NumType <: Number}(x::Vector{NumType})
       mp_local = unwrap_vp_vector(x, mp)
       elbo_vars_local = e_g_wrapper_fun(mp_local, calculate_derivs=false)
-      test_var ? elbo_vars_local.var_G.v : elbo_vars_local.E_G.v
+      test_var ? elbo_vars_local.var_G.v[1] : elbo_vars_local.E_G.v
     end
 
     x = wrap_vp_vector(mp, true)
@@ -440,7 +440,7 @@ function test_e_g_s_functions()
       mp_local = CelesteTypes.forward_diff_model_params(NumType, mp);
       mp_local.vp[s] = x
       elbo_vars_local = e_g_wrapper_fun(mp_local, calculate_derivs=false)
-      test_var ? elbo_vars_local.var_G_s.v : elbo_vars_local.E_G_s.v
+      test_var ? elbo_vars_local.var_G_s.v[1] : elbo_vars_local.E_G_s.v
     end
 
     x = mp.vp[s];
@@ -449,7 +449,7 @@ function test_e_g_s_functions()
 
     # Sanity check the variance value.
     @test_approx_eq(elbo_vars.var_G_s.v,
-                    elbo_vars.E_G2_s.v - (elbo_vars.E_G_s.v ^ 2))
+                    elbo_vars.E_G2_s.v[1] - (elbo_vars.E_G_s.v[1] ^ 2))
 
     sf = test_var ? deepcopy(elbo_vars.var_G_s) : deepcopy(elbo_vars.E_G_s);
 
@@ -912,7 +912,7 @@ function test_brightness_hessian()
     bright_vp = mp.vp[1][brightness_standard_alignment[i]];
     bright = wrap_source_brightness(mp.vp[1], true);
 
-    @test_approx_eq bright.v wrap_source_brightness_value(bright_vp);
+    @test_approx_eq bright.v[1] wrap_source_brightness_value(bright_vp);
 
     ad_grad = ForwardDiff.gradient(wrap_source_brightness_value, bright_vp);
     @test_approx_eq ad_grad bright.d[:, 1]

--- a/test/test_elbo_values.jl
+++ b/test/test_elbo_values.jl
@@ -116,7 +116,7 @@ function test_that_variance_is_low()
     ElboDeriv.get_expected_pixel_brightness!(
       elbo_vars, h, w, sbs, star_mcs, gal_mcs, tile, mp, tile_sources);
 
-    @test 0 < elbo_vars.var_G.v[1] < 1e-2 * elbo_vars.E_G.v^2
+    @test 0 < elbo_vars.var_G.v[1] < 1e-2 * elbo_vars.E_G.v[1]^2
 end
 
 
@@ -128,7 +128,7 @@ function test_that_star_truth_is_most_likely()
         mp_a = deepcopy(mp)
         mp_a.vp[1][ids.a] = [ 1.0 - bad_a, bad_a ]
         bad_a_lik = ElboDeriv.elbo_likelihood(tiled_blob, mp_a)
-        @test best.v[1] > bad_a_lik.v
+        @test best.v[1] > bad_a_lik.v[1]
     end
 
     for h2 in -2:2
@@ -137,7 +137,7 @@ function test_that_star_truth_is_most_likely()
                 mp_mu = deepcopy(mp)
                 mp_mu.vp[1][ids.u] += [h2 * .5, w2 * .5]
                 bad_mu = ElboDeriv.elbo_likelihood(tiled_blob, mp_mu)
-                @test best.v[1] > bad_mu.v
+                @test best.v[1] > bad_mu.v[1]
             end
         end
     end
@@ -146,7 +146,7 @@ function test_that_star_truth_is_most_likely()
         mp_r1 = deepcopy(mp)
         mp_r1.vp[1][ids.r1] += log(delta)
         bad_r1 = ElboDeriv.elbo_likelihood(tiled_blob, mp_r1)
-        @test best.v[1] > bad_r1.v
+        @test best.v[1] > bad_r1.v[1]
     end
 
     for b in 1:4
@@ -154,7 +154,7 @@ function test_that_star_truth_is_most_likely()
             mp_c1 = deepcopy(mp)
             mp_c1.vp[1][ids.c1[b, 1]] += delta
             bad_c1 = ElboDeriv.elbo_likelihood(tiled_blob, mp_c1)
-            @test best.v[1] > bad_c1.v
+            @test best.v[1] > bad_c1.v[1]
         end
     end
 
@@ -171,7 +171,7 @@ function test_that_galaxy_truth_is_most_likely()
         mp_a.vp[1][ids.a] = [ 1.0 - bad_a, bad_a ];
         bad_a =
           ElboDeriv.elbo_likelihood(tiled_blob, mp_a; calculate_derivs=false);
-        @test best.v[1] > bad_a.v;
+        @test best.v[1] > bad_a.v[1];
     end
 
     for h2 in -2:2
@@ -181,7 +181,7 @@ function test_that_galaxy_truth_is_most_likely()
                 mp_mu.vp[1][ids.u] += [h2 * .5, w2 * .5]
                 bad_mu = ElboDeriv.elbo_likelihood(
                   tiled_blob, mp_mu; calculate_derivs=false)
-                @test best.v[1] > bad_mu.v
+                @test best.v[1] > bad_mu.v[1]
             end
         end
     end
@@ -191,7 +191,7 @@ function test_that_galaxy_truth_is_most_likely()
         mp_r1.vp[1][ids.r1] += 2 * log(bad_scale)
         bad_r1 = ElboDeriv.elbo_likelihood(
           tiled_blob, mp_r1; calculate_derivs=false)
-        @test best.v[1] > bad_r1.v
+        @test best.v[1] > bad_r1.v[1]
     end
 
     for n in [:e_axis, :e_angle, :e_scale]
@@ -200,7 +200,7 @@ function test_that_galaxy_truth_is_most_likely()
             mp_bad.vp[1][ids.(n)] *= bad_scale
             bad_elbo = ElboDeriv.elbo_likelihood(
               tiled_blob, mp_bad; calculate_derivs=false)
-            @test best.v[1] > bad_elbo.v
+            @test best.v[1] > bad_elbo.v[1]
         end
     end
 
@@ -210,7 +210,7 @@ function test_that_galaxy_truth_is_most_likely()
             mp_c1.vp[1][ids.c1[b, 2]] += delta
             bad_c1 = ElboDeriv.elbo_likelihood(
               tiled_blob, mp_c1; calculate_derivs=false)
-            @test best.v[1] > bad_c1.v
+            @test best.v[1] > bad_c1.v[1]
         end
     end
 end
@@ -251,7 +251,7 @@ function test_coadd_cat_init_is_most_likely()  # on a real stamp
         mp_r1.vp[s][ids.r1] += 2 * log(bad_scale)
         bad_r1 = ElboDeriv.elbo_likelihood(
           tiled_blob, mp_r1; calculate_derivs=false)
-        @test best.v[1] > bad_r1.v
+        @test best.v[1] > bad_r1.v[1]
     end
 
     for n in [:e_axis, :e_angle, :e_scale]
@@ -260,7 +260,7 @@ function test_coadd_cat_init_is_most_likely()  # on a real stamp
             mp_bad.vp[s][ids.(n)] *= bad_scale
             bad_elbo = ElboDeriv.elbo_likelihood(
               tiled_blob, mp_bad; calculate_derivs=false)
-            @test best.v[1] > bad_elbo.v
+            @test best.v[1] > bad_elbo.v[1]
         end
     end
 
@@ -270,7 +270,7 @@ function test_coadd_cat_init_is_most_likely()  # on a real stamp
 
         bad_a = ElboDeriv.elbo_likelihood(
           tiled_blob, mp_a; calculate_derivs=false)
-        @test best.v[1] > bad_a.v
+        @test best.v[1] > bad_a.v[1]
     end
 
     for h2 in -2:2
@@ -280,7 +280,7 @@ function test_coadd_cat_init_is_most_likely()  # on a real stamp
                 mp_mu.vp[s][ids.u] += [0.5h2, 0.5w2]
                 bad_mu = ElboDeriv.elbo_likelihood(
                   tiled_blob, mp_mu; calculate_derivs=false)
-                @test best.v[1] > bad_mu.v
+                @test best.v[1] > bad_mu.v[1]
             end
         end
     end
@@ -291,8 +291,8 @@ function test_coadd_cat_init_is_most_likely()  # on a real stamp
             mp_c1.vp[s][ids.c1[b, :]] += delta
             bad_c1 = ElboDeriv.elbo_likelihood(
               tiled_blob, mp_c1; calculate_derivs=false)
-            info("$(best.v)  >  $(bad_c1.v)")
-            @test best.v[1] > bad_c1.v
+            info("$(best.v[1])  >  $(bad_c1.v[1])")
+            @test best.v[1] > bad_c1.v[1]
         end
     end
 end
@@ -369,7 +369,7 @@ function test_tiny_image_tiling()
   end
   elbo_lik_tiles2 = deepcopy(elbo_vars_array[1].elbo);
 
-  @test_approx_eq elbo_lik_tiles.v[1] elbo_lik_tiles2.v
+  @test_approx_eq elbo_lik_tiles.v[1] elbo_lik_tiles2.v[1]
   @test_approx_eq_eps elbo_lik.v[1] elbo_lik_tiles.v[1] 100.
 
 end
@@ -390,7 +390,7 @@ function test_elbo_with_nan()
 
     # We deleted a pixel, so there's reason to expect them to be different,
     # but importantly they're reasonably close and not NaN.
-    @test_approx_eq_eps (nan_elbo.v[1] - initial_elbo.v) / initial_elbo.v[1] 0. 1e-4
+    @test_approx_eq_eps (nan_elbo.v[1] - initial_elbo.v[1]) / initial_elbo.v[1] 0. 1e-4
     deriv_rel_err = (nan_elbo.d - initial_elbo.d) ./ initial_elbo.d
     @test_approx_eq_eps deriv_rel_err fill(0., length(mp.vp[1])) 0.05
 end

--- a/test/test_elbo_values.jl
+++ b/test/test_elbo_values.jl
@@ -318,12 +318,16 @@ function test_tiny_image_tiling()
   # These will be reused for all the subsequent tests because only
   # the tile sources change.
   if ElboDeriv.Threaded
-    elbo_vars_array = [ ElboDeriv.ElboIntermediateVariables(Float64, mp0.S,
+    elbo_vars_array =
+    ElboDeriv.ElboIntermediateVariables{Float64}[
+      ElboDeriv.ElboIntermediateVariables(Float64, mp0.S,
         length(mp0.active_sources), calculate_derivs=false)
       for i in 1:nthreads() ]
   else
-    elbo_vars_array = [ ElboDeriv.ElboIntermediateVariables(Float64, mp0.S,
-        length(mp0.active_sources), calculate_derivs=false) ]
+    elbo_vars_array =
+      ElboDeriv.ElboIntermediateVariables{Float64}[
+        ElboDeriv.ElboIntermediateVariables(Float64, mp0.S,
+          length(mp0.active_sources), calculate_derivs=false) ]
   end
   sbs = ElboDeriv.load_source_brightnesses(mp0, calculate_derivs=false);
   ElboDeriv.elbo_likelihood!(elbo_vars_array, tiled_blob0[3], mp0, 3, sbs);

--- a/test/test_elbo_values.jl
+++ b/test/test_elbo_values.jl
@@ -116,7 +116,7 @@ function test_that_variance_is_low()
     ElboDeriv.get_expected_pixel_brightness!(
       elbo_vars, h, w, sbs, star_mcs, gal_mcs, tile, mp, tile_sources);
 
-    @test 0 < elbo_vars.var_G.v < 1e-2 * elbo_vars.E_G.v^2
+    @test 0 < elbo_vars.var_G.v[1] < 1e-2 * elbo_vars.E_G.v^2
 end
 
 
@@ -128,7 +128,7 @@ function test_that_star_truth_is_most_likely()
         mp_a = deepcopy(mp)
         mp_a.vp[1][ids.a] = [ 1.0 - bad_a, bad_a ]
         bad_a_lik = ElboDeriv.elbo_likelihood(tiled_blob, mp_a)
-        @test best.v > bad_a_lik.v
+        @test best.v[1] > bad_a_lik.v
     end
 
     for h2 in -2:2
@@ -137,7 +137,7 @@ function test_that_star_truth_is_most_likely()
                 mp_mu = deepcopy(mp)
                 mp_mu.vp[1][ids.u] += [h2 * .5, w2 * .5]
                 bad_mu = ElboDeriv.elbo_likelihood(tiled_blob, mp_mu)
-                @test best.v > bad_mu.v
+                @test best.v[1] > bad_mu.v
             end
         end
     end
@@ -146,7 +146,7 @@ function test_that_star_truth_is_most_likely()
         mp_r1 = deepcopy(mp)
         mp_r1.vp[1][ids.r1] += log(delta)
         bad_r1 = ElboDeriv.elbo_likelihood(tiled_blob, mp_r1)
-        @test best.v > bad_r1.v
+        @test best.v[1] > bad_r1.v
     end
 
     for b in 1:4
@@ -154,7 +154,7 @@ function test_that_star_truth_is_most_likely()
             mp_c1 = deepcopy(mp)
             mp_c1.vp[1][ids.c1[b, 1]] += delta
             bad_c1 = ElboDeriv.elbo_likelihood(tiled_blob, mp_c1)
-            @test best.v > bad_c1.v
+            @test best.v[1] > bad_c1.v
         end
     end
 
@@ -171,7 +171,7 @@ function test_that_galaxy_truth_is_most_likely()
         mp_a.vp[1][ids.a] = [ 1.0 - bad_a, bad_a ];
         bad_a =
           ElboDeriv.elbo_likelihood(tiled_blob, mp_a; calculate_derivs=false);
-        @test best.v > bad_a.v;
+        @test best.v[1] > bad_a.v;
     end
 
     for h2 in -2:2
@@ -181,7 +181,7 @@ function test_that_galaxy_truth_is_most_likely()
                 mp_mu.vp[1][ids.u] += [h2 * .5, w2 * .5]
                 bad_mu = ElboDeriv.elbo_likelihood(
                   tiled_blob, mp_mu; calculate_derivs=false)
-                @test best.v > bad_mu.v
+                @test best.v[1] > bad_mu.v
             end
         end
     end
@@ -191,7 +191,7 @@ function test_that_galaxy_truth_is_most_likely()
         mp_r1.vp[1][ids.r1] += 2 * log(bad_scale)
         bad_r1 = ElboDeriv.elbo_likelihood(
           tiled_blob, mp_r1; calculate_derivs=false)
-        @test best.v > bad_r1.v
+        @test best.v[1] > bad_r1.v
     end
 
     for n in [:e_axis, :e_angle, :e_scale]
@@ -200,7 +200,7 @@ function test_that_galaxy_truth_is_most_likely()
             mp_bad.vp[1][ids.(n)] *= bad_scale
             bad_elbo = ElboDeriv.elbo_likelihood(
               tiled_blob, mp_bad; calculate_derivs=false)
-            @test best.v > bad_elbo.v
+            @test best.v[1] > bad_elbo.v
         end
     end
 
@@ -210,7 +210,7 @@ function test_that_galaxy_truth_is_most_likely()
             mp_c1.vp[1][ids.c1[b, 2]] += delta
             bad_c1 = ElboDeriv.elbo_likelihood(
               tiled_blob, mp_c1; calculate_derivs=false)
-            @test best.v > bad_c1.v
+            @test best.v[1] > bad_c1.v
         end
     end
 end
@@ -251,7 +251,7 @@ function test_coadd_cat_init_is_most_likely()  # on a real stamp
         mp_r1.vp[s][ids.r1] += 2 * log(bad_scale)
         bad_r1 = ElboDeriv.elbo_likelihood(
           tiled_blob, mp_r1; calculate_derivs=false)
-        @test best.v > bad_r1.v
+        @test best.v[1] > bad_r1.v
     end
 
     for n in [:e_axis, :e_angle, :e_scale]
@@ -260,7 +260,7 @@ function test_coadd_cat_init_is_most_likely()  # on a real stamp
             mp_bad.vp[s][ids.(n)] *= bad_scale
             bad_elbo = ElboDeriv.elbo_likelihood(
               tiled_blob, mp_bad; calculate_derivs=false)
-            @test best.v > bad_elbo.v
+            @test best.v[1] > bad_elbo.v
         end
     end
 
@@ -270,7 +270,7 @@ function test_coadd_cat_init_is_most_likely()  # on a real stamp
 
         bad_a = ElboDeriv.elbo_likelihood(
           tiled_blob, mp_a; calculate_derivs=false)
-        @test best.v > bad_a.v
+        @test best.v[1] > bad_a.v
     end
 
     for h2 in -2:2
@@ -280,7 +280,7 @@ function test_coadd_cat_init_is_most_likely()  # on a real stamp
                 mp_mu.vp[s][ids.u] += [0.5h2, 0.5w2]
                 bad_mu = ElboDeriv.elbo_likelihood(
                   tiled_blob, mp_mu; calculate_derivs=false)
-                @test best.v > bad_mu.v
+                @test best.v[1] > bad_mu.v
             end
         end
     end
@@ -292,7 +292,7 @@ function test_coadd_cat_init_is_most_likely()  # on a real stamp
             bad_c1 = ElboDeriv.elbo_likelihood(
               tiled_blob, mp_c1; calculate_derivs=false)
             info("$(best.v)  >  $(bad_c1.v)")
-            @test best.v > bad_c1.v
+            @test best.v[1] > bad_c1.v
         end
     end
 end
@@ -369,8 +369,8 @@ function test_tiny_image_tiling()
   end
   elbo_lik_tiles2 = deepcopy(elbo_vars_array[1].elbo);
 
-  @test_approx_eq elbo_lik_tiles.v elbo_lik_tiles2.v
-  @test_approx_eq_eps elbo_lik.v elbo_lik_tiles.v 100.
+  @test_approx_eq elbo_lik_tiles.v[1] elbo_lik_tiles2.v
+  @test_approx_eq_eps elbo_lik.v[1] elbo_lik_tiles.v[1] 100.
 
 end
 
@@ -390,7 +390,7 @@ function test_elbo_with_nan()
 
     # We deleted a pixel, so there's reason to expect them to be different,
     # but importantly they're reasonably close and not NaN.
-    @test_approx_eq_eps (nan_elbo.v - initial_elbo.v) / initial_elbo.v 0. 1e-4
+    @test_approx_eq_eps (nan_elbo.v[1] - initial_elbo.v) / initial_elbo.v[1] 0. 1e-4
     deriv_rel_err = (nan_elbo.d - initial_elbo.d) ./ initial_elbo.d
     @test_approx_eq_eps deriv_rel_err fill(0., length(mp.vp[1])) 0.05
 end

--- a/test/test_elbo_values.jl
+++ b/test/test_elbo_values.jl
@@ -331,8 +331,8 @@ function test_tiny_image_tiling()
   if ElboDeriv.Threaded
     for i in 2:nthreads()
       CelesteTypes.add_scaled_sfs!(
-        elbo_vars_array[1].elbo, elbo_vars_array[i].elbo,
-        calculate_hessian=elbo_vars_array[1].calculate_hessian &&
+        elbo_vars_array[1].elbo, elbo_vars_array[i].elbo, 1.0,
+        elbo_vars_array[1].calculate_hessian &&
           elbo_vars_array[1].calculate_derivs)
     end
   end
@@ -346,8 +346,8 @@ function test_tiny_image_tiling()
   if ElboDeriv.Threaded
     for i in 2:nthreads()
       CelesteTypes.add_scaled_sfs!(
-        elbo_vars_array[1].elbo, elbo_vars_array[i].elbo,
-        calculate_hessian=elbo_vars_array[1].calculate_hessian &&
+        elbo_vars_array[1].elbo, elbo_vars_array[i].elbo, 1.0,
+        elbo_vars_array[1].calculate_hessian &&
           elbo_vars_array[1].calculate_derivs)
     end
   end
@@ -362,8 +362,8 @@ function test_tiny_image_tiling()
   if ElboDeriv.Threaded
     for i in 2:nthreads()
       CelesteTypes.add_scaled_sfs!(
-        elbo_vars_array[1].elbo, elbo_vars_array[i].elbo,
-        calculate_hessian=elbo_vars_array[1].calculate_hessian &&
+        elbo_vars_array[1].elbo, elbo_vars_array[i].elbo, 1.0,
+        elbo_vars_array[1].calculate_hessian &&
           elbo_vars_array[1].calculate_derivs)
     end
   end

--- a/test/test_images.jl
+++ b/test/test_images.jl
@@ -45,7 +45,7 @@ function test_blob()
         convert(Vector{ASCIIString}, cat_df[:objid])
   tiled_blob, mp =
     ModelInit.initialize_celeste(blob, cat_entries, patch_radius=1e-6,
-                                 fit_psf=false);
+                                 fit_psf=false, tile_width=20);
 
   # Just check some basic facts about the catalog.
   @test size(cat_df)[1] == 805

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -204,11 +204,11 @@ function test_tiling()
 
     mp2 = ModelInit.cat_init(three_bodies, tile_width=10)
     elbo_tiles = ElboDeriv.elbo(blob, mp2)
-    @test_approx_eq_eps elbo_tiles.v elbo.v 1e-5
+    @test_approx_eq_eps elbo_tiles.v[1] elbo.v[1] 1e-5
 
     mp3 = ModelInit.cat_init(three_bodies, patch_radius=30.)
     elbo_patches = ElboDeriv.elbo(blob, mp3)
-    @test_approx_eq_eps elbo_patches.v elbo.v 1e-5
+    @test_approx_eq_eps elbo_patches.v[1] elbo.v[1] 1e-5
 
     for s in 1:mp.S
         for i in 1:length(1:length(CanonicalParams))
@@ -219,7 +219,7 @@ function test_tiling()
 
     mp4 = ModelInit.cat_init(three_bodies, patch_radius=35., tile_width=10)
     elbo_both = ElboDeriv.elbo(blob, mp4)
-    @test_approx_eq_eps elbo_both.v elbo.v 1e-1
+    @test_approx_eq_eps elbo_both.v[1] elbo.v[1] 1e-1
 
     for s in 1:mp.S
         for i in 1:length(1:length(CanonicalParams))

--- a/test/test_optimization.jl
+++ b/test/test_optimization.jl
@@ -94,53 +94,7 @@ function test_objective_wrapper()
     this_iter = wrapper.state.f_evals;
     wrapper.f_value(x[:] + 1.0);
     @test wrapper.state.f_evals == this_iter + 1
-
-    # # Check the AD gradient.
-    # ad_grad = wrapper.f_ad_grad(x[:]);
-    # @test_approx_eq ad_grad[:] w_grad
 end
-
-# function test_objective_hessians()
-#     blob, mp, bodies, tiled_blob = SampleData.gen_three_body_dataset();
-#     # Change the tile size.
-#     tiled_blob, mp = ModelInit.initialize_celeste(
-#       blob, bodies, tile_width=5, fit_psf=false, patch_radius=10.);
-#     mp.active_sources = Int64[2, 3]
-#     trans = Transform.get_mp_transform(mp, loc_width=1.0);
-#     omitted_ids = Int64[];
-#     kept_ids = setdiff(1:length(ids_free), omitted_ids);
-#     x = trans.vp_to_array(mp.vp, omitted_ids);
-#
-#     wrapper =
-#       OptimizeElbo.ObjectiveWrapperFunctions(
-#         mp -> ElboDeriv.elbo(tiled_blob, mp),
-#         mp, trans, kept_ids, omitted_ids);
-#
-#     # Test that the Hessian works in its various flavors.
-#     println("Testing autodiff Hessian...")
-#     w_hess = zeros(Float64, length(x), length(x));
-#     wrapper.f_ad_hessian!(x[:], w_hess);
-#
-#     hess_i, hess_j, hess_val = wrapper.f_ad_hessian_sparse(x[:]);
-#     w_hess_sparse =
-#       OptimizeElbo.unpack_hessian_vals(hess_i, hess_j, hess_val, size(x));
-#     @test_approx_eq(w_hess, full(w_hess_sparse))
-#
-#     println("Testing slow autodiff Hessian...")
-#     wrapper_slow_hess =
-#       OptimizeElbo.ObjectiveWrapperFunctions(
-#         mp -> ElboDeriv.elbo(tiled_blob, mp),
-#         mp, trans, kept_ids, omitted_ids, fast_hessian=false);
-#
-#     slow_w_hess = zeros(Float64, length(x), length(x));
-#     wrapper_slow_hess.f_ad_hessian!(x[:], slow_w_hess);
-#     @test_approx_eq(slow_w_hess, w_hess)
-#
-#     hess_i, hess_j, hess_val = wrapper_slow_hess.f_ad_hessian_sparse(x[:]);
-#     slow_w_hess_sparse =
-#       OptimizeElbo.unpack_hessian_vals(hess_i, hess_j, hess_val, size(x));
-#     @test_approx_eq(slow_w_hess, full(slow_w_hess_sparse))
-# end
 
 
 function test_star_optimization()
@@ -283,7 +237,7 @@ function test_kappa_finding()
       for d in 1:D
           ElboDeriv.subtract_kl_c(d, 2, 1, mp, accum)
       end
-      accum
+      accum.v[1]
     end
 
     mp.vp[1][ids.c1[:,2]] = mp.pp.c_mean[:, 1, 2]

--- a/test/test_optimization.jl
+++ b/test/test_optimization.jl
@@ -84,7 +84,7 @@ function test_objective_wrapper()
     w_grad2 = zeros(Float64, length(x));
     wrapper.f_value_grad!(x[:], w_grad2);
 
-    @test_approx_eq(w_v, elbo_result.v)
+    @test_approx_eq(w_v, elbo_result.v[1])
     @test_approx_eq(w_grad, elbo_grad)
     @test_approx_eq(w_grad, w_grad2)
 
@@ -170,7 +170,7 @@ function test_single_source_optimization()
   f = ElboDeriv.elbo;
   omitted_ids = Int64[]
 
-  ElboDeriv.elbo_likelihood(tiled_blob, mp).v
+  ElboDeriv.elbo_likelihood(tiled_blob, mp).v[1]
 
   OptimizeElbo.maximize_likelihood(tiled_blob, mp, transform, verbose=true)
 
@@ -235,8 +235,8 @@ function test_two_body_optimization_newton()
     sum((bfgs_image .- original_image) .^ 2)
 
     # newton beats bfgs on the elbo, though not on the likelihood.
-    elbo_function(tiled_blob, mp_bfgs).v
-    elbo_function(tiled_blob, mp_newton).v
+    elbo_function(tiled_blob, mp_bfgs).v[1]
+    elbo_function(tiled_blob, mp_newton).v[1]
 end
 
 
@@ -259,7 +259,7 @@ function test_kappa_finding()
         for d in 1:D
             ElboDeriv.subtract_kl_c(d, 2, 1, mp, accum)
         end
-        -accum.v
+        -accum.v[1]
     end
 
     mp.vp[1][ids.k[:, 2]] = [0.01, 0.99]
@@ -356,7 +356,7 @@ function test_bad_a_init()
     elbo_true2 = ElboDeriv.elbo_likelihood(tiled_blob, mp2)
     mp2.vp[1][ids.a] = [ 0.99, 0.01 ]
     elbo_bad2 = ElboDeriv.elbo_likelihood(tiled_blob, mp2)
-    @test elbo_true2.v[1] > elbo_bad2.v
+    @test elbo_true2.v[1] > elbo_bad2.v[1]
     @test elbo_bad2.d[ids.a[2], 1] > 0
 end
 

--- a/test/test_optimization.jl
+++ b/test/test_optimization.jl
@@ -356,7 +356,7 @@ function test_bad_a_init()
     elbo_true2 = ElboDeriv.elbo_likelihood(tiled_blob, mp2)
     mp2.vp[1][ids.a] = [ 0.99, 0.01 ]
     elbo_bad2 = ElboDeriv.elbo_likelihood(tiled_blob, mp2)
-    @test elbo_true2.v > elbo_bad2.v
+    @test elbo_true2.v[1] > elbo_bad2.v
     @test elbo_bad2.d[ids.a[2], 1] > 0
 end
 
@@ -425,7 +425,7 @@ function test_quadratic_optimization()
           unused_blob::TiledBlob, mp::ModelParams{NumType})
 
         val = zero_sensitive_float(CanonicalParams, NumType)
-        val.v = -sum((mp.vp[1] - centers) .^ 2)
+        val.v[1] = -sum((mp.vp[1] - centers) .^ 2)
         val.d[:] = -2.0 * (mp.vp[1] - centers)
         val.h[:, :] = diagm(fill(-2.0, length(CanonicalParams)))
         val
@@ -450,7 +450,7 @@ function test_quadratic_optimization()
         xtol_rel=1e-16, ftol_abs=1e-16)
 
     @test_approx_eq_eps mp.vp[1] centers 1e-6
-    @test_approx_eq_eps quadratic_function(unused_blob, mp).v 0.0 1e-15
+    @test_approx_eq_eps quadratic_function(unused_blob, mp).v[1] 0.0 1e-15
 end
 
 ####################################################

--- a/test/test_sensitive_float.jl
+++ b/test/test_sensitive_float.jl
@@ -143,7 +143,7 @@ function test_combine_sfs()
   sf1 = deepcopy(ret1);
   sf2 = deepcopy(ret2);
   g_d, g_h = combine_fun_derivatives(x)
-  CelesteTypes.combine_sfs!(sf1, sf2, sf1.v[1] ^ 2 * sqrt(sf2.v), g_d, g_h);
+  CelesteTypes.combine_sfs!(sf1, sf2, sf1.v[1] ^ 2 * sqrt(sf2.v[1]), g_d, g_h);
 
   @test_approx_eq sf1.v[1] v
   @test_approx_eq sf1.d[:] grad

--- a/test/test_sensitive_float.jl
+++ b/test/test_sensitive_float.jl
@@ -5,44 +5,6 @@ using CelesteTypes
 using Compat
 
 
-# function test_add_sensitive_floats()
-#   # TODO: test the new Hessian functionality
-#
-#   S = 3
-#   function generate_random_sf()
-#       sf1 = zero_sensitive_float(CanonicalParams, Float64, S)
-#       sf1.v[1] = rand()
-#       sf1.d = rand(size(sf1.d))
-#       sf1.h = rand(size(sf1.h))
-#       sf1
-#   end
-#
-#   sf1 = generate_random_sf();
-#   sf2 = generate_random_sf();
-#
-#   sf3 = sf1 + sf2
-#   @test sf3.v[1] == sf1.v[1] + sf2.v
-#   @test sf3.d == sf1.d + sf2.d
-#   @test sf3.h == sf1.h + sf2.h
-#
-#   sf_bad_size = zero_sensitive_float(CanonicalParams, Float64, S + 1);
-#   sf_bad_type = zero_sensitive_float(UnconstrainedParams, Float64, S);
-#
-#   @test_throws AssertionError sf_bad_size + sf1
-#   @test_throws AssertionError sf_bad_type + sf1
-#
-#   function sf_equal(sf1::SensitiveFloat, sf2::SensitiveFloat)
-#     sf1.v[1] == sf2.v[1] && sf2.d == sf2.d && sf1.h == sf2.h
-#   end
-#
-#   # Check that recursive summing works.
-#   sf_vector = [ generate_random_sf() for i=1:3 ]
-#   @test sf_equal(sum(sf_vector), reduce(+, sf_vector))
-#   @test sf_equal(sum(sf_vector), sf_vector[1] + sf_vector[2] + sf_vector[3])
-#
-# end
-
-
 function test_combine_sfs()
   # TODO: this test was designed for multiply_sf.  Make it more general.
 
@@ -176,20 +138,20 @@ function test_add_sources_sf()
   function f1{NumType <: Number}(x::Vector{NumType})
     sf_local = zero_sensitive_float(CanonicalParams, NumType, 1);
     scaled_exp!(sf_local, x, a1)
-    sf_local.v
+    sf_local.v[1]
   end
 
   a2 = rand(P);
   function f2{NumType <: Number}(x::Vector{NumType})
     sf_local = zero_sensitive_float(CanonicalParams, NumType, 1);
     scaled_exp!(sf_local, x, a2)
-    sf_local.v
+    sf_local.v[1]
   end
 
   x1 = rand(P);
   clear!(sf_s);
   scaled_exp!(sf_s, x1, a1);
-  v1 = sf_s.v
+  v1 = sf_s.v[1]
 
   fd_grad1 = ForwardDiff.gradient(f1, x1);
   @test_approx_eq sf_s.d fd_grad1
@@ -197,7 +159,7 @@ function test_add_sources_sf()
   fd_hess1 = ForwardDiff.hessian(f1, x1);
   @test_approx_eq sf_s.h fd_hess1
 
-  CelesteTypes.add_sources_sf!(sf_all, sf_s, 1)
+  CelesteTypes.add_sources_sf!(sf_all, sf_s, 1, true)
 
   x2 = rand(P);
   clear!(sf_s);
@@ -210,7 +172,7 @@ function test_add_sources_sf()
   fd_hess2 = ForwardDiff.hessian(f2, x2);
   @test_approx_eq sf_s.h fd_hess2
 
-  CelesteTypes.add_sources_sf!(sf_all, sf_s, 2)
+  CelesteTypes.add_sources_sf!(sf_all, sf_s, 2, true)
 
   @test_approx_eq (v1 + v2) sf_all.v
 
@@ -225,5 +187,4 @@ end
 
 
 test_combine_sfs()
-# test_add_sensitive_floats()
 test_add_sources_sf()

--- a/test/test_sensitive_float.jl
+++ b/test/test_sensitive_float.jl
@@ -11,7 +11,7 @@ using Compat
 #   S = 3
 #   function generate_random_sf()
 #       sf1 = zero_sensitive_float(CanonicalParams, Float64, S)
-#       sf1.v = rand()
+#       sf1.v[1] = rand()
 #       sf1.d = rand(size(sf1.d))
 #       sf1.h = rand(size(sf1.h))
 #       sf1
@@ -21,7 +21,7 @@ using Compat
 #   sf2 = generate_random_sf();
 #
 #   sf3 = sf1 + sf2
-#   @test sf3.v == sf1.v + sf2.v
+#   @test sf3.v[1] == sf1.v[1] + sf2.v
 #   @test sf3.d == sf1.d + sf2.d
 #   @test sf3.h == sf1.h + sf2.h
 #
@@ -32,7 +32,7 @@ using Compat
 #   @test_throws AssertionError sf_bad_type + sf1
 #
 #   function sf_equal(sf1::SensitiveFloat, sf2::SensitiveFloat)
-#     sf1.v == sf2.v && sf2.d == sf2.d && sf1.h == sf2.h
+#     sf1.v[1] == sf2.v[1] && sf2.d == sf2.d && sf1.h == sf2.h
 #   end
 #
 #   # Check that recursive summing works.
@@ -104,7 +104,7 @@ function test_combine_sfs()
   s_ind[2] = (1:p) + p
 
   ret1 = zero_sensitive_float(CanonicalParams, Float64, S);
-  ret1.v = base_fun1(x)
+  ret1.v[1] = base_fun1(x)
   fill!(ret1.d, 0.0);
   fill!(ret1.h, 0.0);
   for s=1:S
@@ -113,7 +113,7 @@ function test_combine_sfs()
   end
 
   ret2 = zero_sensitive_float(CanonicalParams, Float64, S);
-  ret2.v = base_fun2(x)
+  ret2.v[1] = base_fun2(x)
   fill!(ret2.d, 0.0);
   fill!(ret2.h, 0.0);
   for s=1:S
@@ -143,9 +143,9 @@ function test_combine_sfs()
   sf1 = deepcopy(ret1);
   sf2 = deepcopy(ret2);
   g_d, g_h = combine_fun_derivatives(x)
-  CelesteTypes.combine_sfs!(sf1, sf2, sf1.v ^ 2 * sqrt(sf2.v), g_d, g_h);
+  CelesteTypes.combine_sfs!(sf1, sf2, sf1.v[1] ^ 2 * sqrt(sf2.v), g_d, g_h);
 
-  @test_approx_eq sf1.v v
+  @test_approx_eq sf1.v[1] v
   @test_approx_eq sf1.d[:] grad
   @test_approx_eq sf1.h hess
 end
@@ -162,13 +162,13 @@ function test_add_sources_sf()
       sf::SensitiveFloat{CanonicalParams, NumType},
       x::Vector{NumType}, a::Vector{Float64})
 
-    sf.v = one(NumType)
+    sf.v[1] = one(NumType)
     for p in 1:P
-      sf.v *= exp(sum(x[p] * a[p]))
+      sf.v[1] *= exp(sum(x[p] * a[p]))
     end
     if NumType == Float64
-      sf.d[:, 1] = sf.v * a
-      sf.h[:, :] = sf.v * (a * a')
+      sf.d[:, 1] = sf.v[1] * a
+      sf.h[:, :] = sf.v[1] * (a * a')
     end
   end
 

--- a/test/test_transforms.jl
+++ b/test/test_transforms.jl
@@ -33,7 +33,7 @@ function test_transform_sensitive_float()
 		mp_local = CelesteTypes.forward_diff_model_params(NumType, mp);
 		transform.to_vp!(vp_free, mp_local.vp)
 		elbo = ElboDeriv.elbo(tiled_blob, mp_local, calculate_derivs=false)
-		elbo.v
+		elbo.v[1]
 	end
 
 	transform = Transform.get_mp_transform(mp, loc_width=1.0);

--- a/test/test_transforms.jl
+++ b/test/test_transforms.jl
@@ -252,7 +252,7 @@ function test_identity_transform()
 	sf = zero_sensitive_float(CanonicalParams, Float64, mp.S);
 	sf.d = rand(length(ids), mp.S)
 	sf_new = transform.transform_sensitive_float(sf, mp);
-	@test_approx_eq sf_new.v sf.v
+	@test_approx_eq sf_new.v[1] sf.v
 	@test_approx_eq sf_new.d sf.d
 	[ @test_approx_eq sf_new.h[s] sf.h[s] for s=1:mp.S]
 end


### PR DESCRIPTION
The likelihood now allocates very close to zero memory after initialization.  On a single source in the benchmark script, this gives about a 1.4x speedup.  Without the Hessian, it's about about a 2x speedup.  That probably gets this back up to the speed of the original on the gradient-only calculations (though Kyle's changes have broken the pre-Hessian tag and I haven't actually checked yet).

I haven't carefully investigated the issue of scaling, yet.  But I want to make this pull request before my flight to MX leaves and I'm away for the weekend!

Tests pass on my machine, still waiting for Travis.
