### PR TITLE
store patch radius in pixels in SkyPatch in initialization

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -327,7 +327,7 @@ celestial object in a single image.
 Attributes:
   - center: The approximate source location in world coordinates
   - radius: The width of the influence of the object in world coordinates
-
+  - radius_pix: The width of the influence of the object in pixel coordinates
   - psf: The point spread function in this region of the sky
   - wcs_jacobian: The jacobian of the WCS transform in this region of the
                   sky for each band
@@ -336,6 +336,7 @@ Attributes:
 immutable SkyPatch
     center::Vector{Float64}
     radius::Float64
+    radius_pix::Float64
 
     psf::Vector{PsfComponent}
     wcs_jacobian::Matrix{Float64}

--- a/test/test_images.jl
+++ b/test/test_images.jl
@@ -53,9 +53,9 @@ function test_blob()
     @test 2 * width <= cropped_blob[b][1].h_width <= 2 * (width + 1)
     @test 2 * width <= cropped_blob[b][1].w_width <= 2 * (width + 1)
     patches = vec(mp.patches[:, b])
-    tile_sources =
-      ModelInit.get_local_sources(cropped_blob[b][1], patch_ctrs_pix(patches),
-                                  patch_radii_pix(patches, blob[b]))
+    tile_sources = ModelInit.get_local_sources(cropped_blob[b][1],
+                                               patch_ctrs_pix(patches),
+                                               patch_radii_pix(patches))
     @test obj_index in tile_sources
   end
 
@@ -119,8 +119,9 @@ function test_get_tiled_image_source()
       mp.patches[1, b] = SkyPatch(loc, 1e-6, blob[b], fit_psf=false)
     end
     patches = vec(mp.patches[:, 3])
-    local_sources = ModelInit.get_tiled_image_sources(
-      tiled_img, patch_ctrs_pix(patches), patch_radii_pix(patches, img))
+    local_sources = ModelInit.get_tiled_image_sources(tiled_img,
+                                                      patch_ctrs_pix(patches),
+                                                      patch_radii_pix(patches))
     @test local_sources[hh, ww] == Int[1]
     for hh2 in 1:size(tiled_img)[1], ww2 in 1:size(tiled_img)[2]
       if (hh2 != hh) || (ww2 != ww)
@@ -142,14 +143,14 @@ function test_local_source_candidate()
     # Get the sources by iterating over everything.
     patches = vec(mp.patches[:,b])
       
-    tile_sources = ModelInit.get_tiled_image_sources(
-      tiled_blob[b], patch_ctrs_pix(patches),
-      patch_radii_pix(patches, blob[b]))
+    tile_sources = ModelInit.get_tiled_image_sources(tiled_blob[b],
+                                                     patch_ctrs_pix(patches),
+                                                     patch_radii_pix(patches))
 
     # Get a set of candidates.
-    candidates = ModelInit.local_source_candidates(
-      tiled_blob[b], patch_ctrs_pix(patches),
-      patch_radii_pix(patches, blob[b]))
+    candidates = ModelInit.local_source_candidates(tiled_blob[b],
+                                                   patch_ctrs_pix(patches),
+                                                   patch_radii_pix(patches))
 
     # Check that all the actual sources are candidates and that this is the
     # same as what is returned by initialize_model_params.

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -74,9 +74,8 @@ function test_local_sources()
     @test mp.S == 3
 
     patches = vec(mp.patches[:, 3])
-    subset1000 = ModelInit.get_local_sources(
-      tile, patch_ctrs_pix(patches),
-      patch_radii_pix(patches, blob[3]))
+    subset1000 = ModelInit.get_local_sources(tile, patch_ctrs_pix(patches),
+                                             patch_radii_pix(patches))
     @test subset1000 == [1,2,3]
 
     tile_width = 10
@@ -85,9 +84,8 @@ function test_local_sources()
       fill(fill(tile, 1, 1), 5), blob, three_bodies; patch_radius=20.);
 
     patches = vec(mp.patches[:, 3])
-    subset10 = ModelInit.get_local_sources(
-      tile, patch_ctrs_pix(patches),
-      patch_radii_pix(patches, blob[3]))
+    subset10 = ModelInit.get_local_sources(tile, patch_ctrs_pix(patches),
+                                           patch_radii_pix(patches))
     @test subset10 == [1]
 
     last_tile = ImageTile(11, 24, blob[3], tile_width)
@@ -95,9 +93,9 @@ function test_local_sources()
       fill(fill(last_tile, 1, 1), 5), blob, three_bodies; patch_radius=20.)
 
     patches = vec(mp.patches[:, 3])
-    last_subset = ModelInit.get_local_sources(
-      last_tile, patch_ctrs_pix(patches),
-      patch_radii_pix(patches, blob[3]))
+    last_subset = ModelInit.get_local_sources(last_tile,
+                                              patch_ctrs_pix(patches),
+                                              patch_radii_pix(patches))
     @test length(last_subset) == 0
 
     pop_tile = ImageTile(7, 9, blob[3], tile_width)
@@ -105,9 +103,8 @@ function test_local_sources()
       fill(fill(pop_tile, 1, 1), 5), blob, three_bodies; patch_radius=20.);
 
     patches = vec(mp.patches[:, 3])
-    pop_subset = ModelInit.get_local_sources(
-      pop_tile, patch_ctrs_pix(patches),
-      patch_radii_pix(patches, blob[3]))
+    pop_subset = ModelInit.get_local_sources(pop_tile, patch_ctrs_pix(patches),
+                                             patch_radii_pix(patches))
 
     @test pop_subset == [2,3]
 end
@@ -181,7 +178,7 @@ function test_local_sources_3()
 
     patches = vec(mp.patches[:,test_b])
     @test ModelInit.get_local_sources(tile, patch_ctrs_pix(patches),
-                                      patch_radii_pix(patches, blob[test_b])) == [1]
+                                      patch_radii_pix(patches)) == [1]
 
     # Source should not match when you're 1 tile and a half away along the diagonal plus
     # the pixel radius from the center of the tile.
@@ -192,7 +189,7 @@ function test_local_sources_3()
         blob[test_b],
         tile_width)
     @test ModelInit.get_local_sources(tile, patch_ctrs_pix(patches),
-                                      patch_radii_pix(patches, blob[test_b])) == []
+                                      patch_radii_pix(patches)) == []
 
     tile = ImageTile(
         round(Int, (pix_loc[1]) / tile_width),
@@ -201,7 +198,7 @@ function test_local_sources_3()
         blob[test_b],
         tile_width)
     @test ModelInit.get_local_sources(tile, patch_ctrs_pix(patches),
-                                      patch_radii_pix(patches, blob[test_b])) == []
+                                      patch_radii_pix(patches)) == []
 
 end
 


### PR DESCRIPTION
SkyPatch is mainly (other than in tests) initialized from a
CatalogEntry, where a radius in pixels is calculated.  Formerly, that
radius was immediately converted to world coordinates and stored,
discarding the radius in pixels. However, we use the radius in pixels
all over the place, so it makes sense to store it instead of converting
back to pixels all the time.
