### PR TITLE
fixes issue 126 by changing the bounding box in transform to accomoda…

### DIFF
--- a/src/Transform.jl
+++ b/src/Transform.jl
@@ -781,7 +781,7 @@ function get_mp_transform(mp::ModelParams; loc_width::Float64=1.5e-3)
     bounds[si][:r1] = Array(ParamBox, Ia)
     bounds[si][:r2] = Array(ParamBox, Ia)
     for i in 1:Ia
-      bounds[si][:r1][i] = ParamBox(-1.0, 10., 1.0)
+      bounds[si][:r1][i] = ParamBox(-3.0, 10., 1.0)
       bounds[si][:r2][i] = ParamBox(1e-4, 0.1, 1.0)
     end
     bounds[si][:c1] = Array(ParamBox, 4 * Ia)


### PR DESCRIPTION
fixes #126 by changing the bounding box for r1 (the scale parameter) in Transform.jl to include all values reasonable for a log normal distribution of brightnesses
