### PR TITLE
Fix nm bug

### DIFF
--- a/dev/fit_psf.jl
+++ b/dev/fit_psf.jl
@@ -2,6 +2,7 @@ using Celeste
 using Celeste.Types
 using Celeste.SkyImages
 using Celeste.PSF
+using DataFrames
 
 import Celeste.SDSSIO
 
@@ -16,6 +17,9 @@ using Celeste.Transform
 datadir = joinpath(Pkg.dir("Celeste"), "test/data")
 
 using Celeste.PSF
+
+Logging.configure(level=Logging.DEBUG)
+
 
 run_num = 4263
 camcol_num = 5
@@ -38,14 +42,45 @@ raw_psf = raw_psf_comp(500., 500.);
 
 psf_params_original = PSF.initialize_psf_params(K, for_test=false);
 psf_params = deepcopy(psf_params_original)
-psf_transform = PSF.get_psf_transform(psf_params);
-psf_optimizer = PsfOptimizer(psf_transform, K, verbose=true);
-
+psf_scale = Float64[1e-2, 1e-2, 1e-1, 1e-1, 1e-1, 1.0]
+psf_transform = PSF.get_psf_transform(psf_params; scale=psf_scale);
+psf_optimizer = PsfOptimizer(psf_transform, K, verbose=true, grtol=1e-12, ftol=1e-6);
 optim_result = psf_optimizer.fit_psf(raw_psf, psf_params_original);
+
+optim_result.iterations
+optim_result.f_minimum
+optim_result.f_converged
+optim_result.gr_converged
+
 psf_params_fit =
   constrain_psf_params(
     unwrap_psf_params(optim_result.minimum), psf_optimizer.psf_transform);
 
+
+d_dict = Dict()
+d_dict["iter"] = Array(Int, 0)
+d_dict["interior"] = Array(Bool, 0)
+d_dict["delta"] = Array(Float64, 0)
+d_dict["f"] = Array(Float64, 0)
+for i = 1:length(optim_result.minimum)
+  d_dict["x$i"] = Array(Float64, 0)
+end
+for iter in 1:length(optim_result.trace.states)
+  tr = optim_result.trace.states[iter]
+  push!(d_dict["f"], tr.value)
+  push!(d_dict["iter"], iter)
+  push!(d_dict["interior"], tr.metadata["interior"])
+  push!(d_dict["delta"], tr.metadata["delta"])
+  x = tr.metadata["x"]
+  for i = 1:length(x)
+    push!(d_dict["x$i"], x[i])
+  end
+end
+
+DataFrame(d_dict)
+
+se = PSF.evaluate_psf_fit(psf_params_fit, raw_psf, true);
+eigvals(se.h)
 
 @time celeste_psf, psf_params_fit =
     PSF.fit_raw_psf_for_celeste(raw_psf, psf_optimizer, psf_params_original)

--- a/dev/fit_psf.jl
+++ b/dev/fit_psf.jl
@@ -39,7 +39,13 @@ raw_psf = raw_psf_comp(500., 500.);
 psf_params_original = PSF.initialize_psf_params(K, for_test=false);
 psf_params = deepcopy(psf_params_original)
 psf_transform = PSF.get_psf_transform(psf_params);
-psf_optimizer = PsfOptimizer(psf_transform, K);
+psf_optimizer = PsfOptimizer(psf_transform, K, verbose=true);
+
+optim_result = psf_optimizer.fit_psf(raw_psf, psf_params_original);
+psf_params_fit =
+  constrain_psf_params(
+    unwrap_psf_params(optim_result.minimum), psf_optimizer.psf_transform);
+
 
 @time celeste_psf, psf_params_fit =
     PSF.fit_raw_psf_for_celeste(raw_psf, psf_optimizer, psf_params_original)

--- a/src/PSF.jl
+++ b/src/PSF.jl
@@ -54,7 +54,7 @@ type PsfOptimizer
   psf_2df::Optim.TwiceDifferentiableFunction
   fit_psf::Function
 
