### PR TITLE
Reduce memory usage by 70%

### DIFF
--- a/bin/celeste.jl
+++ b/bin/celeste.jl
@@ -19,7 +19,7 @@ Usage:
 Options:
   -h, --help         Show this screen.
   --version          Show the version.
-  --logging=<LEVEL>  Level for the Logging package (OFF, DEBUG, INFO, WARNING, ERROR, or CRITICAL). [default: WARNING]
+  --logging=<LEVEL>  Level for the Logging package (OFF, DEBUG, INFO, WARNING, ERROR, or CRITICAL). [default: INFO]
 
 The `stage-box` subcommand copies and/or uncompresses all files covering the
 given RA/Dec range from /project to user's SCRATCH directory.
@@ -34,10 +34,28 @@ field, using only that field.
 The `score-field` subcommand is not yet implemented for the new API.
 """
 
+function set_logging_level(level)
+    if level == "OFF"
+      Logging.configure(level=Logging.OFF)
+    elseif level == "DEBUG"
+      Logging.configure(level=Logging.DEBUG)
+    elseif level == "INFO"
+      Logging.configure(level=Logging.INFO)
+    elseif level == "WARNING"
+      Logging.configure(level=Logging.WARNING)
+    elseif level == "ERROR"
+      Logging.configure(level=Logging.ERROR)
+    elseif level == "CRITICAL"
+      Logging.configure(level=Logging.CRITICAL)
+    else
+      Logging.err("Unknown logging level $(level)")
+    end
+end
+
+
 function main()
-    Celeste.set_logging_level("WARNING")
     args = docopt(DOC, version=v"0.1.0", options_first=true)
-    Celeste.set_logging_level(args["--logging"])
+    set_logging_level(args["--logging"])
     if args["stage-box"] || args["infer-box"]
         ramin = parse(Float64, args["<ramin>"])
         ramax = parse(Float64, args["<ramax>"])

--- a/src/ElboDeriv.jl
+++ b/src/ElboDeriv.jl
@@ -696,8 +696,7 @@ function get_expected_pixel_brightness!{NumType <: Number}(
   if include_epsilon
     # There are no derivatives with respect to epsilon, so can safely add
     # to the value.
-    elbo_vars.E_G.v[1] +=
-      tile.constant_background ? tile.epsilon : tile.epsilon_mat[h, w]
+    elbo_vars.E_G.v[1] += tile.epsilon_mat[h, w]
   end
 
   true
@@ -815,7 +814,7 @@ function process_active_pixels!{NumType <: Number}(
       mp, tile_sources, include_epsilon=true)
 
     # Add the terms to the elbo given the brightness.
-    iota = tile.constant_background ? tile.iota : tile.iota_vec[pixel.h]
+    iota = tile.iota_vec[pixel.h]
     add_elbo_log_term!(elbo_vars, this_pixel, iota)
     add_scaled_sfs!(elbo_vars.elbo,
                     elbo_vars.E_G, -iota,
@@ -865,7 +864,7 @@ function tile_predicted_image{NumType <: Number}(
         get_expected_pixel_brightness!(
           elbo_vars, h, w, sbs, star_mcs, gal_mcs, tile,
           mp, tile_sources, include_epsilon=include_epsilon)
-        iota = tile.constant_background ? tile.iota : tile.iota_vec[h]
+        iota = tile.iota_vec[h]
         predicted_pixels[h, w] = elbo_vars.E_G.v[1] * iota
       end
     end

--- a/src/ElboDeriv.jl
+++ b/src/ElboDeriv.jl
@@ -717,7 +717,7 @@ Args:
 """
 function add_elbo_log_term!{NumType <: Number}(
     elbo_vars::ElboIntermediateVariables{NumType},
-    x_nbm::Float64, iota::Float64)
+    x_nbm::AbstractFloat, iota::AbstractFloat)
 
   # See notes for a derivation.  The log term is
   # log E[G] - Var(G) / (2 * E[G] ^2 )

