### PR TITLE
Minimum source radius

### DIFF
--- a/dev/celeste_interactive.jl
+++ b/dev/celeste_interactive.jl
@@ -7,9 +7,9 @@ using PyPlot
 
 import FITSIO
 import JLD
-import ..SDSS
+import ..SDSSIO
 import ..WCSUtils
-
+import ..SDSS
 
 using Celeste.Types
 import Celeste.SkyImages
@@ -22,15 +22,23 @@ dir = joinpath(Pkg.dir("Celeste"), "test/data")
 #http://skyserver.sdss.org/dr8/en/tools/explore/obj.asp?id=1237662226208063623
 # 164.39678593,39.13884552
 
-run = 3900
-camcol = 6
-field = 269
+# run = 3900
+# camcol = 6
+# field = 269
+#
+# run = 3840
+# camcol = 1
+# field = 70
 
-run = 3840
-camcol = 1
-field = 70
+# objid = "1237662226208063623"
 
-objid = "1237662226208063623"
+Logging.configure(level=Logging.DEBUG)
+
+run = 4263
+camcol = 5
+field = 119
+
+objid = "1237663784734491542"
 
 make_cmd = "make RUN=$run CAMCOL=$camcol FIELD=$field"
 
@@ -42,7 +50,7 @@ run_string = @sprintf "%06d" run
 camcol_string = @sprintf "%d" camcol
 field_string = @sprintf "%04d" field
 
-cat_df = SDSS.load_catalog_df(dir, run_string, camcol_string, field_string);
+cat_df = Celeste.SDSS.load_catalog_df(dir, run_string, camcol_string, field_string);
 cat_filename = @sprintf "photoObj-%06d-%d-%04d.fits" run camcol field
 cat_entries = SkyImages.read_photoobj_celeste(joinpath(dir, cat_filename));
 
@@ -51,7 +59,7 @@ cat_entries = SkyImages.read_photoobj_celeste(joinpath(dir, cat_filename));
 tiled_blob, mp = ModelInit.initialize_celeste(images, cat_entries,
                                               tile_width=20,
                                               fit_psf=false);
-WCSUtils.pix_to_world(images[3].wcs, [0., 0.])
+Celeste.WCSUtils.pix_to_world(images[3].wcs, [0., 0.])
 
 # Choose an object:
 s = findfirst(mp.objids, objid)
@@ -62,15 +70,16 @@ mp.active_sources = [ s ];
 
 # View
 trimmed_tiled_blob =
-  ModelInit.trim_source_tiles(s, mp, tiled_blob, noise_fraction=0.01);
+  ModelInit.trim_source_tiles(s, mp, tiled_blob, noise_fraction=0.1);
 band = 3
 stitched_image, h_range, w_range =
   Celeste.SkyImages.stitch_object_tiles(s, band, mp, trimmed_tiled_blob, predicted=true);
 
-pix_loc = WCSUtils.world_to_pix(
+using Celeste.WCSUtils
+pix_loc = Celeste.WCSUtils.world_to_pix(
   mp.patches[s, band], mp.vp[s][ids.u])
 matshow(stitched_image, vmax=1200);
-PyPlot.plot(pix_loc[2] - w_range[1] + 1, pix_loc[1] - h_range[1] + 1, "wo", markersize=5)
+PyPlot.plot(pix_loc[2] - w_range[1], pix_loc[1] - h_range[1], "wo", markersize=5)
 PyPlot.colorbar()
 PyPlot.title(objid)
 

--- a/src/ModelInit.jl
+++ b/src/ModelInit.jl
@@ -667,7 +667,6 @@ function trim_source_tiles(
     println("Processing band $b...")
 
     pix_loc = WCSUtils.world_to_pix(mp.patches[s, b], mp.vp[s][ids.u]);
-    println(pix_loc)
 
     H, W = size(tiled_blob[b])
     @assert size(mp.tile_sources[b]) == size(tiled_blob[b])
@@ -697,20 +696,9 @@ function trim_source_tiles(
           close_pixel =
             (h - pix_loc[1]) ^ 2 + (w - pix_loc[2]) ^ 2 < min_radius_pix_sq
 
-          if close_pixel
-            println("Close pixel.  Bright = $bright_pixel")
-          end
           if !(bright_pixel || close_pixel)
             tile_copy.pixels[h_im, w_im] = NaN
           end
-          # if tile.constant_background
-          #   bright_pixels = pred_tile_pixels .>
-          #     (tile.iota * tile.epsilon .* noise_fraction)
-          # else
-          #   bright_pixels = pred_tile_pixels .>
-          #       (tile.iota_vec .* tile.epsilon_mat .* noise_fraction)
-          # end
-
         end
 
         trimmed_tiled_blob[b][hh, ww] = tile_copy;

--- a/test/test_derivatives.jl
+++ b/test/test_derivatives.jl
@@ -134,7 +134,7 @@ function test_real_image()
   # Limit to very few pixels so that the autodiff is reasonably fast.
   s = trimmed_mp.active_sources[1]
   very_trimmed_tiled_blob = ModelInit.trim_source_tiles(
-    s, trimmed_mp, trimmed_tiled_blob, noise_fraction=10.);
+    s, trimmed_mp, trimmed_tiled_blob, noise_fraction=10., min_radius_pix=1.0);
 
   # To see:
   # using PyPlot

--- a/test/test_elbo_values.jl
+++ b/test/test_elbo_values.jl
@@ -389,6 +389,37 @@ function test_trim_source_tiles()
       elbo_full.d[non_loc_ids, 1] ./ elbo_trim.d[non_loc_ids, 1],
       fill(1.0, length(non_loc_ids)), 4e-3)
   end
+
+  # Test min_radius_pix on just one tile.
+  b = 3
+  s_tiles = SkyImages.find_source_tiles(s, b, mp)
+
+  # Set the source to be very dim:
+  mp.vp[s][ids.r1] = 0.01
+  mp.vp[s][ids.r2] = 0.01
+
+  min_radius_pix = 6.0
+  trimmed_tiled_blob = ModelInit.trim_source_tiles(
+    s, mp, tiled_blob, noise_fraction=0.1, min_radius_pix = min_radius_pix);
+
+  total_nonempty_pixels = 0.0
+  for tile_index in s_tiles
+    tile = trimmed_tiled_blob[b][tile_index...]
+    total_nonempty_pixels += sum(!Base.isnan(tile.pixels))
+  end
+  @test_approx_eq_eps total_nonempty_pixels pi * min_radius_pix ^ 2 2.0
+
+  min_radius_pix = 0.0
+  trimmed_tiled_blob = ModelInit.trim_source_tiles(
+    s, mp, tiled_blob, noise_fraction=0.1, min_radius_pix = min_radius_pix);
+
+  total_nonempty_pixels = 0.0
+  for tile_index in s_tiles
+    tile = trimmed_tiled_blob[b][tile_index...]
+    total_nonempty_pixels += sum(!Base.isnan(tile.pixels))
+  end
+  @test total_nonempty_pixels == 0.0
+
 end
 
 


### PR DESCRIPTION
This seems to do the trick -- the problem source in https://github.com/jeff-regier/Celeste.jl/issues/186 is fit to nearly the catalog value with a minimum radius of six pixels.

Tests pending.
