### PR TITLE
Only fit psf for relevant sources

### DIFF
--- a/src/ModelInit.jl
+++ b/src/ModelInit.jl
@@ -242,6 +242,13 @@ function SkyPatch(ce::CatalogEntry, img::Image; fit_psf=true,
              scale_patch_size * pix_radius, psf, wcs_jacobian, pixel_center)
 end
 
+"""
+Initialize a SkyPatch from an existing SkyPatch and a new PSF.
+"""
+SkyPatch(patch::SkyPatch, psf::Vector{PsfComponent}) =
+    SkyPatch(patch.center, patch.radius, patch.radius_pix,
+             psf, patch.wcs_jacobian, patch.pixel_center)
+
 
 """
 A fast function to determine which sources might belong to which tiles.
@@ -465,6 +472,15 @@ function get_relevant_sources{NumType <: Number}(
   relevant_sources
 end
 
+function get_all_relevant_sources{NumType <: Number}(
+    mp::ModelParams{NumType}, idx::Vector{Int})
+    out = Int[]
+    for i in idx
+        out = union(out, get_relevant_sources(mp, i))
+    end
+    return out
+end
+
 
 """
 Return a reduced Celeste dataset useful for a single object.
@@ -630,6 +646,5 @@ function initialize_objid(objid::ASCIIString, mp_all::ModelParams{Float64},
                                            noise_fraction=0.1)
   return trimmed_tiled_images, mp, active_s, s
 end
-
 
 end # module

