### PR TITLE
[WIP] Update to ForwardDiff 0.2.x

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,7 +3,7 @@ Compat
 DataFrames
 Distributions
 DocOpt
-ForwardDiff 0.1.8 0.2
+ForwardDiff 0.2
 JLD
 Lumberjack
 Optim 0.5 0.5.1

--- a/src/elbo_kl.jl
+++ b/src/elbo_kl.jl
@@ -173,23 +173,16 @@ function subtract_kl!{NumType <: Number}(
 
     if calculate_derivs
         if calculate_hessian
-            hess, all_results =
-                ForwardDiff.hessian(subtract_kl_value_wrapper,
-                                    vp_vec,
-                                    ForwardDiff.AllResults)
-            accum.h += hess
-            accum.d += reshape(ForwardDiff.gradient(all_results), P, Sa)
-            accum.v[1] += ForwardDiff.value(all_results)
+            result = ForwardDiff.HessianResult(vp_vec)
+            ForwardDiff.hessian!(result, subtract_kl_value_wrapper, vp_vec)
+            accum.h += ForwardDiff.hessian(result)
         else
-            grad, all_results =
-                ForwardDiff.gradient(subtract_kl_value_wrapper,
-                                     vp_vec,
-                                     ForwardDiff.AllResults)
-            accum.d += reshape(grad, P, Sa)
-            accum.v[1] += ForwardDiff.value(all_results)
+            result = ForwardDiff.GradientResult(vp_vec)
+            ForwardDiff.gradient!(result, subtract_kl_value_wrapper, vp_vec)
         end
+        accum.d += reshape(ForwardDiff.gradient(result), P, Sa)
+        accum.v[1] += ForwardDiff.value(result)
     else
         accum.v[1] += subtract_kl_value_wrapper(vp_vec)
     end
 end
-

--- a/test/derivative_utils.jl
+++ b/test/derivative_utils.jl
@@ -1,39 +1,36 @@
 import Base.convert
 
-
-function convert(FDType::Type{ForwardDiff.GradientNumber},
-                 ea::ElboArgs{Float64})
-    x = ea.vp[1]
-    P = length(x)
-    FDType = ForwardDiff.GradientNumber{length(ea.vp[1]), Float64}
-
-    fd_x = [ ForwardDiff.GradientNumber(x[i], zeros(Float64, P)...) for i=1:P ]
-    convert(FDType, x[1])
-
-    vp_fd = convert(Array{Array{FDType, 1}, 1}, ea.vp[1])
-    ea_fd = ElboArgs(vp_fd)
-end
-
-function convert(FDType::Type{ForwardDiff.HessianNumber},
-                 ea::ElboArgs{Float64})
-    x = ea.vp[1]
-    P = length(x)
-    FDType = ForwardDiff.HessianNumber{length(ea.vp[1]), Float64}
-
-    fd_x = [ ForwardDiff.HessianNumber(x[i], zeros(Float64, P)...) for i=1:P ]
-    convert(FDType, x[1])
-
-    vp_fd = convert(Array{Array{FDType, 1}, 1}, ea.vp[1])
-    ea_fd = ElboArgs(vp_fd)
-end
+# function convert(FDType::Type{ForwardDiff.GradientNumber},
+#                  ea::ElboArgs{Float64})
+#     x = ea.vp[1]
+#     P = length(x)
+#     FDType = ForwardDiff.GradientNumber{length(ea.vp[1]), Float64}
+#
+#     fd_x = [ ForwardDiff.GradientNumber(x[i], zeros(Float64, P)...) for i=1:P ]
+#     convert(FDType, x[1])
+#
+#     vp_fd = convert(Array{Array{FDType, 1}, 1}, ea.vp[1])
+#     ea_fd = ElboArgs(vp_fd)
+# end
+#
+# function convert(FDType::Type{ForwardDiff.HessianNumber},
+#                  ea::ElboArgs{Float64})
+#     x = ea.vp[1]
+#     P = length(x)
+#     FDType = ForwardDiff.HessianNumber{length(ea.vp[1]), Float64}
+#
+#     fd_x = [ ForwardDiff.HessianNumber(x[i], zeros(Float64, P)...) for i=1:P ]
+#     convert(FDType, x[1])
+#
+#     vp_fd = convert(Array{Array{FDType, 1}, 1}, ea.vp[1])
+#     ea_fd = ElboArgs(vp_fd)
+# end
 
 
 # Maybe write it as a convert()?
-function forward_diff_model_params{T <: Number}(
-            FDType::Type{T},
-            ea0::ElboArgs{Float64})
+function forward_diff_model_params{T<:Number}(::Type{T}, ea0::ElboArgs{Float64})
     P = length(ea0.vp[1])
-    vp = Vector{FDType}[zeros(FDType, P) for s=1:ea0.S]
+    vp = Vector{T}[zeros(T, P) for s=1:ea0.S]
     # Set the values (but not gradient numbers) for parameters other
     # than the galaxy parameters.
     for s=1:ea0.S, i=1:length(ids)
@@ -46,4 +43,3 @@ function forward_diff_model_params{T <: Number}(
              ea0.patches,
              ea0.active_sources)
 end
-

--- a/test/test_derivatives.jl
+++ b/test/test_derivatives.jl
@@ -823,12 +823,12 @@ function test_galaxy_cache_component()
         f_wrap(par))
 
     # Check the gradient.
-    ad_grad_fun = ForwardDiff.gradient(f_wrap)
+    ad_grad_fun = x -> ForwardDiff.gradient(f_wrap, x)
     ad_grad = ad_grad_fun(par)
     bvn_derivs = elbo_vars.bvn_derivs
     @test_approx_eq ad_grad [bvn_derivs.bvn_u_d; bvn_derivs.bvn_s_d]
 
-    ad_hess_fun = ForwardDiff.hessian(f_wrap)
+    ad_hess_fun = x -> ForwardDiff.hessian(f_wrap, x)
     ad_hess = ad_hess_fun(par)
 
     @test_approx_eq ad_hess[1:2, 1:2] bvn_derivs.bvn_uu_h
@@ -871,11 +871,11 @@ function test_galaxy_sigma_derivs()
 
         gal_derivs = ElboDeriv.GalaxySigmaDerivs(e_angle, e_axis, e_scale, XiXi)
 
-        ad_grad_fun = ForwardDiff.gradient(f_wrap)
+        ad_grad_fun = x -> ForwardDiff.gradient(f_wrap, x)
         ad_grad = ad_grad_fun(par)
         @test_approx_eq gal_derivs.j[si, :][:] ad_grad
 
-        ad_hess_fun = ForwardDiff.hessian(f_wrap)
+        ad_hess_fun = x -> ForwardDiff.hessian(f_wrap, x)
         ad_hess = ad_hess_fun(par)
         @test_approx_eq(
             ad_hess,


### PR DESCRIPTION
This updates the code to utilize the new ForwardDiff.  I had trouble locally aligning the versions of Celeste's dependencies, so I'm relying on Travis to tell me whether or not this PR works.

I'm using WIP tag for this PR because I was a bit confused by the `convert` methods in `test/derivative_utils.jl`. They break the semantic interface of `Base.convert`, i.e. these convert methods do not obey `convert(T, x)::T)`. It seems like their purpose is to map `ElboArgs{T}` to `ElboArgs{GradientNumber{N,T}}` or `ElboArgs{HessianNumber{N,T}}`, but I'm not sure where/how this is getting used. 

I technically could do a naive rewrite of these methods using `ForwardDiff`'s new `Dual` type, but as I was unsure, I chose to comment them out and see what happens.
