### PR TITLE
moves initialization and psf fitting inside the threaded loop

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,6 @@ import Celeste: WCSUtils, ModelInit, ElboDeriv, Model, ModelInit
 import Celeste: PSF, OptimizeElbo, SDSSIO, SensitiveFloats, Transform
 import Celeste: BivariateNormals
 
-
 include("Synthetic.jl")
 include("SampleData.jl")
 
@@ -14,6 +13,9 @@ using SampleData
 
 using Base.Test
 using Distributions
+
+import Logging
+Logging.configure(level=Logging.INFO)
 
 anyerrors = false
 


### PR DESCRIPTION
This PR moves 1) model initialization, and 2) psf fitting instead the main threaded loop over sources.

It adds a new routine outside the threaded loop, that finds each sources' neighboring sources, ahead of time. This serial routine has quadratic runtime, but in practice in finishes in about 1 second for thousands of sources.

Scores on stripe 82 continue to look good, though the `relevant_sources` aren't always the same.

@kpamnany  Will you try this out with threading enabled? There may be less interaction between threads now.