--- a/src/ElboDeriv.jl
+++ b/src/ElboDeriv.jl
@@ -803,7 +803,7 @@ function process_active_pixels!{NumType <: Number}(
 
   # iterate over the pixels
   for pixel in active_pixels
-    tile = tiled_blob[pixel.b][pixel.tile_ind]
+    tile = tiled_blob[pixel.b].tiles[pixel.tile_ind]
     tile_sources = mp.tile_sources[pixel.b][pixel.tile_ind]
     this_pixel = tile.pixels[pixel.h, pixel.w]
 
@@ -913,10 +913,10 @@ function get_active_pixels{NumType <: Number}(
     tiled_blob::TiledBlob, mp::ModelParams{NumType})
 
   active_pixels = ActivePixel[]
-  for b in 1:length(tiled_blob), tile_ind in 1:length(tiled_blob[b])
+  for b in 1:length(tiled_blob), tile_ind in 1:length(tiled_blob[b].tiles)
     tile_sources = mp.tile_sources[b][tile_ind]
     if length(intersect(tile_sources, mp.active_sources)) > 0
-      tile = tiled_blob[b][tile_ind]
+      tile = tiled_blob[b].tiles[tile_ind]
       for w in 1:tile.w_width, h in 1:tile.h_width
         if !Base.isnan(tile.pixels[h, w])
           push!(active_pixels, ActivePixel(b, tile_ind, h, w))

--- a/src/Model.jl
+++ b/src/Model.jl
@@ -1,13 +1,11 @@
 module Model
 
-export CatalogEntry,
-       Image, Blob,
-       TiledImage, TiledBlob,
-       ImageTile, SkyPatch, PsfComponent,
-       GalaxyComponent, GalaxyPrototype
-
 # parameter types
-export ModelParams, PriorParams, UnconstrainedParams,
+export CatalogEntry,
+       Image, Blob, TiledImage, TiledBlob, ImageTile, 
+       SkyPatch, PsfComponent,
+       GalaxyComponent, GalaxyPrototype,
+       ModelParams, PriorParams, UnconstrainedParams,
        CanonicalParams, BrightnessParams, StarPosParams,
        GalaxyPosParams, GalaxyShapeParams,
        VariationalParams, FreeVariationalParams, RectVariationalParams,
@@ -21,8 +19,7 @@ export band_letters, D, Ia, B, psf_K, galaxy_prototypes,
        shape_standard_alignment,
        brightness_standard_alignment,
        gal_shape_alignment,
-       ids_names,
-       ids_free_names,
+       ids_names, ids_free_names,
        ids, ids_free, star_ids, gal_ids, gal_shape_ids, psf_ids, bids
 
 
@@ -49,89 +46,7 @@ include("psf_model.jl")
 include("image_model.jl")
 include("param_set.jl")
 include("imaged_sources.jl")
+include("model_params.jl")
 
-
-# A vector of variational parameters.  The outer index is
-# of celestial objects, and the inner index is over individual
-# parameters for that object (referenced using ParamIndex).
-
-typealias VariationalParams{NumType <: Number} Vector{Vector{NumType}}
-typealias RectVariationalParams{NumType <: Number} Vector{Vector{NumType}}
-typealias FreeVariationalParams{NumType <: Number} Vector{Vector{NumType}}
-
-
-"""
-The parameters for a particular image.
-
-Attributes:
- - vp: The variational parameters
- - pp: The prior parameters
- - patches: An (objects X bands) matrix of SkyPatch objects
- - tile_width: The number of pixels across a tile
- - tile_sources: A vector (over bands) of an array (over tiles) of vectors
-                 of sources influencing each tile.
- - active_sources: Indices of the sources that are currently being fit by the
-                   model.
- - objids: Global object ids for the sources in this ModelParams object.
-
- - S: The number of sources.
-"""
-type ModelParams{T <: Number}
-    vp::VariationalParams{T}
-    pp::PriorParams
-    patches::Array{SkyPatch, 2}
-    tile_sources::Vector{Array{Vector{Int}, 2}}
-    active_sources::Vector{Int}
-    objids::Vector{ASCIIString}
-
-    S::Int
-
-    function ModelParams(vp::VariationalParams{T}, pp::PriorParams)
-        # There must be one patch for each celestial object.
-        S = length(vp)
-        all_tile_sources = fill(fill(collect(1:S), 1, 1), 5)
-        patches = Array(SkyPatch, S, 5)
-        active_sources = collect(1:S)
-        objids = ASCIIString[string(s) for s in 1:S]
-
-        new(vp, pp, patches, all_tile_sources, active_sources, objids, S)
-    end
-end
-
-
-# Make a copy of a ModelParams keeping only some sources.
-function ModelParams{T <: Number}(mp_all::ModelParams{T}, keep_s::Vector{Int})
-    mp = ModelParams{T}(deepcopy(mp_all.vp[keep_s]), mp_all.pp);
-    mp.active_sources = Int[]
-    mp.objids = Array(ASCIIString, length(keep_s))
-    mp.patches = Array(SkyPatch, mp.S, size(mp_all.patches, 2))
-
-    # Indices of sources in the new model params
-    for sa in 1:length(keep_s)
-        s = keep_s[sa]
-        mp.objids[sa] = mp_all.objids[s]
-        mp.patches[sa, :] = mp_all.patches[s, :]
-        if s in mp_all.active_sources
-            push!(mp.active_sources, sa)
-        end
-    end
-
-    @assert length(mp_all.tile_sources) == size(mp_all.patches, 2)
-    num_bands = length(mp_all.tile_sources)
-    mp.tile_sources = Array(Matrix{Vector{Int}}, num_bands)
-    for b=1:num_bands
-        mp.tile_sources[b] = Array(Vector{Int}, size(mp_all.tile_sources[b]))
-        for tile_ind in 1:length(mp_all.tile_sources[b])
-                tile_s = intersect(mp_all.tile_sources[b][tile_ind], keep_s)
-                mp.tile_sources[b][tile_ind] =
-                    Int[ findfirst(keep_s, s) for s in tile_s ]
-        end
-    end
-
-    mp
-end
-
-ModelParams{T <: Number}(vp::VariationalParams{T}, pp::PriorParams) =
-    ModelParams{T}(vp, pp)
 
 end  # module

--- a/src/ModelInit.jl
+++ b/src/ModelInit.jl
@@ -242,11 +242,8 @@ function trim_source_tiles(s::Int,
                     w_im = w - minimum(tile.w_range) + 1
 
                     keep_pixel = false
-                    bright_pixel = tile.constant_background ?
-                        pred_tile_pixels[h_im, w_im] >
-                            tile.iota * tile.epsilon * noise_fraction:
-                        pred_tile_pixels[h_im, w_im] >
-                            tile.iota_vec[h_im] * tile.epsilon_mat[h_im, w_im] * noise_fraction
+                    bright_pixel = pred_tile_pixels[h_im, w_im] >
+                       tile.iota_vec[h_im] * tile.epsilon_mat[h_im, w_im] * noise_fraction
                     close_pixel =
                         (h - pix_loc[1]) ^ 2 + (w - pix_loc[2]) ^ 2 < min_radius_pix_sq
 
@@ -263,10 +260,13 @@ function trim_source_tiles(s::Int,
                 # say that an empty tile has a source.
                 # TODO: Make a TiledBlob simply an array of an array of tiles
                 # rather than a 2d array to avoid this hack.
-                empty_tile = ImageTile(b, tile.h_range, tile.w_range,
-                                       tile.h_width, tile.w_width,
-                                       Array(Float64, 0, 0), tile.constant_background,
-                                       tile.epsilon, Array(Float64, 0, 0), tile.iota,
+                empty_tile = ImageTile(b,
+                                       tile.h_range,
+                                       tile.w_range,
+                                       tile.h_width,
+                                       tile.w_width,
+                                       Array(Float64, 0, 0),
+                                       Array(Float64, 0, 0),
                                        Array(Float64, 0))
 
                 trimmed_tiled_blob[b][hh, ww] = empty_tile;

--- a/src/ModelInit.jl
+++ b/src/ModelInit.jl
@@ -1,17 +1,3 @@
-"""
-This module contains code that necessary to initialize the model,
-but that couldn't go in Model because of dependence on modules 
-that import Model (i.e. PSF and ElboDeriv)
-
-Eventually the dependency on ElboDeriv will be severed when we
-move to using blob detection algorithms to decide what pixels
-are relevant, rather than rendering the image ElboDeriv to
-screen pixels. (Eventually we won't have a good initial catalog.)
-
-The PSF module should eventually be included in Model, once
-we're learning the PSF outselves, rather than fitting SDSS.
-Until then, we have both Model and ModelInit.
-"""
 module ModelInit
 
 import Logging
@@ -25,9 +11,6 @@ import ..PSF
 Initilize the model params to the given catalog and tiled image.
 
 Args:
-  - tiled_blob: A TiledBlob
-  - blob: The original Blob
-  - cat: A vector of catalog entries
   - fit_psf: Whether to give each patch its own local PSF
   - patch_radius: If set less than Inf or if radius_from_cat=false,
                   the radius in world coordinates of each patch.
@@ -35,13 +18,10 @@ Args:
                      If false, use patch_radius for each patch.
 """
 function initialize_model_params(
-            tiled_blob::TiledBlob,
-            blob::Blob,
+            images::Vector{TiledImage},
             cat::Vector{CatalogEntry};
             fit_psf::Bool=true,
             patch_radius::Float64=NaN)
-
-    @assert length(tiled_blob) == length(blob)
     @assert length(cat) > 0
 
     Logging.info("Loading variational parameters from catalogs.")
@@ -50,11 +30,12 @@ function initialize_model_params(
     mp = ModelParams(vp, Model.prior)
     mp.objids = ASCIIString[cat_entry.objid for cat_entry in cat]
 
-    mp.patches = Array(SkyPatch, mp.S, length(blob))
-    mp.tile_sources = Array(Array{Vector{Int}, 2}, length(blob))
+    N = length(images)
+    mp.patches = Array(SkyPatch, mp.S, N)
+    mp.tile_sources = Array(Array{Vector{Int}, 2}, N)
 
-    for b = 1:length(blob)
-        img = blob[b]
+    for i = 1:N
+        img = images[i]
 
         for s=1:mp.S
             world_center = cat[s].pos
@@ -70,15 +51,19 @@ function initialize_model_params(
                 radius_pix = maxabs(eigvals(wcs_jacobian)) * patch_radius
             end
 
-            mp.patches[s, b] = SkyPatch(world_center,
+            mp.patches[s, i] = SkyPatch(world_center,
                                         radius_pix,
                                         psf,
                                         wcs_jacobian,
                                         pixel_center)
         end
 
-        mp.tile_sources[b] = Model.get_tiled_image_sources(tiled_blob[b],
-                                                           mp.patches[:, b])
+        # TODO: get rid of these puny methods
+        patch_centers = Model.patch_ctrs_pix(mp.patches[:, i])
+        patch_radii = Model.patch_radii_pix(mp.patches[:, i])
+
+        mp.tile_sources[i] = Model.get_sources_per_tile(images[i].tiles,
+                                               patch_centers, patch_radii)
     end
 
     return mp
@@ -142,44 +127,44 @@ end
 
 """
 Args:
-  - mp: A ModelParams whose patches will be updated.
   - relevant_sources: A vector of source ids that index into mp.patches
-  - blob: A vector of images.
 
 Returns:
   - Updates mp.patches in place with fitted psfs for each source in
     relevant_sources.
 """
 function fit_object_psfs!{NumType <: Number}(
-    mp::ModelParams{NumType}, target_sources::Vector{Int}, blob::Blob)
-
+                        mp::ModelParams{NumType}, 
+                        target_sources::Vector{Int},
+                        images::Vector{TiledImage})
     # Initialize an optimizer
     initial_psf_params = PSF.initialize_psf_params(psf_K, for_test=false);
     psf_transform = PSF.get_psf_transform(initial_psf_params);
     psf_optimizer = PSF.PsfOptimizer(psf_transform, psf_K);
 
-    @assert size(mp.patches, 2) == length(blob)
+    @assert size(mp.patches, 2) == length(images)
 
-    for b in 1:length(blob)    # loop over images
-        Logging.debug("Fitting PSFS for band $b")
+    for i in 1:length(images)
+        Logging.debug("Fitting PSFS for band $i")
         # Get a starting point in the middle of the image.
-        pixel_loc = Float64[ blob[b].H / 2.0, blob[b].W / 2.0 ]
-        raw_central_psf = blob[b].raw_psf_comp(pixel_loc[1], pixel_loc[2])
+        pixel_loc = Float64[ images[i].H / 2.0, images[i].W / 2.0 ]
+        raw_central_psf = images[i].raw_psf_comp(pixel_loc[1], pixel_loc[2])
         central_psf, central_psf_params =
-            PSF.fit_raw_psf_for_celeste(raw_central_psf, psf_optimizer, initial_psf_params)
+            PSF.fit_raw_psf_for_celeste(raw_central_psf,
+                                psf_optimizer, initial_psf_params)
 
         # Get all relevant sources *in this image*
-        relevant_sources = get_all_relevant_sources_in_image(mp.tile_sources[b],
+        relevant_sources = get_all_relevant_sources_in_image(mp.tile_sources[i],
                                                              target_sources)
 
         for s in relevant_sources
-            Logging.debug("Fitting PSF for b=$b, source=$s, objid=$(mp.objids[s])")
-            patch = mp.patches[s, b]
+            Logging.debug("Fitting PSF for b=$i, source=$s, objid=$(mp.objids[s])")
+            patch = mp.patches[s, i]
             # Set the starting point at the center's PSF.
             psf, psf_params =
                 PSF.get_source_psf(
-                    patch.center, blob[b], psf_optimizer, central_psf_params)
-            mp.patches[s, b] = SkyPatch(patch, psf)
+                    patch.center, images[i], psf_optimizer, central_psf_params)
+            mp.patches[s, i] = SkyPatch(patch, psf)
         end
     end
 end
@@ -205,11 +190,13 @@ Returns:
   be the same as the original tiles but with NaN where the expected source
   electron counts are below <noise_fraction> of the noise at that pixel.
 """
-function trim_source_tiles!(s::Int,
+function trim_source_tiles(s::Int,
                            mp::ModelParams{Float64},
                            tiled_blob::TiledBlob;
                            noise_fraction::Float64=0.1,
                            min_radius_pix::Float64=8.0)
+    trimmed = deepcopy(tiled_blob)
+
     min_radius_pix_sq = min_radius_pix ^ 2
     for b = 1:length(tiled_blob)
         patch = mp.patches[s, b]
@@ -218,10 +205,10 @@ function trim_source_tiles!(s::Int,
                                         patch.pixel_center,
                                         mp.vp[s][ids.u])
 
-        H, W = size(tiled_blob[b])
-        @assert size(mp.tile_sources[b]) == size(tiled_blob[b])
-        for hh=1:H, ww=1:W
-            tile = tiled_blob[b][hh, ww];
+        Ht, Wt = size(tiled_blob[b].tiles)
+        @assert size(mp.tile_sources[b]) == size(tiled_blob[b].tiles)
+        for hh=1:Ht, ww=1:Wt
+            tile = tiled_blob[b].tiles[hh, ww];
             tile_sources = mp.tile_sources[b][hh, ww]
             if s in tile_sources
                 pred_tile_pixels =
@@ -239,7 +226,7 @@ function trim_source_tiles!(s::Int,
                         (h - pix_loc[1]) ^ 2 + (w - pix_loc[2]) ^ 2 < min_radius_pix_sq
 
                     if !(bright_pixel || close_pixel)
-                        tiled_blob[b][hh, ww].pixels[h_im, w_im] = NaN
+                        trimmed[b].tiles[hh, ww].pixels[h_im, w_im] = NaN
                     end
                 end
             else
@@ -249,17 +236,19 @@ function trim_source_tiles!(s::Int,
                 # say that an empty tile has a source.
                 # TODO: Make a TiledBlob simply an array of an array of tiles
                 # rather than a 2d array to avoid this hack.
-                tiled_blob[b][hh, ww] = ImageTile(b,
-                                          tile.h_range,
-                                          tile.w_range,
-                                          tile.h_width,
-                                          tile.w_width,
-                                          Array(Float64, 0, 0),
-                                          Array(Float64, 0, 0),
-                                          Array(Float64, 0))
+                trimmed[b].tiles[hh, ww] = ImageTile(b,
+                                              tile.h_range,
+                                              tile.w_range,
+                                              tile.h_width,
+                                              tile.w_width,
+                                              Array(Float64, 0, 0),
+                                              Array(Float64, 0, 0),
+                                              Array(Float64, 0))
             end
         end
     end
+
+    trimmed
 end
 
 end

--- a/src/PSF.jl
+++ b/src/PSF.jl
@@ -12,13 +12,6 @@ using Celeste.SensitiveFloats.clear!
 import Optim
 import WCS
 
-export evaluate_psf_fit, psf_params_to_array, psf_array_to_params,
-       get_psf_transform, initialize_psf_params, transform_psf_params!,
-       unwrap_psf_params, wrap_psf_params,
-       unconstrain_psf_params, constrain_psf_params,
-       transform_psf_sensitive_float!,
-       PsfOptimizer, fit_raw_psf_for_celeste,
-       get_psf_at_point, get_source_psf
 
  # Only include until this is merged with Optim.jl.
 include("newton_trust_region.jl")

--- a/src/PSF.jl
+++ b/src/PSF.jl
@@ -169,13 +169,13 @@ Get the PSF located at a particular world location in an image.
 
 Args:
  - world_loc: A location in world coordinates.
- - img: An Image
+ - img: An TiledImage
 
 Returns:
  - An array of PsfComponent objects that represents the PSF as a mixture
    of Gaussians.
 """
-function get_source_psf(world_loc::Vector{Float64}, img::Image)
+function get_source_psf(world_loc::Vector{Float64}, img::TiledImage)
   # Some stamps or simulated data have no raw psf information.  In that case,
   # just use the psf from the image.
   if size(img.raw_psf_comp.rrows) == (0, 0)
@@ -194,14 +194,14 @@ Get the PSF located at a particular world location in an image.
 
 Args:
  - world_loc: A location in world coordinates.
- - img: An Image
+ - img: An TiledImage
 
 Returns:
  - An array of PsfComponent objects that represents the PSF as a mixture
    of Gaussians.
 """
 function get_source_psf(
-    world_loc::Vector{Float64}, img::Image,
+    world_loc::Vector{Float64}, img::TiledImage,
     psf_optimizer::PSF.PsfOptimizer, initial_psf_params::Vector{Vector{Float64}})
 
   # Some stamps or simulated data have no raw psf information.  In that case,

--- a/src/SDSSIO.jl
+++ b/src/SDSSIO.jl
@@ -267,14 +267,12 @@ function load_field_images(
         # epsilon * iota needs to be in units comparable to nelec
         # electron counts.
         # Note that each are actuall pretty variable.
-        iota = Float64(gains[band] / median(calibration))
-        epsilon = Float64(median(sky) * median(calibration))
         iota_vec = convert(Vector{Float64}, gains[band] ./ calibration)
         epsilon_mat = convert(Array{Float64, 2}, sky .* calibration)
 
         # Set it to use a constant background but include the non-constant data.
-        result[bandnum] = Image(H, W, data, bandnum, wcs, epsilon, iota, psf,
-                                run, camcol, field, false, epsilon_mat,
+        result[bandnum] = Image(H, W, data, bandnum, wcs, psf,
+                                run, camcol, field, epsilon_mat,
                                 iota_vec, sdsspsf)
     end
 

--- a/src/SDSSIO.jl
+++ b/src/SDSSIO.jl
@@ -225,7 +225,7 @@ function load_field_images(
     # read gain for each band
     photofield_name = @sprintf("%s/photoField-%06d-%d.fits",
                                photofield_dir, run, camcol)
-    gains = SDSSIO.read_field_gains(photofield_name, field)
+    gains = read_field_gains(photofield_name, field)
 
     # open FITS file containing PSF for each band
     psf_name = @sprintf("%s/psField-%06d-%d-%04d.fit",
@@ -239,15 +239,15 @@ function load_field_images(
         # load image data
         frame_name = @sprintf("%s/frame-%s-%06d-%d-%04d.fits",
                               frame_dir, band, run, camcol, field)
-        data, calibration, sky, wcs = SDSSIO.read_frame(frame_name)
+        data, calibration, sky, wcs = read_frame(frame_name)
 
         # scale data to raw electron counts
-        SDSSIO.decalibrate!(data, sky, calibration, gains[band])
+        decalibrate!(data, sky, calibration, gains[band])
 
         # read mask
         mask_name = @sprintf("%s/fpM-%06d-%s%d-%04d.fit",
                              fpm_dir, run, band, camcol, field)
-        mask_xranges, mask_yranges = SDSSIO.read_mask(mask_name)
+        mask_xranges, mask_yranges = read_mask(mask_name)
 
         # apply mask
         for i=1:length(mask_xranges)
@@ -257,7 +257,7 @@ function load_field_images(
         H, W = size(data)
 
         # read the psf
-        sdsspsf = SDSSIO.read_psf(psffile, band)
+        sdsspsf = read_psf(psffile, band)
 
         # evalute the psf in the center of the image and then fit it.
         psfstamp = sdsspsf(H / 2., W / 2.)
@@ -498,7 +498,7 @@ end
 
 """
 Convert from a catalog in dictionary-of-arrays, as returned by
-SDSSIO.read_photoobj to Vector{CatalogEntry}.
+read_photoobj to Vector{CatalogEntry}.
 """
 function convert(::Type{Vector{CatalogEntry}}, catalog::Dict{ASCIIString, Any})
     out = Array(CatalogEntry, length(catalog["objid"]))
@@ -583,7 +583,7 @@ function read_photoobj_files(fieldids::Vector{Tuple{Int, Int, Int}}, dirs;
         dir = dirs[i]
         fname = @sprintf "%s/photoObj-%06d-%d-%04d.fits" dir run camcol field
         Logging.info("field $(fieldids[i]): reading $fname")
-        rawcatalogs[i] = SDSSIO.read_photoobj(fname)
+        rawcatalogs[i] = read_photoobj(fname)
     end
 
     for i in eachindex(fieldids)
@@ -636,7 +636,7 @@ read_photoobj_celeste(fname)
 Read a SDSS \"photoobj\" FITS catalog into a Vector{CatalogEntry}.
 """
 function read_photoobj_celeste(fname)
-    rawcatalog = SDSSIO.read_photoobj(fname)
+    rawcatalog = read_photoobj(fname)
     convert(Vector{CatalogEntry}, rawcatalog)
 end
 

--- a/src/SensitiveFloats.jl
+++ b/src/SensitiveFloats.jl
@@ -224,7 +224,7 @@ Update sf1 in place with (sf1 + scale * sf2).
 function add_scaled_sfs!{ParamType <: ParamSet, NumType <: Number}(
     sf1::SensitiveFloat{ParamType, NumType},
     sf2::SensitiveFloat{ParamType, NumType},
-    scale::Float64, calculate_hessian::Bool)
+    scale::AbstractFloat, calculate_hessian::Bool)
 
   sf1.v[1] = sf1.v[1] + scale * sf2.v[1]
 

--- a/src/api.jl
+++ b/src/api.jl
@@ -382,7 +382,7 @@ function infer(fieldids::Vector{Tuple{Int, Int, Int}},
         else
             entry = catalog[s]
 
-            try
+#            try
                 nputs(dt_nodeid, "processing source $s: objid = $(entry.objid)")
                 #tic()
 
@@ -406,6 +406,8 @@ function infer(fieldids::Vector{Tuple{Int, Int, Int}},
                                             verbose=false, max_iters=max_iters)
                 fit_time = time() - t0
 
+                gc()
+
                 #t = toq()
                 #nputs(dt_nodeid, "optimized $s in $t secs, writing results")
 
@@ -417,9 +419,9 @@ function infer(fieldids::Vector{Tuple{Int, Int, Int}},
                                                "init_time"=>init_time,
                                                "fit_time"=>fit_time)
                 unlock!(results_lock)
-            catch ex
-                Logging.err(ex)
-            end
+#            catch ex
+#                Logging.err(ex)
+#            end
         end
     end
     timing.opt_srcs = toq()

--- a/src/api.jl
+++ b/src/api.jl
@@ -382,7 +382,7 @@ function infer(fieldids::Vector{Tuple{Int, Int, Int}},
         else
             entry = catalog[s]
 
-#            try
+            try
                 nputs(dt_nodeid, "processing source $s: objid = $(entry.objid)")
                 gc()
 
@@ -419,9 +419,9 @@ function infer(fieldids::Vector{Tuple{Int, Int, Int}},
                                                "init_time"=>init_time,
                                                "fit_time"=>fit_time)
                 unlock!(results_lock)
-#            catch ex
-#                Logging.err(ex)
-#            end
+            catch ex
+                Logging.err(ex)
+            end
         end
     end
     timing.opt_srcs = toq()

--- a/src/api.jl
+++ b/src/api.jl
@@ -384,6 +384,8 @@ function infer(fieldids::Vector{Tuple{Int, Int, Int}},
 
 #            try
                 nputs(dt_nodeid, "processing source $s: objid = $(entry.objid)")
+                gc()
+
                 #tic()
 
                 t0 = time()
@@ -405,8 +407,6 @@ function infer(fieldids::Vector{Tuple{Int, Int, Int}},
                                             mp_source;
                                             verbose=false, max_iters=max_iters)
                 fit_time = time() - t0
-
-                gc()
 
                 #t = toq()
                 #nputs(dt_nodeid, "optimized $s in $t secs, writing results")

--- a/src/api.jl
+++ b/src/api.jl
@@ -383,8 +383,7 @@ function infer(fieldids::Vector{Tuple{Int, Int, Int}},
                 mp_source = ModelParams(mp, relevant_sources)
                 sa = findfirst(relevant_sources, s)
                 mp_source.active_sources = Int[ sa ]
-                trimmed_tiled_images =
-                  ModelInit.trim_source_tiles(sa, mp_source, tiled_images;
+                ModelInit.trim_source_tiles(sa, mp_source, tiled_images;
                                               noise_fraction=0.1)
                 init_time = time() - t0
 
@@ -394,7 +393,7 @@ function infer(fieldids::Vector{Tuple{Int, Int, Int}},
 
                 t0 = time()
                 iter_count, max_f, max_x, result =
-                    OptimizeElbo.maximize_f(ElboDeriv.elbo, trimmed_tiled_images,
+                    OptimizeElbo.maximize_f(ElboDeriv.elbo, tiled_images,
                                             mp_source;
                                             verbose=false, max_iters=max_iters)
                 fit_time = time() - t0

--- a/src/api.jl
+++ b/src/api.jl
@@ -1,15 +1,12 @@
-# Functions for interacting with Celeste from the command line.
-
 import FITSIO
 import JLD
-import Logging  # just for testing right now
+import Logging
 
 using .Model
 import .SDSSIO
 import .ModelInit
 import .OptimizeElbo
 
-import .TrimSourceTiles
 
 const TILE_WIDTH = 20
 const DEFAULT_MAX_ITERS = 50
@@ -115,6 +112,7 @@ end
 @inline nputs(nid, s) = ccall(:puts, Cint, (Ptr{Int8},), string("[$nid] ", s))
 @inline phalse(b) = b[] = false
 
+
 function time_puts(elapsedtime, bytes, gctime, allocs)
     s = @sprintf("%10.6f seconds", elapsedtime/1e9)
     if bytes != 0 || allocs != 0
@@ -143,24 +141,6 @@ function time_puts(elapsedtime, bytes, gctime, allocs)
         s = string(s, @sprintf(", %.2f%% gc time", 100*gctime/elapsedtime))
     end
     nputs(dt_nodeid, s)
-end
-
-function set_logging_level(level)
-    if level == "OFF"
-      Logging.configure(level=Logging.OFF)
-    elseif level == "DEBUG"
-      Logging.configure(level=Logging.DEBUG)
-    elseif level == "INFO"
-      Logging.configure(level=Logging.INFO)
-    elseif level == "WARNING"
-      Logging.configure(level=Logging.WARNING)
-    elseif level == "ERROR"
-      Logging.configure(level=Logging.ERROR)
-    elseif level == "CRITICAL"
-      Logging.configure(level=Logging.CRITICAL)
-    else
-      Logging.err("Unknown logging level $(level)")
-    end
 end
 
 
@@ -234,7 +214,8 @@ function divide_and_infer(ra_range::Tuple{Float64, Float64},
         itimes.get_dirs = toq()
 
         # run inference for this subarea
-        results = infer(fieldids, frame_dirs;
+        results = infer(fieldids,
+                        frame_dirs;
                         ra_range=(iramin, iramax),
                         dec_range=(idecmin, idecmax),
                         fpm_dirs=frame_dirs,
@@ -260,67 +241,6 @@ function divide_and_infer(ra_range::Tuple{Float64, Float64},
     end
     finalize(dt)
     timing.wait_done = toq()
-end
-
-
-"""
-Update ModelParams with the PSFs for a range of object ids.
-
-Args:
-  - mp: A ModelParams whose patches will be updated.
-  - relevant_sources: A vector of source ids that index into mp.patches
-  - blob: A vector of images.
-
-Returns:
-  - Updates mp.patches in place with fitted psfs for each source in
-    relevant_sources.
-
-TODO: Unify with ModelInit.fit_object_psfs! when threading is part of all of
-      Celeste.
-"""
-function fit_object_psfs_threaded!{NumType <: Number}(
-    mp::ModelParams{NumType}, target_sources::Vector{Int}, blob::Blob)
-
-  # Initialize a vector of optimizers and transforms.
-  initial_psf_params = PSF.initialize_psf_params(psf_K, for_test=false);
-  psf_transform = PSF.get_psf_transform(initial_psf_params);
-  psf_optimizer_vec = Array(PSF.PsfOptimizer, nthreads())
-  for tid in 1:nthreads()
-    psf_optimizer_vec[tid] = PSF.PsfOptimizer(deepcopy(psf_transform), psf_K);
-  end
-
-  @assert size(mp.patches, 2) == length(blob)
-
-  for b in 1:length(blob)  # loop over images
-    Logging.debug("Fitting PSFS for band $b")
-    # Get a starting point in the middle of the image.
-    pixel_loc = Float64[ blob[b].H / 2.0, blob[b].W / 2.0 ]
-    raw_central_psf = blob[b].raw_psf_comp(pixel_loc[1], pixel_loc[2])
-    central_psf, central_psf_params =
-      PSF.fit_raw_psf_for_celeste(raw_central_psf, psf_optimizer_vec[1], initial_psf_params)
-
-    # Get all relevant sources *in this image*
-    relevant_sources = Model.get_all_relevant_sources_in_image(
-                                    mp.tiles_sources[b], target_sources)
-
-    mp_lock = SpinLock()
-    @threads for s in relevant_sources
-      tid = threadid()
-      Logging.debug("Thread $tid: fitting PSF for b=$b, source=$s, objid=$(mp.objids[s])")
-      patch = mp.patches[s, b]
-
-      # Set the starting point at the center's PSF.
-      psf, psf_params =
-        PSF.get_source_psf(
-          patch.center, blob[b], psf_optimizer_vec[tid], central_psf_params)
-      new_patch = ModelInit.SkyPatch(patch, psf);
-
-      # Copy to the global array of patches.
-      lock!(mp_lock)
-      mp.patches[s, b] = new_patch
-      unlock!(mp_lock)
-    end
-  end
 end
 
 
@@ -502,276 +422,6 @@ function infer(fieldids::Vector{Tuple{Int, Int, Int}},
 end
 
 
-# -----------------------------------------------------------------------------
-# NERSC-specific functions
-
-"""
-Query the SDSS database for all fields that overlap the given RA, Dec range.
-"""
-function query_overlapping_fields(ramin, ramax, decmin, decmax)
-
-    fname = "/project/projectdirs/dasrepo/celeste-sc16/field_extents.fits"
-
-    f = FITSIO.FITS(fname)
-    hdu = f[2]::FITSIO.TableHDU
-
-    # read in the entire table.
-    all_run = read(hdu, "run")::Vector{Int16}
-    all_camcol = read(hdu, "camcol")::Vector{UInt8}
-    all_field = read(hdu, "field")::Vector{Int16}
-    all_ramin = read(hdu, "ramin")::Vector{Float64}
-    all_ramax = read(hdu, "ramax")::Vector{Float64}
-    all_decmin = read(hdu, "decmin")::Vector{Float64}
-    all_decmax = read(hdu, "decmax")::Vector{Float64}
-
-    close(f)
-
-    # initialize output "table"
-    out = Dict{ASCIIString, Vector}("run"=>Int[],
-                                    "camcol"=>Int[],
-                                    "field"=>Int[],
-                                    "ramin"=>Float64[],
-                                    "ramax"=>Float64[],
-                                    "decmin"=>Float64[],
-                                    "decmax"=>Float64[])
-
-    # The ramin, ramax, etc is a bit unintuitive because we're looking
-    # for any overlap.
-    for i in eachindex(all_ramin)
-        if (all_ramax[i] > ramin && all_ramin[i] < ramax &&
-            all_decmax[i] > decmin && all_decmin[i] < decmax)
-            push!(out["run"], all_run[i])
-            push!(out["camcol"], all_camcol[i])
-            push!(out["field"], all_field[i])
-            push!(out["ramin"], all_ramin[i])
-            push!(out["ramax"], all_ramax[i])
-            push!(out["decmin"], all_decmin[i])
-            push!(out["decmax"], all_decmax[i])
-        end
-    end
-
-    return out
-end
-
-"""
-query_overlapping_fieldids(ramin, ramax, decmin, decmax) -> Vector{Tuple{Int, Int, Int}}
-
-Like `query_overlapping_fields`, but return a Vector of
-(run, camcol, field) triplets.
-"""
-function query_overlapping_fieldids(ramin, ramax, decmin, decmax)
-    fields = query_overlapping_fields(ramin, ramax, decmin, decmax)
-    return Tuple{Int, Int, Int}[(fields["run"][i],
-                                 fields["camcol"][i],
-                                 fields["field"][i])
-                                for i in eachindex(fields["run"])]
-end
-
-query_frame_dirs(fieldids) =
-    [nersc_field_scratchdir(x[1], x[2], x[3]) for x in fieldids]
-query_photofield_dirs(fieldids) =
-    [nersc_photofield_scratchdir(x[1], x[2]) for x in fieldids]
-
-# NERSC source directories
-const NERSC_DATA_ROOT = "/global/projecta/projectdirs/sdss/data/sdss/dr12/boss"
-nersc_photoobj_dir(run::Integer, camcol::Integer) =
-    "$(NERSC_DATA_ROOT)/photoObj/301/$(run)/$(camcol)"
-nersc_psfield_dir(run::Integer, camcol::Integer) =
-    "$(NERSC_DATA_ROOT)/photo/redux/301/$(run)/objcs/$(camcol)"
-nersc_photofield_dir(run::Integer) =
-    "$(NERSC_DATA_ROOT)/photoObj/301/$(run)"
-nersc_frame_dir(run::Integer, camcol::Integer) =
-    "$(NERSC_DATA_ROOT)/photoObj/frames/301/$(run)/$(camcol)"
-nersc_fpm_dir(run::Integer, camcol::Integer) =
-    "$(NERSC_DATA_ROOT)/photo/redux/301/$(run)/objcs/$(camcol)"
-
-
-# NERSC scratch directories
-nersc_field_scratchdir(run::Integer, camcol::Integer, field::Integer) =
-    joinpath(ENV["SCRATCH"], "celeste/$(run)/$(camcol)/$(field)")
-nersc_photofield_scratchdir(run::Integer, camcol::Integer) =
-    joinpath(ENV["SCRATCH"], "celeste/$(run)/$(camcol)")
-
-"""
-    nersc_stage_field(run, camcol, field)
-
-Stage all relevant files for the given run, camcol, field to user's SCRATCH
-directory. The target locations are given by `nersc_field_scratchdir` and
-`nersc_photofield_scratchdir`.
-"""
-function nersc_stage_field(run::Integer, camcol::Integer, field::Integer)
-    # destination directory for all files except photofield.
-    dstdir = nersc_field_scratchdir(run, camcol, field)
-    isdir(dstdir) || mkpath(dstdir)
-
-    # frame files: uncompress bz2 files
-    srcdir = nersc_frame_dir(run, camcol)
-    for band in ['u', 'g', 'r', 'i', 'z']
-        srcfile = @sprintf("%s/frame-%s-%06d-%d-%04d.fits.bz2",
-                           srcdir, band, run, camcol, field)
-        dstfile = @sprintf("%s/frame-%s-%06d-%d-%04d.fits",
-                           dstdir, band, run, camcol, field)
-        if !isfile(dstfile)
-            Logging.info("bzcat --keep $srcfile > $dstfile")
-            Base.run(pipeline(`bzcat --keep $srcfile`, stdout=dstfile))
-        end
-    end
-
-    # fpm files
-    # It isn't strictly necessary to uncompress these, because FITSIO can handle
-    # gzipped files. However, the celeste code assumes the filename ends with
-    # ".fit", so we would have to at least change the name. It seems clearer
-    # to simply uncompress here.
-    srcdir = nersc_fpm_dir(run, camcol)
-    dstdir = nersc_field_scratchdir(run, camcol, field)
-    isdir(dstdir) || mkpath(dstdir)
-    for band in ['u', 'g', 'r', 'i', 'z']
-        srcfile = @sprintf("%s/fpM-%06d-%s%d-%04d.fit.gz",
-                           srcdir, run, band, camcol, field)
-        dstfile = @sprintf("%s/fpM-%06d-%s%d-%04d.fit",
-                           dstdir, run, band, camcol, field)
-        if !isfile(dstfile)
-            Logging.info("gunzip --stdout $srcfile > $dstfile")
-            Base.run(pipeline(`gunzip --stdout $srcfile`, stdout=dstfile))
-        end
-    end
-
-    # photoobj: simply copy
-    srcfile = @sprintf("%s/photoObj-%06d-%d-%04d.fits",
-                       nersc_photoobj_dir(run, camcol), run, camcol, field)
-    dstfile = @sprintf("%s/photoObj-%06d-%d-%04d.fits",
-                       nersc_field_scratchdir(run, camcol, field), run,
-                       camcol, field)
-    isfile(dstfile) || cp(srcfile, dstfile)
-
-    # psField: simply copy
-    srcfile = @sprintf("%s/psField-%06d-%d-%04d.fit",
-                       nersc_psfield_dir(run, camcol), run, camcol, field)
-    dstfile = @sprintf("%s/psField-%06d-%d-%04d.fit",
-                       nersc_field_scratchdir(run, camcol, field), run,
-                       camcol, field)
-    isfile(dstfile) || cp(srcfile, dstfile)
-
-    # photofield: simply copy
-    srcfile = @sprintf("%s/photoField-%06d-%d.fits",
-                       nersc_photofield_dir(run), run, camcol)
-    dstfile = @sprintf("%s/photoField-%06d-%d.fits",
-                       nersc_photofield_scratchdir(run, camcol), run, camcol)
-    isfile(dstfile) || cp(srcfile, dstfile)
-end
-
-
-"""
-Stage all relevant files for the given sky patch to user's SCRATCH.
-"""
-function stage_box_nersc(ramin, ramax, decmin, decmax)
-    fieldids = query_overlapping_fieldids(ramin, ramax, decmin, decmax)
-    for (run, camcol, field) in fieldids
-        nersc_stage_field(run, camcol, field)
-    end
-end
-
-
-"""
-Save provided results to a JLD file.
-"""
-function save_results(outdir, ramin, ramax, decmin, decmax, results)
-    fname = @sprintf("%s/celeste-%.4f-%.4f-%.4f-%.4f.jld",
-                     outdir, ramin, ramax, decmin, decmax)
-    JLD.save(fname, "results", results)
-end
-
-
-"""
-NERSC-specific infer function, called from main entry point.
-"""
-function infer_box_nersc(ramin, ramax, decmin, decmax, outdir)
-    # Base.@time hack for distributed environment
-    gc_stats = ()
-    gc_diff_stats = ()
-    elapsed_time = 0.0
-    gc_stats = Base.gc_num()
-    elapsed_time = time_ns()
-
-    times = InferTiming()
-    if dt_nnodes > 1
-        divide_and_infer((ramin, ramax),
-                         (decmin, decmax),
-                         timing=times,
-                         outdir=outdir)
-    else
-        # Get vector of (run, camcol, field) triplets overlapping this patch
-        tic()
-        fieldids = query_overlapping_fieldids(ramin, ramax,
-                                              decmin, decmax)
-        times.query_fids = toq()
-
-        # Get relevant directories corresponding to each field.
-        tic()
-        frame_dirs = query_frame_dirs(fieldids)
-        photofield_dirs = query_photofield_dirs(fieldids)
-        times.get_dirs = toq()
-
-        results = infer(fieldids, frame_dirs;
-                        ra_range=(ramin, ramax),
-                        dec_range=(decmin, decmax),
-                        fpm_dirs=frame_dirs,
-                        psfield_dirs=frame_dirs,
-                        photoobj_dirs=frame_dirs,
-                        photofield_dirs=photofield_dirs,
-                        timing=times)
-
-        tic()
-        save_results(outdir, ramin, ramax, decmin, decmax, results)
-        times.write_results = toq()
-    end
-
-    # Base.@time hack for distributed environment
-    elapsed_time = time_ns() - elapsed_time
-    gc_diff_stats = Base.GC_Diff(Base.gc_num(), gc_stats)
-    time_puts(elapsed_time, gc_diff_stats.allocd, gc_diff_stats.total_time,
-              Base.gc_alloc_count(gc_diff_stats))
-
-    times.num_srcs = max(1, times.num_srcs)
-    nputs(dt_nodeid, "timing: query_fids=$(times.query_fids)")
-    nputs(dt_nodeid, "timing: get_dirs=$(times.get_dirs)")
-    nputs(dt_nodeid, "timing: num_infers=$(times.num_infers)")
-    nputs(dt_nodeid, "timing: read_photoobj=$(times.read_photoobj)")
-    nputs(dt_nodeid, "timing: read_img=$(times.read_img)")
-    nputs(dt_nodeid, "timing: init_mp=$(times.init_mp)")
-    nputs(dt_nodeid, "timing: fit_psf=$(times.fit_psf)")
-    nputs(dt_nodeid, "timing: opt_srcs=$(times.opt_srcs)")
-    nputs(dt_nodeid, "timing: num_srcs=$(times.num_srcs)")
-    nputs(dt_nodeid, "timing: average opt_srcs=$(times.opt_srcs/times.num_srcs)")
-    nputs(dt_nodeid, "timing: write_results=$(times.write_results)")
-    nputs(dt_nodeid, "timing: wait_done=$(times.wait_done)")
-end
-
-
-"""
-NERSC-specific infer function, called from main entry point.
-"""
-function infer_field_nersc(run::Int, camcol::Int, field::Int,
-                           outdir::AbstractString; objid="")
-    # ensure that files are staged and set up paths.
-    nersc_stage_field(run, camcol, field)
-    field_dirs = [nersc_field_scratchdir(run, camcol, field)]
-    photofield_dirs = [nersc_photofield_scratchdir(run, camcol)]
-
-    results = infer([(run, camcol, field)], field_dirs;
-                    objid=objid,
-                    fpm_dirs=field_dirs,
-                    psfield_dirs=field_dirs,
-                    photoobj_dirs=field_dirs,
-                    photofield_dirs=photofield_dirs,
-                    primary_initialization=false)
-
-    fname = if objid == ""
-        @sprintf "%s/celeste-%06d-%d-%04d.jld" outdir run camcol field
-    else
-        @sprintf "%s/celeste-objid-%s.jld" outdir objid
-    end
-    JLD.save(fname, "results", results)
-    Logging.debug("infer_field_nersc finished successfully")
-end
+# NERSC-specific functions, for input and output to the routines above
+include("nersc_io.jl")
 

--- a/src/image_model.jl
+++ b/src/image_model.jl
@@ -123,8 +123,11 @@ Args:
     - hh: Optional h index in tile coordinates
     - ww: Optional w index in tile coordinates
 """
-function ImageTile(img::Image, h_range::UnitRange{Int},
-                                     w_range::UnitRange{Int}; hh::Int=1, ww::Int=1)
+function ImageTile(img::Image,
+                   h_range::UnitRange{Int},
+                   w_range::UnitRange{Int};
+                   hh::Int=1,
+                   ww::Int=1)
     b = img.b
     h_width = maximum(h_range) - minimum(h_range) + 1
     w_width = maximum(w_range) - minimum(w_range) + 1

--- a/src/image_model.jl
+++ b/src/image_model.jl
@@ -7,7 +7,7 @@ type Image
     W::Int
 
     # An HxW matrix of pixel intensities.
-    pixels::Matrix{Float64}
+    pixels::Matrix{Float32}
 
     # The band id (takes on values from 1 to 5).
     b::Int
@@ -25,11 +25,11 @@ type Image
     field_num::Int
 
     # The background noise in nanomaggies. (varies by position)
-    epsilon_mat::Array{Float64, 2}
+    epsilon_mat::Array{Float32, 2}
 
     # The expected number of photons contributed to this image
     # by a source 1 nanomaggie in brightness. (varies by row)
-    iota_vec::Array{Float64, 1}
+    iota_vec::Array{Float32, 1}
 
     # storing a RawPSF here isn't ideal, because it's an SDSS type
     # not a Celeste type
@@ -61,10 +61,10 @@ immutable ImageTile
     w_range::UnitRange{Int}
     h_width::Int
     w_width::Int
-    pixels::Matrix{Float64}
+    pixels::Matrix{Float32}
 
-    epsilon_mat::Matrix{Float64}
-    iota_vec::Vector{Float64}
+    epsilon_mat::Matrix{Float32}
+    iota_vec::Vector{Float32}
 end
 
 

--- a/src/imaged_sources.jl
+++ b/src/imaged_sources.jl
@@ -123,32 +123,24 @@ Returns:
     into patches indicating which patches are affected by any pixels
     in the tiles.
 """
-function get_tiled_image_sources(tiled_image::TiledImage,
-                                 patch_ctrs::Vector{Vector{Float64}},
-                                 patch_radii_px::Vector{Float64})
-    out = similar(tiled_image, Vector{Int})
+function get_sources_per_tile(image_tiles::Matrix{ImageTile},
+                              patch_ctrs::Vector{Vector{Float64}},
+                              patch_radii_px::Vector{Float64})
+    out = similar(image_tiles, Vector{Int})
 
-    HH, WW = size(tiled_image)
+    HH, WW = size(image_tiles)
     for ww in 1:WW, hh in 1:HH
-        cands = local_source_candidates(tiled_image[hh, ww],
+        cands = local_source_candidates(image_tiles[hh, ww],
                                         patch_ctrs,
                                         patch_radii_px)
         # get indicies in cands that truly overlap the tile.
-        idx = get_local_sources(tiled_image[hh, ww],
+        idx = get_local_sources(image_tiles[hh, ww],
                                 patch_ctrs[cands],
                                 patch_radii_px[cands])
         out[hh, ww] = cands[idx]
     end
 
     return out
-end
-
-
-function get_tiled_image_sources(tiled_image::TiledImage,
-                                 patches::Vector{SkyPatch})
-    patch_centers = patch_ctrs_pix(patches)
-    patch_radii = patch_radii_pix(patches)
-    get_tiled_image_sources(tiled_image, patch_centers, patch_radii)
 end
 
 
@@ -172,7 +164,7 @@ function choose_patch_radius(
             pixel_center::Vector{Float64},
             ce::CatalogEntry,
             psf::Array{PsfComponent},
-            img::Image;
+            img::TiledImage;
             width_scale=1.0,
             max_radius=100)
 
@@ -184,15 +176,9 @@ function choose_patch_radius(
     obj_width =
       ce.is_star ? psf_width: width_scale * ce.gal_scale / 0.67 + psf_width
 
-    # Get the average sky noise in a rectangle of the width of the psf.
-    h_max, w_max = size(img.epsilon_mat)
-    h_lim = [Int(floor((pixel_center[1] - obj_width))),
-                   Int(ceil((pixel_center[1] + obj_width)))]
-    w_lim = [Int(floor((pixel_center[2] - obj_width))),
-                   Int(ceil((pixel_center[2] + obj_width)))]
-    h_range = max(h_lim[1], 1):min(h_lim[2], h_max)
-    w_range = max(w_lim[1], 1):min(w_lim[2], w_max)
-    epsilon = mean(img.epsilon_mat[h_range, w_range])
+    # Get the average sky noise around a source
+    close_tile = get_containing_tile(pixel_center, img)
+    epsilon = mean(close_tile.epsilon_mat)
 
     flux = ce.is_star ? ce.star_fluxes[img.b] : ce.gal_fluxes[img.b]
     @assert flux > 0.

--- a/src/imaged_sources.jl
+++ b/src/imaged_sources.jl
@@ -184,19 +184,16 @@ function choose_patch_radius(
     obj_width =
       ce.is_star ? psf_width: width_scale * ce.gal_scale / 0.67 + psf_width
 
-    if img.constant_background
-        epsilon = img.epsilon
-    else
-        # Get the average sky noise in a rectangle of the width of the psf.
-        h_max, w_max = size(img.epsilon_mat)
-        h_lim = [Int(floor((pixel_center[1] - obj_width))),
-                       Int(ceil((pixel_center[1] + obj_width)))]
-        w_lim = [Int(floor((pixel_center[2] - obj_width))),
-                       Int(ceil((pixel_center[2] + obj_width)))]
-        h_range = max(h_lim[1], 1):min(h_lim[2], h_max)
-        w_range = max(w_lim[1], 1):min(w_lim[2], w_max)
-        epsilon = mean(img.epsilon_mat[h_range, w_range])
-    end
+    # Get the average sky noise in a rectangle of the width of the psf.
+    h_max, w_max = size(img.epsilon_mat)
+    h_lim = [Int(floor((pixel_center[1] - obj_width))),
+                   Int(ceil((pixel_center[1] + obj_width)))]
+    w_lim = [Int(floor((pixel_center[2] - obj_width))),
+                   Int(ceil((pixel_center[2] + obj_width)))]
+    h_range = max(h_lim[1], 1):min(h_lim[2], h_max)
+    w_range = max(w_lim[1], 1):min(w_lim[2], w_max)
+    epsilon = mean(img.epsilon_mat[h_range, w_range])
+
     flux = ce.is_star ? ce.star_fluxes[img.b] : ce.gal_fluxes[img.b]
     @assert flux > 0.
 

--- a/src/light_source_model.jl
+++ b/src/light_source_model.jl
@@ -121,6 +121,9 @@ function load_prior()
 end
 
 
+prior = load_prior()
+
+
 """
 Return a default-initialized VariationalParams object.
 """

--- a/src/model_params.jl
+++ b/src/model_params.jl
@@ -1,0 +1,82 @@
+# A vector of variational parameters.  The outer index is
+# of celestial objects, and the inner index is over individual
+# parameters for that object (referenced using ParamIndex).
+
+typealias VariationalParams{NumType <: Number} Vector{Vector{NumType}}
+typealias RectVariationalParams{NumType <: Number} Vector{Vector{NumType}}
+typealias FreeVariationalParams{NumType <: Number} Vector{Vector{NumType}}
+
+
+"""
+The parameters for a particular image.
+
+Attributes:
+ - vp: The variational parameters
+ - pp: The prior parameters
+ - patches: An (objects X bands) matrix of SkyPatch objects
+ - tile_width: The number of pixels across a tile
+ - tile_sources: A vector (over bands) of an array (over tiles) of vectors
+                 of sources influencing each tile.
+ - active_sources: Indices of the sources that are currently being fit by the
+                   model.
+ - objids: Global object ids for the sources in this ModelParams object.
+
+ - S: The number of sources.
+"""
+type ModelParams{T <: Number}
+    vp::VariationalParams{T}
+    pp::PriorParams
+    patches::Array{SkyPatch, 2}
+    tile_sources::Vector{Array{Vector{Int}, 2}}
+    active_sources::Vector{Int}
+    objids::Vector{ASCIIString}
+
+    S::Int
+
+    function ModelParams(vp::VariationalParams{T}, pp::PriorParams)
+        # There must be one patch for each celestial object.
+        S = length(vp)
+        all_tile_sources = fill(fill(collect(1:S), 1, 1), 5)
+        patches = Array(SkyPatch, S, 5)
+        active_sources = collect(1:S)
+        objids = ASCIIString[string(s) for s in 1:S]
+
+        new(vp, pp, patches, all_tile_sources, active_sources, objids, S)
+    end
+end
+
+
+# Make a copy of a ModelParams keeping only some sources.
+function ModelParams{T <: Number}(mp_all::ModelParams{T}, keep_s::Vector{Int})
+    mp = ModelParams{T}(deepcopy(mp_all.vp[keep_s]), mp_all.pp);
+    mp.active_sources = Int[]
+    mp.objids = Array(ASCIIString, length(keep_s))
+    mp.patches = Array(SkyPatch, mp.S, size(mp_all.patches, 2))
+
+    # Indices of sources in the new model params
+    for sa in 1:length(keep_s)
+        s = keep_s[sa]
+        mp.objids[sa] = mp_all.objids[s]
+        mp.patches[sa, :] = mp_all.patches[s, :]
+        if s in mp_all.active_sources
+            push!(mp.active_sources, sa)
+        end
+    end
+
+    @assert length(mp_all.tile_sources) == size(mp_all.patches, 2)
+    num_bands = length(mp_all.tile_sources)
+    mp.tile_sources = Array(Matrix{Vector{Int}}, num_bands)
+    for b=1:num_bands
+        mp.tile_sources[b] = Array(Vector{Int}, size(mp_all.tile_sources[b]))
+        for tile_ind in 1:length(mp_all.tile_sources[b])
+                tile_s = intersect(mp_all.tile_sources[b][tile_ind], keep_s)
+                mp.tile_sources[b][tile_ind] =
+                    Int[ findfirst(keep_s, s) for s in tile_s ]
+        end
+    end
+
+    mp
+end
+
+ModelParams{T <: Number}(vp::VariationalParams{T}, pp::PriorParams) =
+    ModelParams{T}(vp, pp)

--- a/src/nersc_io.jl
+++ b/src/nersc_io.jl
@@ -1,0 +1,285 @@
+            catch ex
+                Logging.err(ex)
+            end
+        end
+    end
+    timing.opt_srcs = toq()
+    timing.num_srcs = length(target_sources)
+
+    results
+end
+
+
+# -----------------------------------------------------------------------------
+# NERSC-specific functions
+
+"""
+Query the SDSS database for all fields that overlap the given RA, Dec range.
+"""
+function query_overlapping_fields(ramin, ramax, decmin, decmax)
+
+    fname = "/project/projectdirs/dasrepo/celeste-sc16/field_extents.fits"
+
+    f = FITSIO.FITS(fname)
+    hdu = f[2]::FITSIO.TableHDU
+
+    # read in the entire table.
+    all_run = read(hdu, "run")::Vector{Int16}
+    all_camcol = read(hdu, "camcol")::Vector{UInt8}
+    all_field = read(hdu, "field")::Vector{Int16}
+    all_ramin = read(hdu, "ramin")::Vector{Float64}
+    all_ramax = read(hdu, "ramax")::Vector{Float64}
+    all_decmin = read(hdu, "decmin")::Vector{Float64}
+    all_decmax = read(hdu, "decmax")::Vector{Float64}
+
+    close(f)
+
+    # initialize output "table"
+    out = Dict{ASCIIString, Vector}("run"=>Int[],
+                                    "camcol"=>Int[],
+                                    "field"=>Int[],
+                                    "ramin"=>Float64[],
+                                    "ramax"=>Float64[],
+                                    "decmin"=>Float64[],
+                                    "decmax"=>Float64[])
+
+    # The ramin, ramax, etc is a bit unintuitive because we're looking
+    # for any overlap.
+    for i in eachindex(all_ramin)
+        if (all_ramax[i] > ramin && all_ramin[i] < ramax &&
+            all_decmax[i] > decmin && all_decmin[i] < decmax)
+            push!(out["run"], all_run[i])
+            push!(out["camcol"], all_camcol[i])
+            push!(out["field"], all_field[i])
+            push!(out["ramin"], all_ramin[i])
+            push!(out["ramax"], all_ramax[i])
+            push!(out["decmin"], all_decmin[i])
+            push!(out["decmax"], all_decmax[i])
+        end
+    end
+
+    return out
+end
+
+"""
+query_overlapping_fieldids(ramin, ramax, decmin, decmax) -> Vector{Tuple{Int, Int, Int}}
+
+Like `query_overlapping_fields`, but return a Vector of
+(run, camcol, field) triplets.
+"""
+function query_overlapping_fieldids(ramin, ramax, decmin, decmax)
+    fields = query_overlapping_fields(ramin, ramax, decmin, decmax)
+    return Tuple{Int, Int, Int}[(fields["run"][i],
+                                 fields["camcol"][i],
+                                 fields["field"][i])
+                                for i in eachindex(fields["run"])]
+end
+
+query_frame_dirs(fieldids) =
+    [nersc_field_scratchdir(x[1], x[2], x[3]) for x in fieldids]
+query_photofield_dirs(fieldids) =
+    [nersc_photofield_scratchdir(x[1], x[2]) for x in fieldids]
+
+# NERSC source directories
+const NERSC_DATA_ROOT = "/global/projecta/projectdirs/sdss/data/sdss/dr12/boss"
+nersc_photoobj_dir(run::Integer, camcol::Integer) =
+    "$(NERSC_DATA_ROOT)/photoObj/301/$(run)/$(camcol)"
+nersc_psfield_dir(run::Integer, camcol::Integer) =
+    "$(NERSC_DATA_ROOT)/photo/redux/301/$(run)/objcs/$(camcol)"
+nersc_photofield_dir(run::Integer) =
+    "$(NERSC_DATA_ROOT)/photoObj/301/$(run)"
+nersc_frame_dir(run::Integer, camcol::Integer) =
+    "$(NERSC_DATA_ROOT)/photoObj/frames/301/$(run)/$(camcol)"
+nersc_fpm_dir(run::Integer, camcol::Integer) =
+    "$(NERSC_DATA_ROOT)/photo/redux/301/$(run)/objcs/$(camcol)"
+
+
+# NERSC scratch directories
+nersc_field_scratchdir(run::Integer, camcol::Integer, field::Integer) =
+    joinpath(ENV["SCRATCH"], "celeste/$(run)/$(camcol)/$(field)")
+nersc_photofield_scratchdir(run::Integer, camcol::Integer) =
+    joinpath(ENV["SCRATCH"], "celeste/$(run)/$(camcol)")
+
+"""
+    nersc_stage_field(run, camcol, field)
+
+Stage all relevant files for the given run, camcol, field to user's SCRATCH
+directory. The target locations are given by `nersc_field_scratchdir` and
+`nersc_photofield_scratchdir`.
+"""
+function nersc_stage_field(run::Integer, camcol::Integer, field::Integer)
+    # destination directory for all files except photofield.
+    dstdir = nersc_field_scratchdir(run, camcol, field)
+    isdir(dstdir) || mkpath(dstdir)
+
+    # frame files: uncompress bz2 files
+    srcdir = nersc_frame_dir(run, camcol)
+    for band in ['u', 'g', 'r', 'i', 'z']
+        srcfile = @sprintf("%s/frame-%s-%06d-%d-%04d.fits.bz2",
+                           srcdir, band, run, camcol, field)
+        dstfile = @sprintf("%s/frame-%s-%06d-%d-%04d.fits",
+                           dstdir, band, run, camcol, field)
+        if !isfile(dstfile)
+            Logging.info("bzcat --keep $srcfile > $dstfile")
+            Base.run(pipeline(`bzcat --keep $srcfile`, stdout=dstfile))
+        end
+    end
+
+    # fpm files
+    # It isn't strictly necessary to uncompress these, because FITSIO can handle
+    # gzipped files. However, the celeste code assumes the filename ends with
+    # ".fit", so we would have to at least change the name. It seems clearer
+    # to simply uncompress here.
+    srcdir = nersc_fpm_dir(run, camcol)
+    dstdir = nersc_field_scratchdir(run, camcol, field)
+    isdir(dstdir) || mkpath(dstdir)
+    for band in ['u', 'g', 'r', 'i', 'z']
+        srcfile = @sprintf("%s/fpM-%06d-%s%d-%04d.fit.gz",
+                           srcdir, run, band, camcol, field)
+        dstfile = @sprintf("%s/fpM-%06d-%s%d-%04d.fit",
+                           dstdir, run, band, camcol, field)
+        if !isfile(dstfile)
+            Logging.info("gunzip --stdout $srcfile > $dstfile")
+            Base.run(pipeline(`gunzip --stdout $srcfile`, stdout=dstfile))
+        end
+    end
+
+    # photoobj: simply copy
+    srcfile = @sprintf("%s/photoObj-%06d-%d-%04d.fits",
+                       nersc_photoobj_dir(run, camcol), run, camcol, field)
+    dstfile = @sprintf("%s/photoObj-%06d-%d-%04d.fits",
+                       nersc_field_scratchdir(run, camcol, field), run,
+                       camcol, field)
+    isfile(dstfile) || cp(srcfile, dstfile)
+
+    # psField: simply copy
+    srcfile = @sprintf("%s/psField-%06d-%d-%04d.fit",
+                       nersc_psfield_dir(run, camcol), run, camcol, field)
+    dstfile = @sprintf("%s/psField-%06d-%d-%04d.fit",
+                       nersc_field_scratchdir(run, camcol, field), run,
+                       camcol, field)
+    isfile(dstfile) || cp(srcfile, dstfile)
+
+    # photofield: simply copy
+    srcfile = @sprintf("%s/photoField-%06d-%d.fits",
+                       nersc_photofield_dir(run), run, camcol)
+    dstfile = @sprintf("%s/photoField-%06d-%d.fits",
+                       nersc_photofield_scratchdir(run, camcol), run, camcol)
+    isfile(dstfile) || cp(srcfile, dstfile)
+end
+
+
+"""
+Stage all relevant files for the given sky patch to user's SCRATCH.
+"""
+function stage_box_nersc(ramin, ramax, decmin, decmax)
+    fieldids = query_overlapping_fieldids(ramin, ramax, decmin, decmax)
+    for (run, camcol, field) in fieldids
+        nersc_stage_field(run, camcol, field)
+    end
+end
+
+
+"""
+Save provided results to a JLD file.
+"""
+function save_results(outdir, ramin, ramax, decmin, decmax, results)
+    fname = @sprintf("%s/celeste-%.4f-%.4f-%.4f-%.4f.jld",
+                     outdir, ramin, ramax, decmin, decmax)
+    JLD.save(fname, "results", results)
+end
+
+
+"""
+NERSC-specific infer function, called from main entry point.
+"""
+function infer_box_nersc(ramin, ramax, decmin, decmax, outdir)
+    # Base.@time hack for distributed environment
+    gc_stats = ()
+    gc_diff_stats = ()
+    elapsed_time = 0.0
+    gc_stats = Base.gc_num()
+    elapsed_time = time_ns()
+
+    times = InferTiming()
+    if dt_nnodes > 1
+        divide_and_infer((ramin, ramax),
+                         (decmin, decmax),
+                         timing=times,
+                         outdir=outdir)
+    else
+        # Get vector of (run, camcol, field) triplets overlapping this patch
+        tic()
+        fieldids = query_overlapping_fieldids(ramin, ramax,
+                                              decmin, decmax)
+        times.query_fids = toq()
+
+        # Get relevant directories corresponding to each field.
+        tic()
+        frame_dirs = query_frame_dirs(fieldids)
+        photofield_dirs = query_photofield_dirs(fieldids)
+        times.get_dirs = toq()
+
+        results = infer(fieldids, frame_dirs;
+                        ra_range=(ramin, ramax),
+                        dec_range=(decmin, decmax),
+                        fpm_dirs=frame_dirs,
+                        psfield_dirs=frame_dirs,
+                        photoobj_dirs=frame_dirs,
+                        photofield_dirs=photofield_dirs,
+                        timing=times)
+
+        tic()
+        save_results(outdir, ramin, ramax, decmin, decmax, results)
+        times.write_results = toq()
+    end
+
+    # Base.@time hack for distributed environment
+    elapsed_time = time_ns() - elapsed_time
+    gc_diff_stats = Base.GC_Diff(Base.gc_num(), gc_stats)
+    time_puts(elapsed_time, gc_diff_stats.allocd, gc_diff_stats.total_time,
+              Base.gc_alloc_count(gc_diff_stats))
+
+    times.num_srcs = max(1, times.num_srcs)
+    nputs(dt_nodeid, "timing: query_fids=$(times.query_fids)")
+    nputs(dt_nodeid, "timing: get_dirs=$(times.get_dirs)")
+    nputs(dt_nodeid, "timing: num_infers=$(times.num_infers)")
+    nputs(dt_nodeid, "timing: read_photoobj=$(times.read_photoobj)")
+    nputs(dt_nodeid, "timing: read_img=$(times.read_img)")
+    nputs(dt_nodeid, "timing: init_mp=$(times.init_mp)")
+    nputs(dt_nodeid, "timing: fit_psf=$(times.fit_psf)")
+    nputs(dt_nodeid, "timing: opt_srcs=$(times.opt_srcs)")
+    nputs(dt_nodeid, "timing: num_srcs=$(times.num_srcs)")
+    nputs(dt_nodeid, "timing: average opt_srcs=$(times.opt_srcs/times.num_srcs)")
+    nputs(dt_nodeid, "timing: write_results=$(times.write_results)")
+    nputs(dt_nodeid, "timing: wait_done=$(times.wait_done)")
+end
+
+
+"""
+NERSC-specific infer function, called from main entry point.
+"""
+function infer_field_nersc(run::Int, camcol::Int, field::Int,
+                           outdir::AbstractString; objid="")
+    # ensure that files are staged and set up paths.
+    nersc_stage_field(run, camcol, field)
+    field_dirs = [nersc_field_scratchdir(run, camcol, field)]
+    photofield_dirs = [nersc_photofield_scratchdir(run, camcol)]
+
+    results = infer([(run, camcol, field)], field_dirs;
+                    objid=objid,
+                    fpm_dirs=field_dirs,
+                    psfield_dirs=field_dirs,
+                    photoobj_dirs=field_dirs,
+                    photofield_dirs=photofield_dirs,
+                    primary_initialization=false)
+
+    fname = if objid == ""
+        @sprintf "%s/celeste-%06d-%d-%04d.jld" outdir run camcol field
+    else
+        @sprintf "%s/celeste-objid-%s.jld" outdir objid
+    end
+    JLD.save(fname, "results", results)
+    Logging.debug("infer_field_nersc finished successfully")
+end
+

--- a/test/SampleData.jl
+++ b/test/SampleData.jl
@@ -41,8 +41,8 @@ function initialize_celeste(
         blob::Blob, cat::Vector{CatalogEntry};
         tile_width::Int=20, fit_psf::Bool=true,
         patch_radius::Float64=NaN)
-    tiled_blob = Model.break_blob_into_tiles(blob, tile_width)
-    mp = ModelInit.initialize_model_params(tiled_blob, blob, cat,
+    tiled_blob = TiledImage[TiledImage(img, tile_width=tile_width) for img in blob]
+    mp = ModelInit.initialize_model_params(tiled_blob, cat,
                                fit_psf=fit_psf, patch_radius=patch_radius)
     tiled_blob, mp
 end

--- a/test/SampleData.jl
+++ b/test/SampleData.jl
@@ -97,8 +97,8 @@ function load_stamp_blob(stamp_dir, stamp_id)
         empty_psf_comp = RawPSF(Array(Float64, 0, 0), 0, 0, 
                                  Array(Float64, 0, 0, 0)) 
 
-        Image(H, W, nelec, b, wcs, epsilon, iota, psf,
-              run_num, camcol_num, field_num, false, epsilon_mat, iota_vec,
+        Image(H, W, nelec, b, wcs, psf,
+              run_num, camcol_num, field_num, epsilon_mat, iota_vec,
               empty_psf_comp)
     end
 
@@ -321,9 +321,8 @@ function gen_n_body_dataset(
 
   # Make non-constant background.
   for b=1:5
-    blob[b].constant_background = false
-    blob[b].iota_vec = fill(blob[b].iota, blob[b].H)
-    blob[b].epsilon_mat = fill(blob[b].epsilon, blob[b].H, blob[b].W)
+    blob[b].iota_vec = fill(blob[b].iota_vec[1], blob[b].H)
+    blob[b].epsilon_mat = fill(blob[b].epsilon_mat[1], blob[b].H, blob[b].W)
   end
 
   world_radius_pts = WCSUtils.pix_to_world(

--- a/test/SampleData.jl
+++ b/test/SampleData.jl
@@ -41,37 +41,12 @@ function initialize_celeste(
         blob::Blob, cat::Vector{CatalogEntry};
         tile_width::Int=20, fit_psf::Bool=true,
         patch_radius::Float64=NaN)
-
     tiled_blob = Model.break_blob_into_tiles(blob, tile_width)
     mp = ModelInit.initialize_model_params(tiled_blob, blob, cat,
                                fit_psf=fit_psf, patch_radius=patch_radius)
     tiled_blob, mp
 end
 
-# Initialization for an image with noise and background parameters that are 
-# constant across the image. 
-function Image(H::Int, W::Int, pixels::Matrix{Float64}, b::Int, 
-               wcs::WCSTransform, epsilon::Float64, iota::Float64, 
-               psf::Vector{PsfComponent}, run_num::Int, camcol_num::Int, 
-               field_num::Int) 
-    empty_psf_comp = RawPSF(Array(Float64, 0, 0), 0, 0, 
-                             Array(Float64, 0, 0, 0)) 
-    Image(H, W, pixels, b, wcs, epsilon, iota, psf, 
-          run_num, camcol_num, field_num, 
-          true, Array(Float64, 0, 0), Array(Float64, 0), empty_psf_comp) 
-end 
- 
-# Initialization for an image with noise and background parameters that vary 
-# across the image. 
-function Image(H::Int, W::Int, pixels::Matrix{Float64}, b::Int, 
-               wcs::WCSTransform, epsilon_mat::Vector{Float64}, 
-               iota_vec::Matrix{Float64}, psf::Vector{PsfComponent}, 
-               raw_psf_comp::RawPSF, run_num::Int, camcol_num::Int, 
-               field_num::Int) 
-    Image(H, W, pixels, b, wcs, 0.0, 0.0, psf, run_num, camcol_num, 
-          field_num, false, epsilon_mat, iota_vec, raw_psf_comp) 
-end 
- 
 
 """
 Load a stamp into a Celeste blob.
@@ -117,8 +92,14 @@ function load_stamp_blob(stamp_dir, stamp_id)
         camcol_num = round(Int, hdr["CAMCOL"])
         field_num = round(Int, hdr["FIELD"])
 
+        epsilon_mat = fill(epsilon, H, W)
+        iota_vec = fill(iota, H)
+        empty_psf_comp = RawPSF(Array(Float64, 0, 0), 0, 0, 
+                                 Array(Float64, 0, 0, 0)) 
+
         Image(H, W, nelec, b, wcs, epsilon, iota, psf,
-              run_num, camcol_num, field_num)
+              run_num, camcol_num, field_num, false, epsilon_mat, iota_vec,
+              empty_psf_comp)
     end
 
     blob = map(fetch_image, 1:5)

--- a/test/Synthetic.jl
+++ b/test/Synthetic.jl
@@ -97,8 +97,14 @@ function gen_image(img0::Image, n_bodies::Vector{CatalogEntry}; expectation=fals
         body.is_star ? write_star(img0, body, pixels) : write_galaxy(img0, body, pixels)
     end
 
-    return Image(img0.H, img0.W, pixels, img0.b, img0.wcs, img0.epsilon,
-                 img0.iota, img0.psf, img0.run_num, img0.camcol_num, img0.field_num)
+    epsilon_mat = fill(img0.epsilon_mat[1], img0.H, img0.W)
+    iota_vec = fill(img0.iota_vec[1], img0.H)
+
+    return Image(img0.H, img0.W, pixels, img0.b, img0.wcs,
+                 img0.epsilon, img0.iota, img0.psf,
+                 img0.run_num, img0.camcol_num, img0.field_num,
+                 img0.constant_background,
+                 epsilon_mat, iota_vec, img0.raw_psf_comp)
 end
 
 """

--- a/test/Synthetic.jl
+++ b/test/Synthetic.jl
@@ -54,10 +54,11 @@ end
 
 function write_star(img0::Image, ce::CatalogEntry, pixels::Matrix{Float64};
                     expectation=false)
+    iota = median(img0.iota_vec)
     for k in 1:length(img0.psf)
         the_mean = WCSUtils.world_to_pix(img0.wcs, ce.pos) + img0.psf[k].xiBar
         the_cov = img0.psf[k].tauBar
-        intensity = ce.star_fluxes[img0.b] * img0.iota * img0.psf[k].alphaBar
+        intensity = ce.star_fluxes[img0.b] * iota * img0.psf[k].alphaBar
         write_gaussian(the_mean, the_cov, intensity, pixels,
             expectation = expectation)
     end
@@ -66,8 +67,8 @@ end
 
 function write_galaxy(img0::Image, ce::CatalogEntry, pixels::Matrix{Float64};
                       expectation=false)
+    iota = median(img0.iota_vec)
     e_devs = [ce.gal_frac_dev, 1 - ce.gal_frac_dev]
-
     XiXi = BivariateNormals.get_bvn_cov(ce.gal_ab, ce.gal_angle, ce.gal_scale)
 
     for i in 1:2
@@ -76,7 +77,7 @@ function write_galaxy(img0::Image, ce::CatalogEntry, pixels::Matrix{Float64};
                 the_mean = WCSUtils.world_to_pix(img0.wcs, ce.pos) +
                            img0.psf[k].xiBar
                 the_cov = img0.psf[k].tauBar + gproto.nuBar * XiXi
-                intensity = ce.gal_fluxes[img0.b] * img0.iota *
+                intensity = ce.gal_fluxes[img0.b] * iota *
                     img0.psf[k].alphaBar * e_devs[i] * gproto.etaBar
                 write_gaussian(the_mean, the_cov, intensity, pixels,
                     expectation=expectation)
@@ -86,10 +87,13 @@ function write_galaxy(img0::Image, ce::CatalogEntry, pixels::Matrix{Float64};
 end
 
 function gen_image(img0::Image, n_bodies::Vector{CatalogEntry}; expectation=false)
+    epsilon = img0.epsilon_mat[1]
+    iota = img0.iota_vec[1]
+
     if expectation
-        pixels = [ img0.epsilon * img0.iota for h=1:img0.H, w=1:img0.W ]
+        pixels = [epsilon * iota for h=1:img0.H, w=1:img0.W]
     else
-        pixels = reshape(float(rand(Distributions.Poisson(img0.epsilon * img0.iota),
+        pixels = reshape(float(rand(Distributions.Poisson(epsilon * iota),
                          img0.H * img0.W)), img0.H, img0.W)
     end
 
@@ -97,14 +101,14 @@ function gen_image(img0::Image, n_bodies::Vector{CatalogEntry}; expectation=fals
         body.is_star ? write_star(img0, body, pixels) : write_galaxy(img0, body, pixels)
     end
 
-    epsilon_mat = fill(img0.epsilon_mat[1], img0.H, img0.W)
-    iota_vec = fill(img0.iota_vec[1], img0.H)
+    epsilon_mat = fill(epsilon, img0.H, img0.W)
+    iota_vec = fill(iota, img0.H)
 
     return Image(img0.H, img0.W, pixels, img0.b, img0.wcs,
-                 img0.epsilon, img0.iota, img0.psf,
+                 img0.psf,
                  img0.run_num, img0.camcol_num, img0.field_num,
-                 img0.constant_background,
-                 epsilon_mat, iota_vec, img0.raw_psf_comp)
+                 epsilon_mat, iota_vec,
+                 img0.raw_psf_comp)
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,8 +34,8 @@ function initialize_celeste(
         blob::Blob, cat::Vector{CatalogEntry};
         tile_width::Int=20, fit_psf::Bool=true,
         patch_radius::Float64=NaN)
-    tiled_blob = Model.break_blob_into_tiles(blob, tile_width)
-    mp = ModelInit.initialize_model_params(tiled_blob, blob, cat,
+    tiled_blob = TiledImage[TiledImage(img, tile_width=tile_width) for img in blob]
+    mp = ModelInit.initialize_model_params(tiled_blob, cat,
                                fit_psf=fit_psf, patch_radius=patch_radius)
     tiled_blob, mp
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,10 @@
 #!/usr/bin/env julia
 
 using Celeste: Model, Transform
-import Celeste: WCSUtils, ModelInit
+import Celeste: WCSUtils, ModelInit, ElboDeriv, Model, ModelInit
+import Celeste: PSF, OptimizeElbo, SDSSIO, SensitiveFloats, Transform
+import Celeste: BivariateNormals
+
 
 include("Synthetic.jl")
 include("SampleData.jl")

--- a/test/test_derivatives.jl
+++ b/test/test_derivatives.jl
@@ -394,7 +394,7 @@ function test_add_log_term()
     tile = tiled_blob[b][1,1];
     tile_sources = mp.tile_sources[b][1,1];
 
-    iota = blob[b].iota
+    iota = median(blob[b].iota_vec)
 
     function add_log_term_wrapper_fun{NumType <: Number}(
         mp::ModelParams{NumType}, calculate_derivs::Bool)

--- a/test/test_derivatives.jl
+++ b/test/test_derivatives.jl
@@ -188,8 +188,9 @@ function test_real_image()
 
   # Limit to very few pixels so that the autodiff is reasonably fast.
   s = trimmed_mp.active_sources[1]
-  very_trimmed_tiled_blob = ModelInit.trim_source_tiles(
+  ModelInit.trim_source_tiles!(
     s, trimmed_mp, trimmed_tiled_blob, noise_fraction=10., min_radius_pix=1.0);
+  very_trimmed_tiled_blob = trimmed_tiled_blob
 
   # To see:
   # using PyPlot

--- a/test/test_derivatives.jl
+++ b/test/test_derivatives.jl
@@ -1,9 +1,7 @@
-using Base.Test
 import DualNumbers
+import ForwardDiff
 
 using Celeste: Model, SensitiveFloats, BivariateNormals, ElboDeriv
-import Celeste: ModelInit, WCSUtils, SDSSIO
-import ForwardDiff
 
 
 println("Running derivative tests.")

--- a/test/test_derivatives.jl
+++ b/test/test_derivatives.jl
@@ -76,10 +76,10 @@ Set all but a few pixels to NaN to speed up autodiff Hessian testing.
 """
 function trim_tiles!(tiled_blob::TiledBlob, keep_pixels)
   for b = 1:length(tiled_blob)
-	  tiled_blob[b][1,1].pixels[
-			setdiff(1:tiled_blob[b][1,1].h_width, keep_pixels), :] = NaN;
-	  tiled_blob[b][1,1].pixels[
-			:, setdiff(1:tiled_blob[b][1,1].w_width, keep_pixels)] = NaN;
+	  tiled_blob[b].tiles[1,1].pixels[
+			setdiff(1:tiled_blob[b].tiles[1,1].h_width, keep_pixels), :] = NaN;
+	  tiled_blob[b].tiles[1,1].pixels[
+			:, setdiff(1:tiled_blob[b].tiles[1,1].w_width, keep_pixels)] = NaN;
 	end
 end
 
@@ -133,38 +133,37 @@ TODO: test!
 function limit_to_object_data(
     objid::ASCIIString, mp_original::ModelParams,
     tiled_blob::TiledBlob, blob::Blob, cat_entries::Vector{CatalogEntry})
-        -
+
   @assert length(tiled_blob) == length(blob)
   mp = deepcopy(mp_original)
-        -
+
   s_original = findfirst(mp_original.objids .== objid)
   @assert(s_original > 0, "objid $objid not found in mp_original.")
   mp_original.active_sources = [ s_original ]
-        -
+
   # Get the sources that overlap with this object.
   relevant_sources = ModelInit.get_relevant_sources(mp, s_original)
-        -
+
   trimmed_mp = ModelInit.initialize_model_params(
-    tiled_blob, blob, cat_entries[relevant_sources], fit_psf=true);
-        -
+    tiled_blob, cat_entries[relevant_sources], fit_psf=true);
+
   s = findfirst(trimmed_mp.objids .== objid)
   trimmed_mp.active_sources = [ s ]
-        -
+
   # Trim to a smaller tiled blob.
-  trimmed_tiled_blob = Array(Array{ImageTile}, 5);
+  trimmed_tiled_blob = deepcopy(tiled_blob)
   original_tiled_sources = deepcopy(trimmed_mp.tile_sources);
   for b=1:length(tiled_blob)
     hh_vec, ww_vec = ind2sub(size(original_tiled_sources[b]),
       find([ s in sources for sources in original_tiled_sources[b]]))
-        -
+
     hh_range = minimum(hh_vec):maximum(hh_vec);
     ww_range = minimum(ww_vec):maximum(ww_vec);
-    trimmed_tiled_blob[b] = tiled_blob[b][hh_range, ww_range];
+    trimmed_tiled_blob[b].tiles = tiled_blob[b].tiles[hh_range, ww_range];
     trimmed_mp.tile_sources[b] =
       deepcopy(original_tiled_sources[b][hh_range, ww_range]);
   end
-  trimmed_tiled_blob = convert(TiledBlob, trimmed_tiled_blob);
-        -
+
   trimmed_mp, trimmed_tiled_blob
 end
 
@@ -188,9 +187,8 @@ function test_real_image()
 
   # Limit to very few pixels so that the autodiff is reasonably fast.
   s = trimmed_mp.active_sources[1]
-  ModelInit.trim_source_tiles!(
+  very_trimmed_tiled_blob = ModelInit.trim_source_tiles(
     s, trimmed_mp, trimmed_tiled_blob, noise_fraction=10., min_radius_pix=1.0);
-  very_trimmed_tiled_blob = trimmed_tiled_blob
 
   # To see:
   # using PyPlot
@@ -238,7 +236,7 @@ end
 
 function test_tile_predicted_image()
   blob, mp, body, tiled_blob = gen_sample_star_dataset(perturb=false);
-  tile = tiled_blob[1][1, 1];
+  tile = tiled_blob[1].tiles[1, 1];
   tile_sources = mp.tile_sources[1][1, 1];
   pred_image =
     ElboDeriv.tile_predicted_image(tile, mp, tile_sources; include_epsilon=true);
@@ -281,7 +279,7 @@ function test_active_sources()
   keep_pixels = 10:11
   trim_tiles!(tiled_blob, keep_pixels)
   b = 1
-  tile = tiled_blob[b][1,1];
+  tile = tiled_blob[b].tiles[1,1];
   h, w = 10, 10
 
   mp.active_sources = [1, 2]
@@ -392,7 +390,7 @@ function test_add_log_term()
   for b = 1:5
     println("Testing log term for band $b.")
     x_nbm = 70.
-    tile = tiled_blob[b][1,1];
+    tile = tiled_blob[b].tiles[1,1];
     tile_sources = mp.tile_sources[b][1,1];
 
     iota = median(blob[b].iota_vec)
@@ -442,7 +440,7 @@ function test_combine_pixel_sources()
     test_var_string = test_var ? "E_G" : "var_G"
     println("Testing $(test_var_string), band $b")
 
-    tile = tiled_blob[b][1,1]; # Note: only one tile in this simulated dataset.
+    tile = tiled_blob[b].tiles[1,1]; # Note: only one tile in this simulated dataset.
     tile_sources = mp.tile_sources[b][1,1];
 
     function e_g_wrapper_fun{NumType <: Number}(
@@ -491,7 +489,7 @@ function test_e_g_s_functions()
     test_var_string = test_var ? "E_G" : "var_G"
     println("Testing $(test_var_string), band $b")
 
-    tile = tiled_blob[b][1,1]; # Note: only one tile in this simulated dataset.
+    tile = tiled_blob[b].tiles[1,1]; # Note: only one tile in this simulated dataset.
     tile_sources = mp.tile_sources[b][1,1];
 
     function e_g_wrapper_fun{NumType <: Number}(

--- a/test/test_elbo_values.jl
+++ b/test/test_elbo_values.jl
@@ -306,8 +306,8 @@ function test_tiny_image_tiling()
   trivial_psf = [pc, pc, pc]
   pixels = ones(100, 1) * 12
   pixels[98:100, 1] = [1e3, 1e4, 1e5]
-  img = Image(3, 1, pixels, 3, blob0[3].wcs, 3., 4., trivial_psf, 1, 1, 1,
-              false, fill(3., size(pixels)), fill(4., size(pixels, 1)),
+  img = Image(3, 1, pixels, 3, blob0[3].wcs, trivial_psf, 1, 1, 1,
+              fill(3., size(pixels)), fill(4., size(pixels, 1)),
               blob0[3].raw_psf_comp);
   catalog = [sample_ce([100., 1], true),];
   catalog[1].star_fluxes = ones(5) * 1e5

--- a/test/test_elbo_values.jl
+++ b/test/test_elbo_values.jl
@@ -95,7 +95,7 @@ function test_that_variance_is_low()
     blob, mp, body, tiled_blob = true_star_init();
 
     test_b = 3
-    tile = tiled_blob[test_b][1,1];
+    tile = tiled_blob[test_b].tiles[1,1];
     tile_sources = mp.tile_sources[test_b][1,1];
 
     h, w = 10, 12
@@ -366,16 +366,16 @@ function test_trim_source_tiles()
 
   # With the above seed, this is near the middle of the image.
   s = 1
-  trimmed_tiled_blob = deepcopy(tiled_blob)
-  ModelInit.trim_source_tiles!(s, mp, trimmed_tiled_blob, noise_fraction=0.1);
+  trimmed_tiled_blob = 
+      ModelInit.trim_source_tiles(s, mp, tiled_blob, noise_fraction=0.1);
   loc_ids = ids.u
   non_loc_ids = setdiff(1:length(ids), ids.u)
   for b=1:length(blob)
     println("Testing b = $b")
     # Make sure pixels got NaN-ed out
     @test(
-      sum([ sum(!Base.isnan(tile.pixels)) for tile in trimmed_tiled_blob[b]]) <
-      sum([ sum(!Base.isnan(tile.pixels)) for tile in tiled_blob[b]]))
+      sum([ sum(!Base.isnan(tile.pixels)) for tile in trimmed_tiled_blob[b].tiles]) <
+      sum([ sum(!Base.isnan(tile.pixels)) for tile in tiled_blob[b].tiles]))
     s_tiles = find_source_tiles(s, b, mp)
     mp.active_sources = [s];
     elbo_full = ElboDeriv.elbo(tiled_blob, mp; calculate_hessian=false);
@@ -397,25 +397,26 @@ function test_trim_source_tiles()
   mp.vp[s][ids.r2] = 0.01
 
   min_radius_pix = 6.0
-  trimmed_tiled_blob = deepcopy(tiled_blob)
-  ModelInit.trim_source_tiles!(
-    s, mp, trimmed_tiled_blob, noise_fraction=0.1, min_radius_pix = min_radius_pix);
+  trimmed_tiled_blob = 
+      ModelInit.trim_source_tiles(
+        s, mp, tiled_blob, noise_fraction=0.1, min_radius_pix = min_radius_pix);
 
   total_nonempty_pixels = 0.0
   for tile_index in s_tiles
-    tile = trimmed_tiled_blob[b][tile_index...]
+    tile = trimmed_tiled_blob[b].tiles[tile_index...]
     total_nonempty_pixels += sum(!Base.isnan(tile.pixels))
   end
   @test_approx_eq_eps total_nonempty_pixels pi * min_radius_pix ^ 2 2.0
 
   min_radius_pix = 0.0
-  trimmed_tiled_blob = deepcopy(tiled_blob)
-  ModelInit.trim_source_tiles!(
-    s, mp, trimmed_tiled_blob, noise_fraction=0.1, min_radius_pix = min_radius_pix);
+  trimmed_tiled_blob = 
+      ModelInit.trim_source_tiles(
+        s, mp, trimmed_tiled_blob, noise_fraction=0.1,
+            min_radius_pix = min_radius_pix);
 
   total_nonempty_pixels = 0.0
   for tile_index in s_tiles
-    tile = trimmed_tiled_blob[b][tile_index...]
+    tile = trimmed_tiled_blob[b].tiles[tile_index...]
     total_nonempty_pixels += sum(!Base.isnan(tile.pixels))
   end
   @test total_nonempty_pixels == 0.0

--- a/test/test_elbo_values.jl
+++ b/test/test_elbo_values.jl
@@ -1,5 +1,4 @@
-using Celeste: Model, ElboDeriv, SensitiveFloats
-import Celeste: ModelInit, ModelInit
+using Celeste: ElboDeriv, SensitiveFloats
 
 using Base.Test
 using Distributions

--- a/test/test_elbo_values.jl
+++ b/test/test_elbo_values.jl
@@ -366,8 +366,8 @@ function test_trim_source_tiles()
 
   # With the above seed, this is near the middle of the image.
   s = 1
-  trimmed_tiled_blob = ModelInit.trim_source_tiles(
-    s, mp, tiled_blob, noise_fraction=0.1);
+  trimmed_tiled_blob = deepcopy(tiled_blob)
+  ModelInit.trim_source_tiles!(s, mp, trimmed_tiled_blob, noise_fraction=0.1);
   loc_ids = ids.u
   non_loc_ids = setdiff(1:length(ids), ids.u)
   for b=1:length(blob)
@@ -397,8 +397,9 @@ function test_trim_source_tiles()
   mp.vp[s][ids.r2] = 0.01
 
   min_radius_pix = 6.0
-  trimmed_tiled_blob = ModelInit.trim_source_tiles(
-    s, mp, tiled_blob, noise_fraction=0.1, min_radius_pix = min_radius_pix);
+  trimmed_tiled_blob = deepcopy(tiled_blob)
+  ModelInit.trim_source_tiles!(
+    s, mp, trimmed_tiled_blob, noise_fraction=0.1, min_radius_pix = min_radius_pix);
 
   total_nonempty_pixels = 0.0
   for tile_index in s_tiles
@@ -408,8 +409,9 @@ function test_trim_source_tiles()
   @test_approx_eq_eps total_nonempty_pixels pi * min_radius_pix ^ 2 2.0
 
   min_radius_pix = 0.0
-  trimmed_tiled_blob = ModelInit.trim_source_tiles(
-    s, mp, tiled_blob, noise_fraction=0.1, min_radius_pix = min_radius_pix);
+  trimmed_tiled_blob = deepcopy(tiled_blob)
+  ModelInit.trim_source_tiles!(
+    s, mp, trimmed_tiled_blob, noise_fraction=0.1, min_radius_pix = min_radius_pix);
 
   total_nonempty_pixels = 0.0
   for tile_index in s_tiles

--- a/test/test_elbo_values.jl
+++ b/test/test_elbo_values.jl
@@ -306,7 +306,9 @@ function test_tiny_image_tiling()
   trivial_psf = [pc, pc, pc]
   pixels = ones(100, 1) * 12
   pixels[98:100, 1] = [1e3, 1e4, 1e5]
-  img = Image(3, 1, pixels, 3, blob0[3].wcs, 3., 4., trivial_psf, 1, 1, 1);
+  img = Image(3, 1, pixels, 3, blob0[3].wcs, 3., 4., trivial_psf, 1, 1, 1,
+              false, fill(3., size(pixels)), fill(4., size(pixels, 1)),
+              blob0[3].raw_psf_comp);
   catalog = [sample_ce([100., 1], true),];
   catalog[1].star_fluxes = ones(5) * 1e5
 

--- a/test/test_images.jl
+++ b/test/test_images.jl
@@ -53,9 +53,6 @@ function test_blob()
   # the full image multiple times.
   blob = SDSSIO.load_field_images(RUN, CAMCOL, FIELD, datadir)
 
-  for b=1:length(blob)
-    @test !blob[b].constant_background
-  end
   fname = @sprintf "%s/photoObj-%06d-%d-%04d.fits" datadir RUN CAMCOL FIELD
   cat_entries = SDSSIO.read_photoobj_celeste(fname)
 

--- a/test/test_images.jl
+++ b/test/test_images.jl
@@ -1,10 +1,6 @@
 using Base.Test
 using DataFrames
-
 import WCS
-
-using Celeste: Model
-import Celeste: ModelInit, ElboDeriv, SDSSIO, PSF
 
 println("Running SkyImages tests.")
 

--- a/test/test_images.jl
+++ b/test/test_images.jl
@@ -119,30 +119,6 @@ function test_blob()
 end
 
 
-function test_fit_object_psfs()
-  blob = SDSSIO.load_field_images(RUN, CAMCOL, FIELD, datadir);
-  fname = @sprintf "%s/photoObj-%06d-%d-%04d.fits" datadir RUN CAMCOL FIELD
-  cat_entries = SDSSIO.read_photoobj_celeste(fname);
-
-  # Only test a few catalog entries.
-  relevant_sources = collect(3:4)
-  test_sources = collect(1:5)
-
-  tiled_blob, mp = initialize_celeste(
-    blob, cat_entries[test_sources], fit_psf=false);
-  ModelInit.fit_object_psfs!(mp, relevant_sources, blob);
-
-  tiled_blob, mp_psf_init = initialize_celeste(
-    blob, cat_entries[test_sources], fit_psf=true);
-
-  for b in 1:length(blob), s in relevant_sources
-    @test_approx_eq(
-      blob[b].raw_psf_comp(mp.patches[s, b].pixel_center...),
-      blob[b].raw_psf_comp(mp_psf_init.patches[s, b].pixel_center...))
-  end
-end
-
-
 function test_stamp_get_object_psf()
   stamp_blob, stamp_mp, body = gen_sample_star_dataset();
   img = stamp_blob[3];

--- a/test/test_images.jl
+++ b/test/test_images.jl
@@ -26,7 +26,7 @@ Returns:
 """
 function crop_blob_to_location(
   blob::Array{Image, 1},
-  width::Union{Float64, Int},
+  width::Int,
   wcs_center::Vector{Float64})
     @assert length(wcs_center) == 2
     @assert width > 0
@@ -42,7 +42,8 @@ function crop_blob_to_location(
         w_min = max(floor(Int, (pix_center[2] - width)), 1)
         w_max = min(ceil(Int, pix_center[2] + width), blob[b].W)
         sub_rows_w = w_min:w_max
-        tiled_blob[b] = fill(ImageTile(blob[b], sub_rows_h, sub_rows_w), 1, 1)
+        tiled_blob[b] = TiledImage(blob[b], tile_width=width)
+        tiled_blob[b].tiles = fill(ImageTile(blob[b], sub_rows_h, sub_rows_w), 1, 1)
     end
     tiled_blob
 end
@@ -72,15 +73,13 @@ function test_blob()
   obj_loc = cat_entries[obj_index].pos  # location of closest object
 
   # Test cropping.
-  width = 5.0
+  width = 5
   cropped_blob = crop_blob_to_location(blob, width, obj_loc);
   for b=1:length(blob)
     # Check that it only has one tile of the right size containing the object.
-    @assert length(cropped_blob[b]) == 1
-    @test 2 * width <= cropped_blob[b][1].h_width <= 2 * (width + 1)
-    @test 2 * width <= cropped_blob[b][1].w_width <= 2 * (width + 1)
+    @assert length(cropped_blob[b].tiles) == 1
     patches = vec(mp.patches[:, b])
-    tile_sources = Model.get_local_sources(cropped_blob[b][1],
+    tile_sources = Model.get_local_sources(cropped_blob[b].tiles[1],
                                            Model.patch_ctrs_pix(patches),
                                            Model.patch_radii_pix(patches))
     @test obj_index in tile_sources
@@ -88,8 +87,8 @@ function test_blob()
 
   # Test get_source_psf at point while we have the blob loaded.
   test_b = 3
-  img = blob[test_b]
-  mp_obj = ModelInit.initialize_model_params(tiled_blob, blob,
+  img = tiled_blob[test_b]
+  mp_obj = ModelInit.initialize_model_params(tiled_blob,
                                              cat_entries[obj_index:obj_index])
   pixel_loc = WCS.world_to_pix(img.wcs, obj_loc);
   original_psf_val = img.raw_psf_comp(pixel_loc[1], pixel_loc[2])
@@ -108,7 +107,7 @@ function test_blob()
 
   mp_several =
     ModelInit.initialize_model_params(
-      tiled_blob, blob, [cat_entries[1]; cat_entries[obj_index]]);
+      tiled_blob, [cat_entries[1]; cat_entries[obj_index]]);
 
   # The second set of vp is the object of interest
   point_patch_psf = PSF.get_psf_at_point(mp_several.patches[2, test_b].psf);
@@ -118,7 +117,7 @@ end
 
 function test_stamp_get_object_psf()
   stamp_blob, stamp_mp, body = gen_sample_star_dataset();
-  img = stamp_blob[3];
+  img = TiledImage(stamp_blob[3]);
   obj_index =  stamp_mp.vp[1][ids.u]
   pixel_loc = WCS.world_to_pix(img.wcs, obj_index)
   original_psf_val = PSF.get_psf_at_point(img.psf);
@@ -134,11 +133,11 @@ function test_get_tiled_image_source()
   blob, mp, body, tiled_blob = gen_sample_star_dataset();
 
   mp = ModelInit.initialize_model_params(
-    tiled_blob, blob, body; patch_radius=1e-6)
+    tiled_blob, body; patch_radius=1e-6)
 
-  tiled_img = Model.break_image_into_tiles(blob[3], 10);
-  for hh in 1:size(tiled_img)[1], ww in 1:size(tiled_img)[2]
-    tile = tiled_img[hh, ww]
+  tiled_img = TiledImage(blob[3], tile_width=10);
+  for hh in 1:size(tiled_img.tiles, 1), ww in 1:size(tiled_img.tiles, 2)
+    tile = tiled_img.tiles[hh, ww]
     loc = Float64[mean(tile.h_range), mean(tile.w_range)]
     for b = 1:5
       mp.vp[1][ids.u] = loc
@@ -152,11 +151,11 @@ function test_get_tiled_image_source()
                                   pixel_center)
     end
     patches = vec(mp.patches[:, 3])
-    local_sources = Model.get_tiled_image_sources(tiled_img,
-                                                  Model.patch_ctrs_pix(patches),
-                                                  Model.patch_radii_pix(patches))
+    local_sources = Model.get_sources_per_tile(tiled_img.tiles,
+                                               Model.patch_ctrs_pix(patches),
+                                               Model.patch_radii_pix(patches))
     @test local_sources[hh, ww] == Int[1]
-    for hh2 in 1:size(tiled_img)[1], ww2 in 1:size(tiled_img)[2]
+    for hh2 in 1:size(tiled_img.tiles, 1), ww2 in 1:size(tiled_img.tiles, 2)
       if (hh2 != hh) || (ww2 != ww)
         @test local_sources[hh2, ww2] == Int[]
       end
@@ -170,15 +169,15 @@ function test_local_source_candidate()
 
   # This is run by gen_n_body_dataset but put it here for safe testing in
   # case that changes.
-  mp = ModelInit.initialize_model_params(tiled_blob, blob, body);
+  mp = ModelInit.initialize_model_params(tiled_blob, body);
 
   for b=1:length(tiled_blob)
     # Get the sources by iterating over everything.
     patches = vec(mp.patches[:,b])
 
-    tile_sources = Model.get_tiled_image_sources(tiled_blob[b],
-                                                 Model.patch_ctrs_pix(patches),
-                                                 Model.patch_radii_pix(patches))
+    tile_sources = Model.get_sources_per_tile(tiled_blob[b].tiles,
+                                              Model.patch_ctrs_pix(patches),
+                                              Model.patch_radii_pix(patches))
 
     # Check that all the actual sources are candidates and that this is the
     # same as what is returned by initialize_model_params.
@@ -186,7 +185,7 @@ function test_local_source_candidate()
     for h=1:HH, w=1:WW
       # Get a set of candidates.
       candidates = Model.local_source_candidates(
-                        tiled_blob[b][h, w],
+                        tiled_blob[b].tiles[h, w],
                         Model.patch_ctrs_pix(patches),
                         Model.patch_radii_pix(patches))
       @test setdiff(tile_sources[h, w], candidates) == []
@@ -225,13 +224,13 @@ function test_set_patch_size()
       initialize_celeste(blob, cat, tile_width=typemax(Int));
 
     for b=1:length(blob)
-      @assert size(tiled_blob[b]) == (1, 1)
+      @assert size(tiled_blob[b].tiles) == (1, 1)
       tile_image = ElboDeriv.tile_predicted_image(
-        tiled_blob[b][1,1], mp, mp.tile_sources[b][1,1]);
+        tiled_blob[b].tiles[1,1], mp, mp.tile_sources[b][1,1]);
 
       pixel_center = WCS.world_to_pix(blob[b].wcs, cat[1].pos)
       radius = Model.choose_patch_radius(
-        pixel_center, cat[1], blob[b].psf, blob[b])
+        pixel_center, cat[1], blob[b].psf, tiled_blob[b])
 
       circle_pts = fill(false, blob[b].H, blob[b].W);
       in_circle = 0.0
@@ -277,8 +276,8 @@ function test_copy_model_params()
   @test s > 0
 
   # Fit with both and make sure you get the same answer.
-  ModelInit.fit_object_psfs!(mp_all, relevant_sources, images);
-  ModelInit.fit_object_psfs!(mp, collect(1:mp.S), images);
+  ModelInit.fit_object_psfs!(mp_all, relevant_sources, tiled_images);
+  ModelInit.fit_object_psfs!(mp, collect(1:mp.S), tiled_images);
 
   @test mp.S == length(relevant_sources)
   for sa in 1:length(relevant_sources)

--- a/test/test_infer.jl
+++ b/test/test_infer.jl
@@ -1,5 +1,4 @@
 ## test the main entry point in Celeste: the `infer` function
-import Celeste
 import JLD
 
 """

--- a/test/test_kl.jl
+++ b/test/test_kl.jl
@@ -1,4 +1,3 @@
-using Base.Test
 using Distributions
 
 using Celeste.KL

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -11,7 +11,7 @@ function test_tile_image()
   tile_width = 20;
   img.epsilon_mat = rand(size(img.pixels));
   img.iota_vec = rand(size(img.pixels, 1));
-  tiles = Model.break_image_into_tiles(img, tile_width);
+  tiles = Model.TiledImage(img; tile_width=tile_width).tiles;
   @test size(tiles) == (
     ceil(Int, img.H  / tile_width),
     ceil(Int, img.W / tile_width))
@@ -45,10 +45,12 @@ function test_local_sources()
     ]
 
     blob = Synthetic.gen_blob(blob0, three_bodies);
+    tiled_blob = TiledImage[TiledImage(img; tile_width=20) for img in blob]
 
     tile = ImageTile(1, 1, blob[3], 1000);
+
     mp = ModelInit.initialize_model_params(
-      fill(fill(tile, 1, 1), 5), blob, three_bodies; patch_radius=20.);
+      tiled_blob, three_bodies; patch_radius=20.);
     @test mp.S == 3
 
     patches = vec(mp.patches[:, 3])
@@ -59,7 +61,7 @@ function test_local_sources()
     tile_width = 10
     tile = ImageTile(1, 1, blob[3], tile_width);
     ModelInit.initialize_model_params(
-      fill(fill(tile, 1, 1), 5), blob, three_bodies; patch_radius=20.);
+      tiled_blob, three_bodies; patch_radius=20.);
 
     patches = vec(mp.patches[:, 3])
     subset10 = Model.get_local_sources(tile, patch_ctrs_pix(patches),
@@ -68,7 +70,7 @@ function test_local_sources()
 
     last_tile = ImageTile(11, 24, blob[3], tile_width)
     ModelInit.initialize_model_params(
-      fill(fill(last_tile, 1, 1), 5), blob, three_bodies; patch_radius=20.)
+      tiled_blob, three_bodies; patch_radius=20.)
 
     patches = vec(mp.patches[:, 3])
     last_subset = Model.get_local_sources(last_tile,
@@ -78,7 +80,7 @@ function test_local_sources()
 
     pop_tile = ImageTile(7, 9, blob[3], tile_width)
     ModelInit.initialize_model_params(
-      fill(fill(pop_tile, 1, 1), 5), blob, three_bodies; patch_radius=20.);
+      tiled_blob, three_bodies; patch_radius=20.);
 
     patches = vec(mp.patches[:, 3])
     pop_subset = Model.get_local_sources(pop_tile, patch_ctrs_pix(patches),
@@ -198,7 +200,7 @@ end
 
 function test_get_relevant_sources()
   blob, mp, body, tiled_blob = gen_n_body_dataset(100; seed=42);
-  mp = ModelInit.initialize_model_params(tiled_blob, blob, body);
+  mp = ModelInit.initialize_model_params(tiled_blob, body);
 
   target_s = 1
   relevant_sources = ModelInit.get_relevant_sources(mp, target_s);

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -1,8 +1,7 @@
 using Base.Test
 
-using Celeste: Model
-import Celeste: ModelInit
 import Celeste.Model: patch_ctrs_pix, patch_radii_pix
+
 
 println("Running misc tests.")
 

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -200,49 +200,6 @@ function test_local_sources_3()
 end
 
 
-function test_tiling()
-    srand(1)
-    blob0 =SampleData.load_stamp_blob(datadir, "164.4311-39.0359_2kpsf")
-    for b in 1:5
-        blob0[b].H, blob0[b].W = 112, 238
-    end
-    three_bodies = [
-        sample_ce([4.5, 3.6], false),
-        sample_ce([60.1, 82.2], true),
-        sample_ce([71.3, 100.4], false),
-    ]
-   blob = Synthetic.gen_blob(blob0, three_bodies)
-
-    mp = ModelInit.cat_init(three_bodies)
-    elbo = ElboDeriv.elbo(blob, mp)
-
-    mp2 = ModelInit.cat_init(three_bodies, tile_width=10)
-    elbo_tiles = ElboDeriv.elbo(blob, mp2)
-    @test_approx_eq_eps elbo_tiles.v[1] elbo.v[1] 1e-5
-
-    mp3 = ModelInit.cat_init(three_bodies, patch_radius=30.)
-    elbo_patches = ElboDeriv.elbo(blob, mp3)
-    @test_approx_eq_eps elbo_patches.v[1] elbo.v[1] 1e-5
-
-    for s in 1:mp.S
-        for i in 1:length(1:length(CanonicalParams))
-            @test_approx_eq_eps elbo_tiles.d[i, s] elbo.d[i, s] 1e-5
-            @test_approx_eq_eps elbo_patches.d[i, s] elbo.d[i, s] 1e-5
-        end
-    end
-
-    mp4 = ModelInit.cat_init(three_bodies, patch_radius=35., tile_width=10)
-    elbo_both = ElboDeriv.elbo(blob, mp4)
-    @test_approx_eq_eps elbo_both.v[1] elbo.v[1] 1e-1
-
-    for s in 1:mp.S
-        for i in 1:length(1:length(CanonicalParams))
-            @test_approx_eq_eps elbo_both.d[i, s] elbo.d[i, s] 1e-1
-        end
-    end
-end
-
-
 function test_sky_noise_estimates()
     blobs = Array(Blob, 2)
     blobs[1], mp, three_bodies = gen_three_body_dataset()  # synthetic

--- a/test/test_optimization.jl
+++ b/test/test_optimization.jl
@@ -1,8 +1,6 @@
 using Base.Test
 
 using Celeste: Model, Transform, SensitiveFloats
-import Celeste: OptimizeElbo, ModelInit, ElboDeriv
-import Celeste.WCSUtils
 
 
 println("Running optimization tests.")

--- a/test/test_psf.jl
+++ b/test/test_psf.jl
@@ -1,10 +1,16 @@
 using Celeste
 using Celeste.Model
 using Celeste.BivariateNormals
-using Celeste.PSF
 using Celeste.SensitiveFloats
 
-import Celeste.SDSSIO
+import Celeste.PSF: evaluate_psf_fit, psf_params_to_array, psf_array_to_params,
+       get_psf_transform, initialize_psf_params, transform_psf_params!,
+       unwrap_psf_params, wrap_psf_params,
+       unconstrain_psf_params, constrain_psf_params,
+       transform_psf_sensitive_float!,
+       PsfOptimizer, fit_raw_psf_for_celeste,
+       get_psf_at_point, get_source_psf
+
 
 using ForwardDiff
 

--- a/test/test_psf.jl
+++ b/test/test_psf.jl
@@ -3,7 +3,7 @@ using Celeste.Model
 using Celeste.BivariateNormals
 using Celeste.SensitiveFloats
 
-import Celeste.PSF: evaluate_psf_fit, psf_params_to_array, psf_array_to_params,
+import Celeste.PSF: evaluate_psf_fit,
        get_psf_transform, initialize_psf_params, transform_psf_params!,
        unwrap_psf_params, wrap_psf_params,
        unconstrain_psf_params, constrain_psf_params,

--- a/test/test_sdssio.jl
+++ b/test/test_sdssio.jl
@@ -1,5 +1,3 @@
-import Celeste.SDSSIO
-
 function test_interp_sky()
     data = [1.  2.  3.  4.;
             5.  6.  7.  8.;

--- a/test/test_sensitive_float.jl
+++ b/test/test_sensitive_float.jl
@@ -1,6 +1,4 @@
-using Base.Test
-
-using Celeste: Model, SensitiveFloats
+using Celeste: SensitiveFloats
 
 
 function test_combine_sfs()

--- a/test/test_transforms.jl
+++ b/test/test_transforms.jl
@@ -1,10 +1,7 @@
 # Test the functions that move between constrained and unconstrained
 # parameterizations.
 
-using Base.Test
-
-using Celeste: Model, Transform, SensitiveFloats
-import Celeste: ModelInit, ElboDeriv
+using Celeste: Transform, SensitiveFloats
 using Compat
 
 

--- a/test/test_transforms.jl
+++ b/test/test_transforms.jl
@@ -14,10 +14,10 @@ function test_transform_sensitive_float()
 	# Only keep a few pixels to make the autodiff results faster.
   keep_pixels = 10:11
 	for b = 1:length(tiled_blob)
-	  tiled_blob[b][1,1].pixels[
-			setdiff(1:tiled_blob[b][1,1].h_width, keep_pixels), :] = NaN;
-	  tiled_blob[b][1,1].pixels[
-			:, setdiff(1:tiled_blob[b][1,1].w_width, keep_pixels)] = NaN;
+	  tiled_blob[b].tiles[1,1].pixels[
+			setdiff(1:tiled_blob[b].tiles[1,1].h_width, keep_pixels), :] = NaN;
+	  tiled_blob[b].tiles[1,1].pixels[
+			:, setdiff(1:tiled_blob[b].tiles[1,1].w_width, keep_pixels)] = NaN;
 	end
 
 


### PR DESCRIPTION
This PR closes #215 , by reducing memory usage through two changes:
- Image data is no longer duplicated in both `Image` and `TiledImage` data types. Everything gets copied to `TiledImage` now, so that the corresponding `Image` data type can be freed. (~50% reduction in memory use.)
- `TiledImage` data is stored as `Float32` rather than `Float64`. The fits files store image data in 32-bit numbers anyway, so we're not discarding any information. (Also, the scores are no worse after the change.)
