### PR TITLE
Use Dtree for distributed parallelism

### DIFF
--- a/bin/celeste.jl
+++ b/bin/celeste.jl
@@ -1,7 +1,13 @@
 #!/usr/bin/env julia
 
 using DocOpt
+using Dtree
 import Celeste
+
+const cpu_hz = 2.3e9
+
+const wira = 0.015
+const widec = 0.015
 
 const DOC =
 """Run Celeste.
@@ -19,7 +25,7 @@ Usage:
 Options:
   -h, --help         Show this screen.
   --version          Show the version.
-  --logging=<LEVEL>  Level for the Logging package (OFF, DEBUG, INFO, WARNING, ERROR, or CRITICAL). [default: INFO]
+  --logging=<LEVEL>  Level for the Logging package (OFF, DEBUG, INFO, WARNING, ERROR, or CRITICAL). [default: WARNING]
   --stage            In `infer-box`, automatically stage files. Default: false.
 
 The `stage-box` subcommand copies and/or uncompresses all files covering the
@@ -35,7 +41,178 @@ field, using only that field.
 The `score-field` subcommand is not yet implemented for the new API.
 """
 
+"""
+An area of the sky subtended by `ramin`, `ramax`, `decmin`, and `decmax`.
+"""
+type SkyArea
+    ramin::Float64
+    ramax::Float64
+    decmin::Float64
+    decmax::Float64
+    nra::Int64
+    ndec::Int64
+end
+
+"""
+Given a SkyArea that is to be divided into `skya.nra` x `skya.ndec` patches,
+return the `i`th patch. `i` is a linear index between 1 and
+`skya.nra * skya.ndec`.
+
+This function assumes a cartesian (rather than spherical) coordinate system!
+"""
+function sky_subarea(skya::SkyArea, i)
+    global wira, widec
+    ix, iy = ind2sub((skya.nra, skya.ndec), i)
+
+    return (skya.ramin + (ix - 1) * wira,
+            min(skya.ramin + ix * wira, skya.ramax),
+            skya.decmin + (iy - 1) * widec,
+            min(skya.decmin + iy * widec, skya.decmax))
+end
+
+
+"""
+Divide the area of sky subtended by `ramin`, `ramax`, `decmin`, and `decmax`
+into patches of `wira`X`widec`. Each such patch is a work item. Use Dtree to
+distribute these to nodes. Within the node, run inference on each patch
+received from Dtree.
+"""
+function celeste_skyarea(ramin, ramax, decmin, decmax, outdir;
+                         stage::Bool=false)
+    # ---
+    if dt_nodeid == 1
+        println("celeste -- running on $dt_nnodes nodes (system clock speed is $cpu_hz Hz)")
+        println("  sky area: $(ramax - ramin) X $(decmax - decmin)")
+    end
+
+    n_infers = 0
+    n_fits = 0
+    tm_infer = tm_fldids = tm_rdprim = tm_filcat = tm_rdimg = tm_imp = tm_psf = tm_fit = tm_out = tm_done = 0.0
+
+    if dt_nnodes == 1 # single node run
+        tic()
+        tm_fldids, tm_rdprim, tm_filcat, tm_rdimg, tm_imp, tm_psf, tm_fit, n_fits, tm_out =
+            Celeste.infer_box_nersc(ramin, ramax, decmin, decmax, outdir;
+                                    stage=stage)
+        tm_infer = toq()
+        n_infers = 1
+
+    else # distributed run
+
+        # partition the sky area into `wira` X `widec` sized patches
+        global wira, widec
+        nra = ceil(Int64, (ramax - ramin) / wira)
+        ndec = ceil(Int64, (decmax - decmin) / widec)
+        skya = SkyArea(ramin, ramax, decmin, decmax, nra, ndec)
+
+        num_work_items = nra * ndec
+        each = ceil(Int64, num_work_items / dt_nnodes)
+
+        if dt_nodeid == 1
+            println("  work item dimensions: $wira X $widec")
+            println("  $num_work_items work items, ~$each per node")
+        end
+
+        # create Dtree and get the initial allocation
+        dt = DtreeScheduler(num_work_items, 0.4)
+        ni, (ci, li) = initwork(dt)
+        rundt = runtree(dt) > 0
+        function rundtree()
+            if rundt
+                rundt = runtree(dt) > 0
+                Dtree.cpu_pause()
+            end
+        end
+
+        # work item processing loop
+        Celeste.nputs(dt_nodeid, "initially $ni work items ($ci to $li)")
+        tic()
+        while ni > 0
+            li == 0 && break
+            if ci > li
+                Celeste.nputs(dt_nodeid, "consumed allocation (last was $li)")
+                ni, (ci, li) = getwork(dt)
+                Celeste.nputs(dt_nodeid, "got $ni work items ($ci to $li)")
+                continue
+            end
+            item = ci
+            ci = ci + 1
+
+            # map item to subarea
+            iramin, iramax, idecmin, idecmax = sky_subarea(skya, item)
+
+            # run inference for this subarea
+            Celeste.nputs(dt_nodeid, "running inference for $iramin, $iramax, $idecmin, $idecmax")
+            tic()
+            tm_fi, tm_rp, tm_fc, tm_ri, tm_i, tm_p, tm_f, n_f, tm_o =
+                Celeste.infer_box_nersc(iramin, iramax, idecmin, idecmax, outdir;
+                                        nid=dt_nodeid, nnodes=dt_nnodes)
+            tm_infer = tm_infer + toq()
+            n_infers = n_infers + 1
+            tm_fldids = tm_fldids + tm_fi
+            tm_rdprim = tm_rdprim + tm_rp
+            tm_filcat = tm_filcat + tm_fc
+            tm_rdimg = tm_rdimg + tm_ri
+            tm_imp = tm_imp + tm_i
+            tm_psf = tm_psf + tm_p
+            tm_fit = tm_fit + tm_f
+            n_fits = n_fits + n_f
+            tm_out = tm_out + tm_o
+
+            rundtree()
+        end
+        tm_work = toq()
+        Celeste.nputs(dt_nodeid, "out of work")
+        tic()
+        while rundt
+            rundtree()
+        end
+        finalize(dt)
+        tm_done = toq()
+    end
+
+    Celeste.nputs(dt_nodeid, "timing ($n_infers sky areas):")
+    Celeste.nputs(dt_nodeid, "infer avg: $(tm_infer/n_infers)")
+    Celeste.nputs(dt_nodeid, "field ids avg: $(tm_fldids/n_infers)")
+    Celeste.nputs(dt_nodeid, "dump output avg: $(tm_out/n_infers)")
+    Celeste.nputs(dt_nodeid, "read primary avg: $(tm_rdprim/n_infers)")
+    Celeste.nputs(dt_nodeid, "filter catalog avg: $(tm_filcat/n_infers)")
+    Celeste.nputs(dt_nodeid, "read images avg: $(tm_rdimg/n_infers)")
+    Celeste.nputs(dt_nodeid, "init model params avg: $(tm_imp/n_infers)")
+    Celeste.nputs(dt_nodeid, "psf avg: $(tm_psf/n_infers)")
+    Celeste.nputs(dt_nodeid, "fit: $((tm_fit/n_fits)/n_infers) (for $n_fits fits)")
+    Celeste.nputs(dt_nodeid, "wait for done: $tm_done secs")
+end
+
+
+function time_puts(elapsedtime, bytes, gctime, allocs)
+    s = @sprintf("%10.6f seconds", elapsedtime/1e9)
+    if bytes != 0 || allocs != 0
+        bytes, mb = Base.prettyprint_getunits(bytes, length(Base._mem_units), Int64(1024))
+        allocs, ma = Base.prettyprint_getunits(allocs, length(Base._cnt_units), Int64(1000))
+        if ma == 1
+            s = string(s, @sprintf(" (%d%s allocation%s: ", allocs, Base._cnt_units[ma], allocs==1 ? "" : "s"))
+        else
+            s = string(s, @sprintf(" (%.2f%s allocations: ", allocs, Base._cnt_units[ma]))
+        end
+        if mb == 1
+            s = string(s, @sprintf("%d %s%s", bytes, Base._mem_units[mb], bytes==1 ? "" : "s"))
+        else
+            s = string(s, @sprintf("%.3f %s", bytes, Base._mem_units[mb]))
+        end
+        if gctime > 0
+            s = string(s, @sprintf(", %.2f%% gc time", 100*gctime/elapsedtime))
+        end
+        s = string(s, ")")
+    elseif gctime > 0
+        s = string(s, @sprintf(", %.2f%% gc time", 100*gctime/elapsedtime))
+    end
+    Celeste.nputs(dt_nodeid, s)
+end
+
+
 function main()