-  function PsfOptimizer(psf_transform::DataTransform, K::Int)
+  function PsfOptimizer(psf_transform::DataTransform, K::Int; verbose::Bool=false)
 
     ftol = grtol = 1e-9
     num_iters = 50
@@ -123,9 +123,9 @@ type PsfOptimizer
                             grtol = grtol,
                             ftol = ftol,
                             iterations = num_iters,
-                            store_trace = false,
-                            show_trace = false,
-                            extended_trace = false,
+                            store_trace = verbose,
+                            show_trace = verbose,
+                            extended_trace = verbose,
                             initial_delta=10.0,
                             delta_hat=1e9,
                             rho_lower = 0.2)

--- a/src/PSF.jl
+++ b/src/PSF.jl
@@ -54,9 +54,9 @@ type PsfOptimizer
   psf_2df::Optim.TwiceDifferentiableFunction
   fit_psf::Function
 
-  function PsfOptimizer(psf_transform::DataTransform, K::Int; verbose::Bool=false)
+  function PsfOptimizer(psf_transform::DataTransform, K::Int;
+                        verbose::Bool=false, ftol::Float64=1e-9, grtol::Float64=1e-9)
 
-    ftol = grtol = 1e-9
     num_iters = 50
 
     bvn_derivs = BivariateNormalDerivatives{Float64}(Float64);
@@ -119,7 +119,7 @@ type PsfOptimizer
       psf_params_free_vec = vec(wrap_psf_params(psf_params_free));
       nm_result = newton_tr(psf_2df,
                             psf_params_free_vec,
-                            xtol = 0.0,
+                            xtol = 0.0, # Don't allow convergence in params
                             grtol = grtol,
                             ftol = ftol,
                             iterations = num_iters,

--- a/src/newton_trust_region.jl
+++ b/src/newton_trust_region.jl
@@ -18,6 +18,7 @@ macro newton_tr_trace()
                 dt["g(x)"] = copy(gr)
                 dt["h(x)"] = copy(H)
                 dt["delta"] = copy(delta)
+                dt["interior"] = interior
             end
             grnorm = norm(gr, Inf)
             update!(tr,
@@ -301,6 +302,9 @@ function newton_tr{T}(d::TwiceDifferentiableFunction,
 
     # Keep track of trust region sizes
     delta = copy(initial_delta)
+
+    # Record whether the point is interior in the trace.
+    interior = false
 
     # Trace the history of states visited
     tr = OptimizationTrace()

--- a/src/newton_trust_region.jl
+++ b/src/newton_trust_region.jl
@@ -353,10 +353,6 @@ function newton_tr{T}(d::TwiceDifferentiableFunction,
           rho = f_x_diff / (0 - m)
         end
 
-        # Logging.debug("m= $m")
-        # Logging.debug("f_x_diff = $f_x_diff")
-        # Logging.debug("rho = $rho")
-
         # Logging.debug("Got rho = $rho from $(f_x) - $(f_x_previous) ",
         #         "(diff = $(f_x - f_x_previous)), and m = $m")
         # Logging.debug("Interior = $interior, delta = $delta.")
@@ -374,13 +370,7 @@ function newton_tr{T}(d::TwiceDifferentiableFunction,
 
         if rho > eta
             # Accept the point and check convergence
-            # Logging.debug("Accepting improvement from f_prev=$(f_x_previous) f=$(f_x).")
-            # Logging.debug(abs(f_x - f_x_previous) / (abs(f_x) + ftol) < ftol)
-            # Logging.debug(nextfloat(f_x) >= f_x_previous)
-            # Logging.debug(f_x)
-            # Logging.debug(nextfloat(f_x))
-            # Logging.debug(f_x_previous)
-
+        
             x_converged,
             f_converged,
             gr_converged,


### PR DESCRIPTION
As I was looking into improving the quality of the PSF fit, I found a bug in my Newton's Method implementation.  When the Hessian is not PD, this bug can cause the algorithm to terminate early in certain extreme cases even when not at a local minimum.  I suspect it was not affecting the astronomy results, but it was affecting the PSF fit.

The substantive change is the line `elseif m > 0`.

Since the manifestation was an early algorithm termination, I hope that this fix should only make things better.
