### PR TITLE
Allows negative RA and DEC

### DIFF
--- a/bin/celeste.jl
+++ b/bin/celeste.jl
@@ -26,7 +26,7 @@ The `score-nersc` subcommand is not yet implemented for the new API.
 
 
 function main()
-    args = docopt(DOC, version=v"0.0.0")
+    args = docopt(DOC, version=v"0.1.0", options_first=true)
     if args["infer-nersc"]
         Celeste.set_logging_level(args["--logging"])
         ramin = parse(Float64, args["<ramin>"])

--- a/src/ModelInit.jl
+++ b/src/ModelInit.jl
@@ -456,7 +456,7 @@ function initialize_model_params(
                 "If !radius_from_cat, you must specify a positive patch_radius.")
     end
 
-    println("Getting VP from sources.")
+    println("Loading variational parameters from catalogs.")
     vp = Array{Float64, 1}[init_source(ce) for ce in cat]
     mp = ModelParams(vp, sample_prior())
     mp.objids = ASCIIString[ cat_entry.objid for cat_entry in cat]

--- a/src/api.jl
+++ b/src/api.jl
@@ -381,6 +381,7 @@ function nersc_fpm_dir(run::Integer, camcol::Integer, field::Integer)
     # ".fit", so we have to at least symlink the files to a new name.
     srcdir = "$(NERSC_DATA_ROOT)/photo/redux/301/$(run)/objcs/$(camcol)"
     dstdir = joinpath(ENV["SCRATCH"], "celeste", "fpm", "$(run)-$(camcol)")
+    debug(dstdir)
     isdir(dstdir) || mkpath(dstdir)
     for band in ['u', 'g', 'r', 'i', 'z']
         srcfile = @sprintf("%s/fpM-%06d-%s%d-%04d.fit.gz",

--- a/src/api.jl
+++ b/src/api.jl
@@ -421,6 +421,7 @@ function infer_nersc(ramin, ramax, decmin, decmax, outdir)
     fname = @sprintf("%s/celeste-%.4f-%.4f-%.4f-%.4f.jld",
                      outdir, ramin, ramax, decmin, decmax)
     JLD.save(fname, "results", results)
+    debug("infer_nersc finished successfully")
 end
 
 


### PR DESCRIPTION
This keeps `celeste.jl` from interpreting hyphens in negative RA and DEC values as the beginnings of flags. But now `--logging=<LEVEL>` has to come first.

e.g.

```
 ./celeste.jl --logging=DEBUG infer-nersc 0 0.2 -18.0 18.2 .
```