+    Celeste.set_logging_level("WARNING")
     args = docopt(DOC, version=v"0.1.0", options_first=true)
     Celeste.set_logging_level(args["--logging"])
     if args["stage-box"] || args["infer-box"]
@@ -47,8 +224,12 @@ function main()
             Celeste.stage_box_nersc(ramin, ramax, decmin, decmax)
         elseif args["infer-box"]
             outdir = args["<outdir>"]
-            Celeste.infer_box_nersc(ramin, ramax, decmin, decmax, outdir,
-                                    stage=args["--stage"])
+            local stats = Base.gc_num()
+            local elapsedtime = time_ns()
+            celeste_skyarea(ramin, ramax, decmin, decmax, outdir, stage=args["--stage"])
+            elapsedtime = time_ns() - elapsedtime
+            local diff = Base.GC_Diff(Base.gc_num(), stats)
+            time_puts(elapsedtime, diff.allocd, diff.total_time, Base.gc_alloc_count(diff))
         end
     elseif args["infer-field"]
         run = parse(Int, args["<run>"])

--- a/bin/celeste.jl
+++ b/bin/celeste.jl
@@ -6,6 +6,7 @@ import Celeste
 
 const cpu_hz = 2.3e9
 
+# A workitem is of this ra / dec size
 const wira = 0.015
 const widec = 0.015
 

