### PR TITLE
Support julia 0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ os:
   - linux
 julia:
   - 0.4
+  - nightly
 notifications:
   email: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,12 @@ before_install:
 
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+  - julia -e 'if VERSION >= v"0.5.0-dev"
+        Pkg.checkout("Optim")
+        Pkg.checkout("DataFrames")
+        Pkg.rm("GaussianMixtures")
+        Pkg.clone("https://github.com/jeff-regier/GaussianMixtures.jl.git")
+    end'
   - julia -e 'Pkg.clone(pwd()); Pkg.build("Celeste")'
   - julia -e 'Pkg.test("Celeste"; coverage=(VERSION < v"0.4"))'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_install:
 
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+  - julia -e 'Pkg.clone(pwd()); Pkg.build("Celeste")'
   - julia -e 'if VERSION >= v"0.5.0-dev"
         Pkg.checkout("Optim");
         Pkg.checkout("DataFrames");
@@ -20,7 +21,6 @@ script:
         Pkg.rm("GaussianMixtures");
         Pkg.clone("https://github.com/jeff-regier/GaussianMixtures.jl.git");
     end'
-  - julia -e 'Pkg.clone(pwd()); Pkg.build("Celeste")'
   - julia -e 'Pkg.test("Celeste"; coverage=(VERSION < v"0.4"))'
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,11 @@ before_install:
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - julia -e 'if VERSION >= v"0.5.0-dev"
-        Pkg.checkout("Optim")
-        Pkg.checkout("DataFrames")
-        Pkg.rm("GaussianMixtures")
-        Pkg.clone("https://github.com/jeff-regier/GaussianMixtures.jl.git")
+        Pkg.checkout("Optim");
+        Pkg.checkout("DataFrames");
+        Pkg.rm("GaussianMixtures");
+        Pkg.rm("GaussianMixtures");
+        Pkg.clone("https://github.com/jeff-regier/GaussianMixtures.jl.git");
     end'
   - julia -e 'Pkg.clone(pwd()); Pkg.build("Celeste")'
   - julia -e 'Pkg.test("Celeste"; coverage=(VERSION < v"0.4"))'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,5 @@
 julia 0.4
+Compat
 DataFrames
 Distributions
 DocOpt

