### PR TITLE
Save memory

### DIFF
--- a/src/ModelInit.jl
+++ b/src/ModelInit.jl
@@ -597,6 +597,7 @@ function local_source_candidates(tiles::TiledImage,
     @assert length(patch_ctrs) == length(patch_radii_px)
 
     candidates = similar(tiles, Vector{Int})
+    patch_distances = zeros(length(patch_ctrs))
 
     for h=1:size(tiles, 1), w=1:size(tiles, 2)
         # Find the patches that are less than the radius plus diagonal from the
@@ -606,7 +607,7 @@ function local_source_candidates(tiles::TiledImage,
         tile_center = (mean(tile.h_range), mean(tile.w_range))
         tile_diag = (0.5 ^ 2) * (tile.h_width ^ 2 + tile.w_width ^ 2)
 
-        patch_distances = zeros(length(patch_ctrs))
+        fill!(patch_distances, 0.0)
         for s in 1:length(patch_ctrs)
             patch_distances[s] += (tile_center[1] - patch_ctrs[s][1])^2
             patch_distances[s] += (tile_center[2] - patch_ctrs[s][2])^2

--- a/src/ModelInit.jl
+++ b/src/ModelInit.jl
@@ -755,9 +755,9 @@ function initialize_model_params(
     for b = 1:length(blob)
         for s=1:mp.S
             mp.patches[s, b] = radius_from_cat ?
-            SkyPatch(cat[s], blob[b], fit_psf=fit_psf,
-                     scale_patch_size=scale_patch_size):
-            SkyPatch(mp.vp[s][ids.u], patch_radius, blob[b], fit_psf=fit_psf)
+                SkyPatch(cat[s], blob[b], fit_psf=fit_psf,
+                         scale_patch_size=scale_patch_size):
+                SkyPatch(mp.vp[s][ids.u], patch_radius, blob[b], fit_psf=fit_psf)
         end
         patches = vec(mp.patches[:, b])
         mp.tile_sources[b] = get_tiled_image_sources(tiled_blob[b],

--- a/src/ModelInit.jl
+++ b/src/ModelInit.jl
@@ -597,7 +597,6 @@ function local_source_candidates(tiles::TiledImage,
     @assert length(patch_ctrs) == length(patch_radii_px)
 
     candidates = similar(tiles, Vector{Int})
-    patch_distances = zeros(length(patch_ctrs))
 
     for h=1:size(tiles, 1), w=1:size(tiles, 2)
         # Find the patches that are less than the radius plus diagonal from the
@@ -607,13 +606,14 @@ function local_source_candidates(tiles::TiledImage,
         tile_center = (mean(tile.h_range), mean(tile.w_range))
         tile_diag = (0.5 ^ 2) * (tile.h_width ^ 2 + tile.w_width ^ 2)
 
-        fill!(patch_distances, 0.0)
+        candidates[h, w] = Int64[]
         for s in 1:length(patch_ctrs)
-            patch_distances[s] += (tile_center[1] - patch_ctrs[s][1])^2
-            patch_distances[s] += (tile_center[2] - patch_ctrs[s][2])^2
+            patch_dist = (tile_center[1] - patch_ctrs[s][1])^2
+                        + (tile_center[2] - patch_ctrs[s][2])^2
+            if patch_dist <= (tile_diag + patch_radii_px[s])^2
+                push!(candidates[h, w], s)
+            end
         end
-        candidates[h, w] =
-            find(patch_distances .<= (tile_diag .+ patch_radii_px) .^ 2)
     end
 
     return candidates

--- a/src/PSF.jl
+++ b/src/PSF.jl
@@ -487,7 +487,7 @@ function evaluate_psf_pixel_fit!{NumType <: Number}(
 
     end
 
-    pdf.v *= psf_params[k][psf_ids.weight]
+    pdf.v[1] *= psf_params[k][psf_ids.weight]
 
     SensitiveFloats.add_sources_sf!(pixel_value, pdf, k, calculate_derivs)
   end

--- a/src/PSF.jl
+++ b/src/PSF.jl
@@ -25,6 +25,8 @@ export evaluate_psf_fit, psf_params_to_array, psf_array_to_params,
 include("newton_trust_region.jl")
 
 
+const ID_MAT_2D = eye(Float64, 2)
+
 """
 A data type to store functions related to optimizing a PSF fit.  Initialize
 using the transform and number of components, and then call fit_psf
@@ -418,11 +420,10 @@ function evaluate_psf_pixel_fit!{NumType <: Number}(
     pixel_value::SensitiveFloat{PsfParams, NumType},
     calculate_derivs::Bool)
 
-  const ID_MAT_2D = eye(Float64, 2)
   clear!(pixel_value)
 
   K = length(psf_params)
-  sigma_ids = [psf_ids.e_axis, psf_ids.e_angle, psf_ids.e_scale]
+  sigma_ids = (psf_ids.e_axis, psf_ids.e_angle, psf_ids.e_scale)
   for k = 1:K
     # I will put in the weights later so that the log pdf sensitive float
     # is accurate.

--- a/src/PSF.jl
+++ b/src/PSF.jl
@@ -577,7 +577,7 @@ function evaluate_psf_fit!{NumType <: Number}(
         bvn_derivs, log_pdf, pdf, pixel_value, calculate_derivs)
 
     diff = (pixel_value.v[1] - raw_psf[x_ind])
-    squared_error.v +=  diff ^ 2
+    squared_error.v[1] +=  diff ^ 2
     if calculate_derivs
       for ind1 = 1:length(squared_error.d)
         squared_error.d[ind1] += 2 * diff * pixel_value.d[ind1]


### PR DESCRIPTION
A crazy amount of memory was getting allocated in two places, where a singleton vector gets multiplied in place by a scalar, without specifying `1` as the index.

Fixing them should help with the runtime of PSF fitting. I don't think it addresses the high peak memory usage, however, since this memory was likely being freed each time the function call completed.
