### PR TITLE
added new type FlatTiledImage, that can be written to a global array

### DIFF
--- a/src/Model.jl
+++ b/src/Model.jl
@@ -1,7 +1,7 @@
 module Model
 
 # parameter types
-export Image, TiledImage, ImageTile,
+export Image, TiledImage, ImageTile, FlatTiledImage,
        SkyPatch, PsfComponent,
        GalaxyComponent, GalaxyPrototype,
        PriorParams, UnconstrainedParams,
@@ -27,7 +27,7 @@ export band_letters, D, Ia, B, psf_K,
 import Base.convert
 import Base.+
 import Distributions
-import FITSIO
+import FITSIO, WCS
 import WCS.WCSTransform
 import ForwardDiff
 import ..Log

--- a/test/test_images.jl
+++ b/test/test_images.jl
@@ -214,6 +214,19 @@ function test_set_patch_size()
 end
 
 
+function test_flat_image()
+    blob, ea, three_bodies = gen_three_body_dataset()
+    img0 = ea.images[1]
+
+    flat_img = FlatTiledImage(img0)
+    @assert img0.H == flat_img.H
+
+    img = TiledImage(flat_img)
+    @assert img0.H == img.H
+    # maybe should check that wcs is the same too....
+end
+
+test_flat_image()
 test_blob()
 test_stamp_get_object_psf()
 test_get_tiled_image_source()


### PR DESCRIPTION
@kpamnany  ---  Please merge this PR when you're ready to use it. I created a new type, `FlatTiledImage`, and constructors that let you convert between a `TiledImage` and a `FlatTiledImage`. The latter should be more suitable for storing in a global array. It stores the WCS information as a `String` rather than a `WCSTransform`. It contains a few `TODO` comments, where you'll presumably want to change the remaining variable length types in `FlatTiledImage` to fixed length types.