--- a/src/ModelInit.jl
+++ b/src/ModelInit.jl
@@ -464,7 +464,7 @@ function limit_to_object_data(
   # Get the sources that overlap with this object.
   relevant_sources = Int[]
   for b = 1:length(blob), tile_sources in mp.tile_sources[b]
-    if s_original in tile_sources > 0
+    if s_original in tile_sources
       relevant_sources = union(relevant_sources, tile_sources);
     end
   end

--- a/src/Transform.jl
+++ b/src/Transform.jl
@@ -9,6 +9,7 @@ export DataTransform, ParamBounds, ParamBox, SimplexBox,
        get_mp_transform, generate_valid_parameters, enforce_bounds!
 
 
+
 ################################
 # Elementary functions.
 

--- a/src/elbo_kl.jl
+++ b/src/elbo_kl.jl
@@ -72,9 +72,10 @@ function subtract_kl!{NumType <: Number}(
     mp::ModelParams{NumType}, accum::SensitiveFloat{CanonicalParams, NumType};
     calculate_derivs::Bool=true, calculate_hessian::Bool=true)
 
+
   # The KL divergence as a function of the active source variational parameters.
-  function subtract_kl_value_wrapper{NumType <: Number}(vp_vec::Vector{NumType})
-    elbo_val = zero(NumType)
+  function subtract_kl_value_wrapper{NumType2 <: Number}(vp_vec::Vector{NumType2})
+    elbo_val = zero(NumType2)
     vp_active = reshape(vp_vec, length(CanonicalParams), length(mp.active_sources))
     for sa in 1:length(mp.active_sources)
       vs = vp_active[:, sa]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,12 +1,5 @@
 #!/usr/bin/env julia
 
-if VERSION > v"0.5.0-dev"
-    Pkg.checkout("Optim")
-    Pkg.checkout("DataFrames")
-    Pkg.rm("GaussianMixtures")
-    Pkg.clone("https://github.com/jeff-regier/GaussianMixtures.jl.git")
-end
-
 using Celeste: Types, SampleData, Transform
 import Celeste.Synthetic
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,12 @@
 #!/usr/bin/env julia
 
+if VERSION > v"0.5.0-dev"
+    Pkg.checkout("Optim")
+    Pkg.checkout("DataFrames")
+    Pkg.rm("GaussianMixtures")
+    Pkg.clone("https://github.com/jeff-regier/GaussianMixtures.jl.git")
+end
+
 using Celeste: Types, SampleData, Transform
 import Celeste.Synthetic
 

--- a/test/test_derivatives.jl
+++ b/test/test_derivatives.jl
@@ -16,6 +16,9 @@ else
     end
 end
 
+const datadir = joinpath(Pkg.dir("Celeste"), "test", "data")
+
+
 println("Running hessian tests.")
 
 

--- a/test/test_derivatives.jl
+++ b/test/test_derivatives.jl
@@ -16,8 +16,6 @@ else
     end
 end
 
-const datadir = joinpath(Pkg.dir("Celeste"), "test", "data")
-
 
 println("Running hessian tests.")
 

--- a/test/test_elbo_values.jl
+++ b/test/test_elbo_values.jl
@@ -219,9 +219,9 @@ end
 
 function test_coadd_cat_init_is_most_likely()  # on a real stamp
     stamp_id = "5.0073-0.0739"
-    blob = SkyImages.load_stamp_blob(dat_dir, stamp_id);
+    blob = SkyImages.load_stamp_blob(datadir, stamp_id);
 
-    cat_entries = SkyImages.load_stamp_catalog(dat_dir, "s82-$stamp_id", blob);
+    cat_entries = SkyImages.load_stamp_catalog(datadir, "s82-$stamp_id", blob);
     bright(ce) = sum(ce.star_fluxes) > 3 || sum(ce.gal_fluxes) > 3
     cat_entries = filter(bright, cat_entries)
 
@@ -303,7 +303,7 @@ function test_tiny_image_tiling()
   # Test that the tilling doesn't matter much for a body that is nearly a
   # point with a narrow psf.
 
-  blob0 = SkyImages.load_stamp_blob(dat_dir, "164.4311-39.0359");
+  blob0 = SkyImages.load_stamp_blob(datadir, "164.4311-39.0359");
   pc = PsfComponent(1./3, zeros(2), 1e-4 * eye(2))
   trivial_psf = [pc, pc, pc]
   pixels = ones(100, 1) * 12

--- a/test/test_images.jl
+++ b/test/test_images.jl
@@ -4,12 +4,14 @@ using DataFrames
 import SloanDigitalSkySurvey: SDSS, WCSUtils, PSF
 
 using Celeste: Types, SampleData
-import Celeste: ModelInit, SkyImages, ElboDeriv
+import Celeste: ModelInit, SkyImages, ElboDeriv, Synthetic
 
 
 println("Running SkyImages tests.")
 
-field_dir = joinpath(dat_dir, "sample_field")
+const datadir = joinpath(Pkg.dir("Celeste"), "test", "data")
+
+field_dir = joinpath(datadir, "sample_field")
 run_num = "003900"
 camcol_num = "6"
 field_num = "0269"
@@ -191,7 +193,7 @@ function test_set_patch_size()
   end
 
   srand(1)
-  blob0 = SkyImages.load_stamp_blob(dat_dir, "164.4311-39.0359");
+  blob0 = SkyImages.load_stamp_blob(datadir, "164.4311-39.0359");
   img_size = 150
   for b in 1:5
       blob0[b].H, blob0[b].W = img_size, img_size

--- a/test/test_images.jl
+++ b/test/test_images.jl
@@ -9,12 +9,10 @@ import Celeste: ModelInit, SkyImages, ElboDeriv, Synthetic
 
 println("Running SkyImages tests.")
 
-const datadir = joinpath(Pkg.dir("Celeste"), "test", "data")
 
-field_dir = joinpath(datadir, "sample_field")
-run_num = "003900"
-camcol_num = "6"
-field_num = "0269"
+const run_num = "003900"
+const camcol_num = "6"
+const field_num = "0269"
 
 function test_interp_sky()
     data = [1.  2.  3.  4.;

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -3,7 +3,7 @@ using Base.Test
 import SloanDigitalSkySurvey: SDSS, WCSUtils
 
 using Celeste: Types, SampleData
-import Celeste: SkyImages, Util, ModelInit
+import Celeste: SkyImages, Util, ModelInit, Synthetic
 
 
 println("Running misc tests.")

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -54,7 +54,7 @@ function test_local_sources()
     # Coarse test that local_sources gets the right objects.
 
     srand(1)
-    blob0 = SkyImages.load_stamp_blob(dat_dir, "164.4311-39.0359");
+    blob0 = SkyImages.load_stamp_blob(datadir, "164.4311-39.0359");
     for b in 1:5
         blob0[b].H, blob0[b].W = 112, 238
         blob0[b].wcs = WCSUtils.wcs_id
@@ -102,7 +102,7 @@ function test_local_sources_2()
     # the polygon logic.)
 
     srand(1)
-    blob0 = SkyImages.load_stamp_blob(dat_dir, "164.4311-39.0359");
+    blob0 = SkyImages.load_stamp_blob(datadir, "164.4311-39.0359");
     one_body = [sample_ce([50., 50.], true),]
     for b in 1:5 blob0[b].wcs = WCSUtils.wcs_id end
 
@@ -132,7 +132,7 @@ function test_local_sources_3()
     srand(1)
     test_b = 3 # Will test using this band only
     pix_loc = Float64[50., 50.]
-    blob0 = SkyImages.load_stamp_blob(dat_dir, "164.4311-39.0359");
+    blob0 = SkyImages.load_stamp_blob(datadir, "164.4311-39.0359");
     body_loc = WCSUtils.pix_to_world(blob0[test_b].wcs, pix_loc)
     one_body = [sample_ce(body_loc, true),]
 
@@ -185,7 +185,7 @@ end
 
 function test_tiling()
     srand(1)
-    blob0 =SkyImages.load_stamp_blob(dat_dir, "164.4311-39.0359")
+    blob0 =SkyImages.load_stamp_blob(datadir, "164.4311-39.0359")
     for b in 1:5
         blob0[b].H, blob0[b].W = 112, 238
     end
@@ -229,7 +229,7 @@ end
 function test_sky_noise_estimates()
     blobs = Array(Blob, 2)
     blobs[1], mp, three_bodies = gen_three_body_dataset()  # synthetic
-    blobs[2] = SkyImages.load_stamp_blob(dat_dir, "164.4311-39.0359")  # real
+    blobs[2] = SkyImages.load_stamp_blob(datadir, "164.4311-39.0359")  # real
 
     for blob in blobs
         for b in 1:5

--- a/test/test_optimization.jl
+++ b/test/test_optimization.jl
@@ -272,7 +272,7 @@ function test_bad_a_init()
     ce = CatalogEntry([7.2, 8.3], false, gal_color_mode, gal_color_mode,
             0.5, .7, pi/4, .5, "test")
 
-    blob0 = SkyImages.load_stamp_blob(dat_dir, "164.4311-39.0359");
+    blob0 = SkyImages.load_stamp_blob(datadir, "164.4311-39.0359");
     for b in 1:5
         blob0[b].H, blob0[b].W = 20, 23
         blob0[b].wcs = WCSUtils.wcs_id
@@ -321,8 +321,8 @@ end
 
 
 function test_real_stamp_optimization()
-    blob = SkyImages.load_stamp_blob(dat_dir, "5.0073-0.0739");
-    cat_entries = SkyImages.load_stamp_catalog(dat_dir, "s82-5.0073-0.0739", blob);
+    blob = SkyImages.load_stamp_blob(datadir, "5.0073-0.0739");
+    cat_entries = SkyImages.load_stamp_catalog(datadir, "s82-5.0073-0.0739", blob);
     bright(ce) = sum(ce.star_fluxes) > 3 || sum(ce.gal_fluxes) > 3
     cat_entries = filter(bright, cat_entries);
     inbounds(ce) = ce.pos[1] > -10. && ce.pos[2] > -10 &&

--- a/test/test_transforms.jl
+++ b/test/test_transforms.jl
@@ -5,7 +5,7 @@ using Base.Test
 
 using Celeste: Types, SampleData, Transform, SensitiveFloats
 import Celeste: ModelInit, ElboDeriv
-
+using Compat
 
 function test_transform_sensitive_float()
 	blob, mp, body, tiled_blob = gen_two_body_dataset();
@@ -280,13 +280,13 @@ function test_transform_simplex_functions()
 			this_scale * Transform.unsimplexify_parameter(param, unscaled_simplex_box))
 
 		# Test the bound checking
-		@test_throws(Exception,
+		@test_throws(AssertionError,
 			Transform.unsimplexify_parameter([ lb - 1e-6, 1 - lb + 1e-6 ], simplex_box))
-		@test_throws(Exception,
+		@test_throws(AssertionError,
 			Transform.unsimplexify_parameter([ 0.3, 0.8 ], simplex_box))
-		@test_throws(Exception,
+		@test_throws(AssertionError,
 			Transform.unsimplexify_parameter([ 0.2, 0.3, 0.5 ], simplex_box))
-		@test_throws(Exception, Transform.simplexify_parameter([ 1., 2. ], simplex_box))
+		@test_throws(AssertionError, Transform.simplexify_parameter([ 1., 2. ], simplex_box))
 	end
 end
 
@@ -315,9 +315,9 @@ function test_transform_box_functions()
 			this_scale * Transform.unbox_parameter(param, unscaled_param_box))
 
 		# Test the bound checking
-		@test_throws Exception Transform.unbox_parameter(lb - 1.0, param_box)
+		@test_throws AssertionError Transform.unbox_parameter(lb - 1.0, param_box)
 		ub < Inf &&
-			@test_throws Exception Transform.unbox_parameter(ub + 1.0, param_box)
+			@test_throws AssertionError Transform.unbox_parameter(ub + 1.0, param_box)
 	end
 end
 
@@ -361,7 +361,7 @@ function test_enforce_bounds()
 	mp.vp[2][ids.r1[2]] = transform.bounds[2][:r1][1].upper_bound + 1.0
 	mp.vp[3][ids.k[1, 1]] = transform.bounds[3][:k][1, 1].lower_bound - 0.00001
 
-	@test_throws Exception transform.from_vp(mp.vp)
+	@test_throws AssertionError transform.from_vp(mp.vp)
 	Transform.enforce_bounds!(mp, transform)
 	transform.from_vp(mp.vp) # Check that it now works
 
@@ -375,15 +375,15 @@ function test_enforce_bounds()
 	mp.vp[sa][ids.r1[2]] = transform.bounds[1][:r1][1].upper_bound + 1.0
 	mp.vp[sa][ids.k[1, 1]] = transform.bounds[1][:k][1, 1].lower_bound - 0.00001
 
-	@test_throws Exception transform.from_vp(mp.vp)
+	@test_throws AssertionError transform.from_vp(mp.vp)
 	Transform.enforce_bounds!(mp, transform)
 	transform.from_vp(mp.vp) # Check that it now works
 
 end
 
 
-test_transform_sensitive_float()
 test_transform_box_functions()
+test_transform_sensitive_float()
 test_box_derivatives()
 test_box_simplex_derivatives()
 test_simplex_derivatives()


### PR DESCRIPTION
This PR turns on travis testing for Julia nightly, and makes the tests pass. It isn't always pretty:
- `runtests.jl` checks out `Optim.jl` master and `DataFrames.jl` master
- I forked `GaussianProcesses.jl` and fixed just enough of it. `runtests.jl` clones the fork.
- `JLD.jl` doesn't work yet, though it may soon: JuliaLang/JLD.jl#57  This doesn't stop the tests because the JLD stuff is all in bin.

Still, I'd say the PR closes #118 