--- a/src/ElboDeriv.jl
+++ b/src/ElboDeriv.jl
@@ -14,7 +14,7 @@ import ..WCSUtils
 # We will either multi-thread the active pixels loop here, or the
 # loop over sources in api.jl. When that is decided, one of these
 # will be removed.
-Threaded = true
+Threaded = false
 if Threaded && VERSION > v"0.5.0-dev"
     using Base.Threads
 else
@@ -861,7 +861,6 @@ function process_active_pixels!{NumType <: Number}(
   end
 
   # iterate over the pixels
-  tic()
   @threads for pixel in active_pixels
     tid = threadid()
     tile = tiled_blob[pixel.b][pixel.tile_ind]
@@ -888,7 +887,6 @@ function process_active_pixels!{NumType <: Number}(
     # the optimization convergence criterion, so I will leave it in for now.
     elbo_vars_array[tid].elbo.v[1] -= lfact(this_pixel)
   end
-  toc()
 end
 
 

--- a/src/ElboDeriv.jl
+++ b/src/ElboDeriv.jl
@@ -11,6 +11,9 @@ import ..KL
 import ForwardDiff
 import ..WCSUtils
 
+# We will either multi-thread the active pixels loop here, or the
+# loop over sources in api.jl. When that is decided, one of these
+# will be removed.
 Threaded = false
 if Threaded && VERSION > v"0.5.0-dev"
     using Base.Threads

--- a/src/ModelInit.jl
+++ b/src/ModelInit.jl
@@ -676,7 +676,6 @@ function trim_source_tiles(
       has_source = s in tile_sources
       bright_pixels = Bool[];
       if has_source
-        info("Tiles $h $w has source $s")
         pred_tile_pixels =
           ElboDeriv.tile_predicted_image(tile, mp, [ s ],
                                          include_epsilon=false);

--- a/src/ModelInit.jl
+++ b/src/ModelInit.jl
@@ -462,7 +462,7 @@ function initialize_model_params(
                 "If !radius_from_cat, you must specify a positive patch_radius.")
     end
 
-    println("Loading variational parameters from catalogs.")
+    info("Loading variational parameters from catalogs.")
     vp = Array{Float64, 1}[init_source(ce) for ce in cat]
     mp = ModelParams(vp, sample_prior())
     mp.objids = ASCIIString[ cat_entry.objid for cat_entry in cat]
@@ -664,7 +664,7 @@ function trim_source_tiles(
 
   min_radius_pix_sq = min_radius_pix ^ 2
   for b = 1:length(tiled_blob)
-    println("Processing band $b...")
+    info("Processing band $b...")
 
     pix_loc = WCSUtils.world_to_pix(mp.patches[s, b], mp.vp[s][ids.u]);
 
@@ -676,7 +676,7 @@ function trim_source_tiles(
       has_source = s in tile_sources
       bright_pixels = Bool[];
       if has_source
-        #println("Tiles $h $w has source $s")
+        info("Tiles $h $w has source $s")
         pred_tile_pixels =
           ElboDeriv.tile_predicted_image(tile, mp, [ s ],
                                          include_epsilon=false);
@@ -719,7 +719,7 @@ function trim_source_tiles(
       end
     end
   end
-  println("Done trimming.")
+  info("Done trimming.")
 
   trimmed_tiled_blob
 end

--- a/src/OptimizeElbo.jl
+++ b/src/OptimizeElbo.jl
@@ -73,7 +73,7 @@ type ObjectiveWrapperFunctions
         function print_status{T <: Number}(
           iter_vp::VariationalParams{T}, value::T, grad::Array{T})
             if state.verbose || (state.f_evals % state.print_every_n == 0)
-                println("f_evals: $(state.f_evals) value: $(value)")
+                info("f_evals: $(state.f_evals) value: $(value)")
             end
             if state.verbose
               S = length(iter_vp)
@@ -242,7 +242,7 @@ function maximize_f(
     max_f = -1.0 * nm_result.f_minimum
     max_x = nm_result.minimum
 
-    println("got $max_f at $max_x after $iter_count function evaluations ",
+    info("got $max_f at $max_x after $iter_count function evaluations ",
             "($(nm_result.iterations) Newton steps)\n")
     iter_count, max_f, max_x, nm_result
 end

--- a/src/Transform.jl
+++ b/src/Transform.jl
@@ -890,7 +890,7 @@ function enforce_bounds!{NumType <: Number}(
         if !(constraint.lower_bound <=
              mp.vp[s][ids.(param)[ind]] <=
              constraint.upper_bound)
-          println("Warning: $param[$s][$ind] was out of bounds.")
+          info("Warning: $param[$s][$ind] was out of bounds.")
           # Don't set the value to exactly the lower bound to avoid Inf
           diff = constraint.upper_bound - constraint.lower_bound
           epsilon = diff == Inf ? 1e-12: diff * 1e-12
@@ -908,7 +908,7 @@ function enforce_bounds!{NumType <: Number}(
           constraint = constraint_vec[col]
           for row in 1:param_size[1]
             if !(constraint.lower_bound <= mp.vp[s][ids.(param)[row, col]] <= 1.0)
-              println("Warning: $param[$s][$row, $col] was out of bounds.")
+              info("Warning: $param[$s][$row, $col] was out of bounds.")
               # Don't set the value to exactly the lower bound to avoid Inf
               epsilon = (1.0 - constraint.lower_bound) * 1e-12
               mp.vp[s][ids.(param)[row, col]] =
@@ -919,7 +919,7 @@ function enforce_bounds!{NumType <: Number}(
             end
           end
           if sum(mp.vp[s][ids.(param)[:, col]]) != 1.0
-            println("Warning: $param[$s][:, $col] is not normalized.")
+            info("Warning: $param[$s][:, $col] is not normalized.")
             mp.vp[s][ids.(param)[:, col]] =
               mp.vp[s][ids.(param)[:, col]] / sum(mp.vp[s][ids.(param)[:, col]])
           end
@@ -929,7 +929,7 @@ function enforce_bounds!{NumType <: Number}(
         constraint = constraint_vec[1]
         for row in 1:param_size[1]
           if !(constraint.lower_bound <= mp.vp[s][ids.(param)[row]] <= 1.0)
-            println("Warning: $param[$s][$row] was out of bounds.")
+            info("Warning: $param[$s][$row] was out of bounds.")
             # Don't set the value to exactly the lower bound to avoid Inf
             epsilon = (1.0 - constraint.lower_bound) * 1e-12
             mp.vp[s][ids.(param)[row]] =
@@ -939,7 +939,7 @@ function enforce_bounds!{NumType <: Number}(
           end
         end
         if sum(mp.vp[s][ids.(param)]) != 1.0
-          println("Warning: $param[$s] is not normalized.")
+          info("Warning: $param[$s] is not normalized.")
           mp.vp[s][ids.(param)] = mp.vp[s][ids.(param)] / sum(mp.vp[s][ids.(param)])
         end
       end

--- a/src/api.jl
+++ b/src/api.jl
@@ -5,6 +5,21 @@ import FITSIO
 import JLD
 using Logging  # just for testing right now
 
+Threaded = false
+if Threaded && VERSION > v"0.5.0-dev"
+    using Base.Threads
+else
+    # Pre-Julia 0.5 there are no threads
+    nthreads() = 1
+    threadid() = 1
+    macro threads(x)
+        x
+    end
+    SpinLock() = 1
+    lock!(l) = ()
+    unlock!(l) = ()
+end
+
 using .Types
 import .SDSS
 import .SkyImages
@@ -15,6 +30,7 @@ const TILE_WIDTH = 20
 const DEFAULT_MAX_ITERS = 50
 const MIN_FLUX = 2.0
 
+@inline nputs(nid, s) = ccall(:puts, Cint, (Ptr{Int8},), string("[$nid] ", s))
 
 function set_logging_level(level)
     if level == "OFF"
@@ -142,15 +158,20 @@ function infer(fieldids::Vector{Tuple{Int, Int, Int}},
                ra_range=(-1000., 1000.),
                dec_range=(-1000., 1000.),
                primary_initialization=true,
-               max_iters=DEFAULT_MAX_ITERS)
+               max_iters=DEFAULT_MAX_ITERS,
+               nid=1, nnodes=1)
     # Read all primary objects in these fields.
+    tic()
     duplicate_policy = primary_initialization ? :primary : :first
     catalog = read_photoobj_files(fieldids, photoobj_dirs,
                         duplicate_policy=duplicate_policy)
+    tm_rdprim = toq()
     info("$(length(catalog)) primary sources")
 
     # Filter out low-flux objects in the catalog.
+    tic()
     catalog = filter(entry->(maximum(entry.star_fluxes) >= MIN_FLUX), catalog)
+    tm_filcat = toq()
     info("$(length(catalog)) primary sources after MIN_FLUX cut")
 
     # Filter any object not specified, if an objid is specified
@@ -168,13 +189,14 @@ function infer(fieldids::Vector{Tuple{Int, Int, Int}},
 
     # If there are no objects of interest, return early.
     if length(target_sources) == 0
-        return Dict{Int, Dict}()
+        return Dict{Int, Dict}(), (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0)
     end
 
     # Read in images for all (run, camcol, field).
     images = Image[]
     image_names = ASCIIString[]
     image_count = 0
+    tic()
     for i in 1:length(fieldids)
         info("reading field ", fieldids[i])
         run, camcol, field = fieldids[i]
@@ -189,6 +211,7 @@ function infer(fieldids::Vector{Tuple{Int, Int, Int}},
         end
         append!(images, fieldims)
     end
+    tm_rdimg = toq()
 
     debug("Image names:")
     debug(image_names)
@@ -196,48 +219,76 @@ function infer(fieldids::Vector{Tuple{Int, Int, Int}},
     # initialize tiled images and model parameters for trimming.  We will
     # initialize the psf again before fitting, so we don't do it here.
     info("initializing celeste without PSF fit")
+    tic()
     tiled_images = SkyImages.break_blob_into_tiles(images, TILE_WIDTH)
     mp = ModelInit.initialize_model_params(tiled_images, images, catalog,
                                            fit_psf=false)
+    tm_imp = toq()
 
     # get indicies of all sources relevant to those we're actually
     # interested in, and fit a local PSF for those sources (since we skipped
     # fitting the PSF for the whole catalog above)
     info("fitting PSF for all relevant sources")
+    tic()
     ModelInit.fit_object_psfs!(mp, target_sources, images)
+    tm_psf = toq()
 
+    # need a ModelParams per thread
+    mp_array = Array(ModelParams, nthreads())
+    mp_array[1] = mp
+    for i = 2:nthreads()
+        mp_array[i] = deepcopy(mp)
+    end
+
+    # iterate over sources
     results = Dict{Int, Dict}()
+    results_lock = SpinLock()
+    tic()
     for s in target_sources
+        tid = threadid()
         entry = catalog[s]
         mp.active_sources = [s]
 
         try
-            info("===================================================")
-            info("processing source $s: objid= $(entry.objid)")
+            nputs(nid, "processing source $s: objid = $(entry.objid)")
+            tic()
 
             t0 = time()
-            trimmed_tiled_images = ModelInit.trim_source_tiles(s, mp, tiled_images;
-                                                               noise_fraction=0.1)
+            trimmed_tiled_images =
+                    ModelInit.trim_source_tiles(s, mp_array[tid], tiled_images;
+                                                noise_fraction=0.1)
             init_time = time() - t0
+
+            t = toq()
+            nputs(nid, "trimmed $s in $t secs, optimizing")
+            tic()
 
             t0 = time()
             iter_count, max_f, max_x, result =
-                OptimizeElbo.maximize_f(ElboDeriv.elbo, trimmed_tiled_images, mp;
-                                        verbose=true, max_iters=max_iters)
+                    OptimizeElbo.maximize_f(ElboDeriv.elbo, trimmed_tiled_images,
+                                            mp_array[tid];
+                                            verbose=false, max_iters=max_iters)
             fit_time = time() - t0
 
+            t = toq()
+            nputs(nid, "optimized $s in $t secs, writing results")
+
+            lock!(results_lock)
             results[entry.thing_id] = Dict("objid"=>entry.objid,
                                            "ra"=>entry.pos[1],
                                            "dec"=>entry.pos[2],
-                                           "vs"=>mp.vp[s],
+                                           "vs"=>mp_array[tid].vp[s],
                                            "init_time"=>init_time,
                                            "fit_time"=>fit_time)
+            unlock!(results_lock)
         catch ex
             err(ex)
         end
     end
+    tm_fit = toq()
+    n_fits = length(target_sources)
 
-    results
+    return results, (tm_rdprim, tm_filcat, tm_rdimg, tm_imp, tm_psf, tm_fit, n_fits)
 end
 
 
@@ -410,9 +461,12 @@ end
 NERSC-specific infer function, called from main entry point.
 """
 function infer_box_nersc(ramin, ramax, decmin, decmax, outdir;
-                         stage::Bool=false)
+                         stage::Bool=false,
+                         nid=1, nnodes=1)
     # Get vector of (run, camcol, field) triplets overlapping this patch
+    tic()
     fieldids = query_overlapping_fieldids(ramin, ramax, decmin, decmax)
+    tm_fldids = toq()
 
     if stage
         for (run, camcol, field) in fieldids
@@ -425,7 +479,8 @@ function infer_box_nersc(ramin, ramax, decmin, decmax, outdir;
     photofield_dirs = [nersc_photofield_scratchdir(x[1], x[2])
                        for x in fieldids]
 
-    results = infer(fieldids, frame_dirs;
+    results, (tm_rdprim, tm_filcat, tm_rdimg, tm_imp, tm_psf, tm_fit, n_fits) =
+              infer(fieldids, frame_dirs;
                     ra_range=(ramin, ramax),
                     dec_range=(decmin, decmax), 
                     fpm_dirs=frame_dirs,
@@ -433,10 +488,13 @@ function infer_box_nersc(ramin, ramax, decmin, decmax, outdir;
                     photoobj_dirs=frame_dirs,
                     photofield_dirs=photofield_dirs)
 
+    tic()
     fname = @sprintf("%s/celeste-%.4f-%.4f-%.4f-%.4f.jld",
                      outdir, ramin, ramax, decmin, decmax)
     JLD.save(fname, "results", results)
+    tm_out = toq()
     debug("infer_box_nersc finished successfully")
+    return (tm_fldids, tm_rdprim, tm_filcat, tm_rdimg, tm_imp, tm_psf, tm_fit, n_fits, tm_out)
 end
 
 
@@ -450,13 +508,14 @@ function infer_field_nersc(run::Int, camcol::Int, field::Int,
     field_dirs = [nersc_field_scratchdir(run, camcol, field)]
     photofield_dirs = [nersc_photofield_scratchdir(run, camcol)]
 
-    results = infer([(run, camcol, field)], field_dirs;
-                    objid=objid,
-                    fpm_dirs=field_dirs,
-                    psfield_dirs=field_dirs,
-                    photoobj_dirs=field_dirs,
-                    photofield_dirs=photofield_dirs,
-                    primary_initialization=false)
+    results, (tm_rdprim, tm_filcat, tm_rdimg, tm_imp, tm_psf, tm_fit, n_fits) =
+            infer([(run, camcol, field)], field_dirs;
+                  objid=objid,
+                  fpm_dirs=field_dirs,
+                  psfield_dirs=field_dirs,
+                  photoobj_dirs=field_dirs,
+                  photofield_dirs=photofield_dirs,
+                  primary_initialization=false)
 
     fname = if objid == ""
         @sprintf "%s/celeste-%06d-%d-%04d.jld" outdir run camcol field
@@ -465,6 +524,7 @@ function infer_field_nersc(run::Int, camcol::Int, field::Int,
     end
     JLD.save(fname, "results", results)
     debug("infer_field_nersc finished successfully")
+    return (tm_fldids, tm_rdprim, tm_filcat, tm_rdimg, tm_imp, tm_psf, tm_fit, n_fits, tm_out)
 end
 
 

--- a/src/api.jl
+++ b/src/api.jl
@@ -5,6 +5,9 @@ import FITSIO
 import JLD
 using Logging  # just for testing right now
 
+# We will either multi-thread the loop over sources here, or the
+# active pixels loop in ElboDeriv.jl. When that is decided, one of
+# these will be removed.
 Threaded = false
 if Threaded && VERSION > v"0.5.0-dev"
     using Base.Threads

--- a/src/api.jl
+++ b/src/api.jl
@@ -250,7 +250,7 @@ function infer(fieldids::Vector{Tuple{Int, Int, Int}},
     for s in target_sources
         tid = threadid()
         entry = catalog[s]
-        mp.active_sources = [s]
+        mp_array[tid].active_sources = [s]
 
         try
             nputs(nid, "processing source $s: objid = $(entry.objid)")

--- a/src/api.jl
+++ b/src/api.jl
@@ -8,7 +8,7 @@ using Logging  # just for testing right now
 # We will either multi-thread the loop over sources here, or the
 # active pixels loop in ElboDeriv.jl. When that is decided, one of
 # these will be removed.
-Threaded = false
+Threaded = true
 if Threaded && VERSION > v"0.5.0-dev"
     using Base.Threads
 else
@@ -247,7 +247,7 @@ function infer(fieldids::Vector{Tuple{Int, Int, Int}},
     results = Dict{Int, Dict}()
     results_lock = SpinLock()
     tic()
-    for s in target_sources
+    @threads for s in target_sources
         tid = threadid()
         entry = catalog[s]
         mp_array[tid].active_sources = [s]

--- a/test/test_derivatives.jl
+++ b/test/test_derivatives.jl
@@ -4,17 +4,6 @@ import DualNumbers
 using Celeste: Types, SampleData, SensitiveFloats, BivariateNormals, ElboDeriv
 import Celeste: Synthetic, SkyImages, ModelInit, SDSS, WCSUtils
 
-if VERSION > v"0.5.0-dev"
-    using Base.Threads
-else
-    # Pre-Julia 0.5 there are no threads
-    nthreads() = 1
-    threadid() = 1
-    macro threads(x)
-        x
-    end
-end
-
 
 println("Running derivative tests.")
 

--- a/test/test_elbo_values.jl
+++ b/test/test_elbo_values.jl
@@ -5,17 +5,6 @@ using Base.Test
 using Distributions
 
 
-if VERSION > v"0.5.0-dev"
-    using Base.Threads
-else
-    # Pre-Julia 0.5 there are no threads
-    nthreads() = 1
-    threadid() = 1
-    macro threads(x)
-        x
-    end
-end
-
 println("Running ELBO value tests.")
 
 
@@ -445,13 +434,13 @@ function test_reduce_elbo_vars_array()
     total_elbo.h += this_elbo.h
   end
 
-  ElboDeriv.reduce_elbo_vars_array!(elbo_vars_array, num_threads=array_length);
+  ElboDeriv.reduce_elbo_vars_array!(elbo_vars_array);
   @test_approx_eq elbo_vars_array[1].elbo.v total_elbo.v;
   @test_approx_eq elbo_vars_array[1].elbo.d total_elbo.d;
   @test_approx_eq elbo_vars_array[1].elbo.h total_elbo.h;
 
   # Check that running it twice doesn't double count.
-  ElboDeriv.reduce_elbo_vars_array!(elbo_vars_array, num_threads=array_length);
+  ElboDeriv.reduce_elbo_vars_array!(elbo_vars_array);
   @test_approx_eq elbo_vars_array[1].elbo.v total_elbo.v;
   @test_approx_eq elbo_vars_array[1].elbo.d total_elbo.d;
   @test_approx_eq elbo_vars_array[1].elbo.h total_elbo.h;

--- a/test/test_infer.jl
+++ b/test/test_infer.jl
@@ -14,7 +14,7 @@ function test_infer_single()
     fieldids = [(3900, 6, 269)]
     dirs = [datadir]
 
-    result = Celeste.infer(fieldids, dirs;
+    result, tm = Celeste.infer(fieldids, dirs;
                     ra_range=ra_range, dec_range=dec_range)
 end
 

--- a/test/test_score.jl
+++ b/test/test_score.jl
@@ -8,7 +8,7 @@ function test_score()
     dec_range = (0.5, 0.52)
     fieldid = (4263, 5, 119)
 
-    inferences = Celeste.infer(ra_range, dec_range, [fieldid], [datadir],
+    inferences, tm = Celeste.infer(ra_range, dec_range, [fieldid], [datadir],
                     max_iters=0, ignore_primary_mask=true)
 
     coadd_path = joinpath(datadir, "coadd_test_catalog.fit")


### PR DESCRIPTION
This will run as before on a single node and additionally output timing. Multi-node support is in progress.

Done:
- Using Dtree to distribute work.
- Add load imbalance measurement.
- Added timing for various Celeste parts.

TODO:
- Tune work item ra/dec based on load imbalance, other criteria?
- Use a thread to drive Dtree in parent nodes.