--- a/src/ModelInit.jl
+++ b/src/ModelInit.jl
@@ -472,6 +472,20 @@ function get_relevant_sources{NumType <: Number}(
   relevant_sources
 end
 
+
+"""
+Union of source indicies that have some overlap with any of the input indicies.
+
+Args:
+
+- `mp`: ModelParams
+- `idx`: Vector of target source indicies
+
+Returns:
+
+- Array of integers that index into mp.s representing all sources that
+  co-occur in at least one tile with *any* of the sources in `idx`.
+"""
 function get_all_relevant_sources{NumType <: Number}(
     mp::ModelParams{NumType}, idx::Vector{Int})
     out = Int[]

--- a/src/ModelInit.jl
+++ b/src/ModelInit.jl
@@ -489,8 +489,8 @@ Returns:
 function get_all_relevant_sources{NumType <: Number}(
     mp::ModelParams{NumType}, idx::Vector{Int})
     out = Int[]
-    for i in idx
-        out = union(out, get_relevant_sources(mp, i))
+    for s in idx
+        out = union(out, get_relevant_sources(mp, s))
     end
     return out
 end

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -326,7 +326,6 @@ celestial object in a single image.
 
 Attributes:
   - center: The approximate source location in world coordinates
-  - radius: The width of the influence of the object in world coordinates
   - radius_pix: The width of the influence of the object in pixel coordinates
   - psf: The point spread function in this region of the sky
   - wcs_jacobian: The jacobian of the WCS transform in this region of the
@@ -335,7 +334,6 @@ Attributes:
 """
 immutable SkyPatch
     center::Vector{Float64}
-    radius::Float64
     radius_pix::Float64
 
     psf::Vector{PsfComponent}

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -327,7 +327,7 @@ celestial object in a single image.
 Attributes:
   - center: The approximate source location in world coordinates
   - radius: The width of the influence of the object in world coordinates
-
+  - radius_pix: The width of the influence of the object in pixel coordinates
   - psf: The point spread function in this region of the sky
   - wcs_jacobian: The jacobian of the WCS transform in this region of the
                   sky for each band
@@ -336,6 +336,7 @@ Attributes:
 immutable SkyPatch
     center::Vector{Float64}
     radius::Float64
+    radius_pix::Float64
 
     psf::Vector{PsfComponent}
     wcs_jacobian::Matrix{Float64}

--- a/src/api.jl
+++ b/src/api.jl
@@ -140,18 +140,34 @@ function infer(ra_range::Tuple{Float64, Float64},
 
     # initialize tiled images and model parameters for trimming.  We will
     # initialize the psf again before fitting, so we don't do it here.
-    tiled_images, mp_all = ModelInit.initialize_celeste(images, catalog,
-                                                        tile_width=TILE_WIDTH,
-                                                        fit_psf=false)
+    info("initializing celeste without PSF fit")
+    tiled_images = SkyImages.break_blob_into_tiles(images, TILE_WIDTH)
+    mp = ModelInit.initialize_model_params(tiled_images, images, catalog,
+                                           fit_psf=false)
+
+    # get indicies of all sources relevant to those we're actually
+    # interested in, and fit a local PSF for those sources (since we skipped
+    # fitting the PSF for the whole catalog above)
+    info("fitting PSF for all relevant sources")
+    relevant_idx = ModelInit.get_all_relevant_sources(mp, idx)
+    for j in 1:size(mp.patches, 2)  # loop over images
+        for i in relevant_idx  # loop over relevant sources
+            patch = mp.patches[i, j]
+            psf = SkyImages.get_source_psf(patch.center, images[j])
+            mp.patches[i, j] = ModelInit.SkyPatch(patch, psf)
+        end
+    end
 
     results = Dict{Int, Dict}()
     for i in idx
         entry = catalog[i]
+        mp.active_sources = [i]
+
         info("processing source $i: objid= $(entry.objid)")
 
         t0 = time()
-        trimmed_tiled_images, mp, active_s, s =
-            ModelInit.initialize_objid(entry.objid, mp_all, catalog, images)
+        trimmed_tiled_images = ModelInit.trim_source_tiles(i, mp, tiled_images;
+                                                           noise_fraction=0.1)
         init_time = time() - t0
 
         t0 = time()
@@ -163,7 +179,7 @@ function infer(ra_range::Tuple{Float64, Float64},
         results[entry.thing_id] = Dict("objid"=>entry.objid,
                                        "ra"=>entry.pos[1],
                                        "dec"=>entry.pos[2],
-                                       "vp"=>mp.vp[active_s],  # should be 's'?
+                                       "vp"=>mp.vp[i],
                                        "init_time"=>init_time,
                                        "fit_time"=>fit_time)
     end

--- a/src/api.jl
+++ b/src/api.jl
@@ -151,22 +151,22 @@ function infer(ra_range::Tuple{Float64, Float64},
     info("fitting PSF for all relevant sources")
     relevant_idx = ModelInit.get_all_relevant_sources(mp, idx)
     for j in 1:size(mp.patches, 2)  # loop over images
-        for i in relevant_idx  # loop over relevant sources
-            patch = mp.patches[i, j]
+        for s in relevant_idx  # loop over relevant sources
+            patch = mp.patches[s, j]
             psf = SkyImages.get_source_psf(patch.center, images[j])
-            mp.patches[i, j] = ModelInit.SkyPatch(patch, psf)
+            mp.patches[s, j] = ModelInit.SkyPatch(patch, psf)
         end
     end
 
     results = Dict{Int, Dict}()
-    for i in idx
-        entry = catalog[i]
-        mp.active_sources = [i]
+    for s in idx
+        entry = catalog[s]
+        mp.active_sources = [s]
 
-        info("processing source $i: objid= $(entry.objid)")
+        info("processing source $s: objid= $(entry.objid)")
 
         t0 = time()
-        trimmed_tiled_images = ModelInit.trim_source_tiles(i, mp, tiled_images;
+        trimmed_tiled_images = ModelInit.trim_source_tiles(s, mp, tiled_images;
                                                            noise_fraction=0.1)
         init_time = time() - t0
 
@@ -179,7 +179,7 @@ function infer(ra_range::Tuple{Float64, Float64},
         results[entry.thing_id] = Dict("objid"=>entry.objid,
                                        "ra"=>entry.pos[1],
                                        "dec"=>entry.pos[2],
-                                       "vp"=>mp.vp[i],
+                                       "vp"=>mp.vp[s],
                                        "init_time"=>init_time,
                                        "fit_time"=>fit_time)
     end

--- a/test/test_images.jl
+++ b/test/test_images.jl
@@ -53,9 +53,9 @@ function test_blob()
     @test 2 * width <= cropped_blob[b][1].h_width <= 2 * (width + 1)
     @test 2 * width <= cropped_blob[b][1].w_width <= 2 * (width + 1)
     patches = vec(mp.patches[:, b])
-    tile_sources =
-      ModelInit.get_local_sources(cropped_blob[b][1], patch_ctrs_pix(patches),
-                                  patch_radii_pix(patches, blob[b]))
+    tile_sources = ModelInit.get_local_sources(cropped_blob[b][1],
+                                               patch_ctrs_pix(patches),
+                                               patch_radii_pix(patches))
     @test obj_index in tile_sources
   end
 
@@ -119,8 +119,9 @@ function test_get_tiled_image_source()
       mp.patches[1, b] = SkyPatch(loc, 1e-6, blob[b], fit_psf=false)
     end
     patches = vec(mp.patches[:, 3])
-    local_sources = ModelInit.get_tiled_image_sources(
-      tiled_img, patch_ctrs_pix(patches), patch_radii_pix(patches, img))
+    local_sources = ModelInit.get_tiled_image_sources(tiled_img,
+                                                      patch_ctrs_pix(patches),
+                                                      patch_radii_pix(patches))
     @test local_sources[hh, ww] == Int[1]
     for hh2 in 1:size(tiled_img)[1], ww2 in 1:size(tiled_img)[2]
       if (hh2 != hh) || (ww2 != ww)
@@ -142,14 +143,14 @@ function test_local_source_candidate()
     # Get the sources by iterating over everything.
     patches = vec(mp.patches[:,b])
       
-    tile_sources = ModelInit.get_tiled_image_sources(
-      tiled_blob[b], patch_ctrs_pix(patches),
-      patch_radii_pix(patches, blob[b]))
+    tile_sources = ModelInit.get_tiled_image_sources(tiled_blob[b],
+                                                     patch_ctrs_pix(patches),
+                                                     patch_radii_pix(patches))
 
     # Get a set of candidates.
-    candidates = ModelInit.local_source_candidates(
-      tiled_blob[b], patch_ctrs_pix(patches),
-      patch_radii_pix(patches, blob[b]))
+    candidates = ModelInit.local_source_candidates(tiled_blob[b],
+                                                   patch_ctrs_pix(patches),
+                                                   patch_radii_pix(patches))
 
     # Check that all the actual sources are candidates and that this is the
     # same as what is returned by initialize_model_params.

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -74,9 +74,8 @@ function test_local_sources()
     @test mp.S == 3
 
     patches = vec(mp.patches[:, 3])
-    subset1000 = ModelInit.get_local_sources(
-      tile, patch_ctrs_pix(patches),
-      patch_radii_pix(patches, blob[3]))
+    subset1000 = ModelInit.get_local_sources(tile, patch_ctrs_pix(patches),
+                                             patch_radii_pix(patches))
     @test subset1000 == [1,2,3]
 
     tile_width = 10
@@ -85,9 +84,8 @@ function test_local_sources()
       fill(fill(tile, 1, 1), 5), blob, three_bodies; patch_radius=20.);
 
     patches = vec(mp.patches[:, 3])
-    subset10 = ModelInit.get_local_sources(
-      tile, patch_ctrs_pix(patches),
-      patch_radii_pix(patches, blob[3]))
+    subset10 = ModelInit.get_local_sources(tile, patch_ctrs_pix(patches),
+                                           patch_radii_pix(patches))
     @test subset10 == [1]
 
     last_tile = ImageTile(11, 24, blob[3], tile_width)
@@ -95,9 +93,9 @@ function test_local_sources()
       fill(fill(last_tile, 1, 1), 5), blob, three_bodies; patch_radius=20.)
 
     patches = vec(mp.patches[:, 3])
-    last_subset = ModelInit.get_local_sources(
-      last_tile, patch_ctrs_pix(patches),
-      patch_radii_pix(patches, blob[3]))
+    last_subset = ModelInit.get_local_sources(last_tile,
+                                              patch_ctrs_pix(patches),
+                                              patch_radii_pix(patches))
     @test length(last_subset) == 0
 
     pop_tile = ImageTile(7, 9, blob[3], tile_width)
@@ -105,9 +103,8 @@ function test_local_sources()
       fill(fill(pop_tile, 1, 1), 5), blob, three_bodies; patch_radius=20.);
 
     patches = vec(mp.patches[:, 3])
-    pop_subset = ModelInit.get_local_sources(
-      pop_tile, patch_ctrs_pix(patches),
-      patch_radii_pix(patches, blob[3]))
+    pop_subset = ModelInit.get_local_sources(pop_tile, patch_ctrs_pix(patches),
+                                             patch_radii_pix(patches))
 
     @test pop_subset == [2,3]
 end
@@ -181,7 +178,7 @@ function test_local_sources_3()
 
     patches = vec(mp.patches[:,test_b])
     @test ModelInit.get_local_sources(tile, patch_ctrs_pix(patches),
-                                      patch_radii_pix(patches, blob[test_b])) == [1]
+                                      patch_radii_pix(patches)) == [1]
 
     # Source should not match when you're 1 tile and a half away along the diagonal plus
     # the pixel radius from the center of the tile.
@@ -192,7 +189,7 @@ function test_local_sources_3()
         blob[test_b],
         tile_width)
     @test ModelInit.get_local_sources(tile, patch_ctrs_pix(patches),
-                                      patch_radii_pix(patches, blob[test_b])) == []
+                                      patch_radii_pix(patches)) == []
 
     tile = ImageTile(
         round(Int, (pix_loc[1]) / tile_width),
@@ -201,7 +198,7 @@ function test_local_sources_3()
         blob[test_b],
         tile_width)
     @test ModelInit.get_local_sources(tile, patch_ctrs_pix(patches),
-                                      patch_radii_pix(patches, blob[test_b])) == []
+                                      patch_radii_pix(patches)) == []
 
 end
 


### PR DESCRIPTION
@rgiordan should review the second commit 5b88c06 to make sure it still does what its supposed to.

The basic idea here is that we:
- initialize model parameters without fitting the PSF (same as before)
- compile a list of all relevant sources (`get_all_relevant_sources(mp)`)
- for each relevant source, replace the corresponding `SkyPatch` in `mp` with a new one that has a fitted PSF. 

This includes #163, which didn't actually turn out to be too relevant.
