### PR TITLE
Print whole vp

### DIFF
--- a/src/OptimizeElbo.jl
+++ b/src/OptimizeElbo.jl
@@ -85,7 +85,7 @@ type ObjectiveWrapperFunctions
               for s=1:S
                 state_df[Symbol(string("grad", s))] = grad[:, s]
               end
-              Log.info(string(state_df))
+              Log.info(repr(state_df))
               Log.info("=======================================\n")
             end
         end

--- a/src/psf_model.jl
+++ b/src/psf_model.jl
@@ -28,7 +28,6 @@ immutable PsfComponent
 
     function PsfComponent(alphaBar::Float64, xiBar::Vector{Float64},
                           tauBar::Matrix{Float64})
-        # @assert(alphaBar > 0, "alphaBar must be positive.")
         new(alphaBar, xiBar, tauBar, tauBar^-1, logdet(tauBar))
     end
 end

--- a/src/psf_model.jl
+++ b/src/psf_model.jl
@@ -28,7 +28,7 @@ immutable PsfComponent
 
     function PsfComponent(alphaBar::Float64, xiBar::Vector{Float64},
                           tauBar::Matrix{Float64})
-        @assert(alphaBar > 0, "alphaBar must be positive.")
+        # @assert(alphaBar > 0, "alphaBar must be positive.")
         new(alphaBar, xiBar, tauBar, tauBar^-1, logdet(tauBar))
     end
 end

--- a/src/psf_model.jl
+++ b/src/psf_model.jl
@@ -28,6 +28,7 @@ immutable PsfComponent
 
     function PsfComponent(alphaBar::Float64, xiBar::Vector{Float64},
                           tauBar::Matrix{Float64})
+        @assert(alphaBar > 0, "alphaBar must be positive.")
         new(alphaBar, xiBar, tauBar, tauBar^-1, logdet(tauBar))
     end
 end
@@ -86,5 +87,3 @@ function get_psf_width(psf::Array{PsfComponent}; width_scale=1.0)
     # mass in the PSF.
     width_scale * sqrt(eigvals(cov_est)[end]) * alpha_norm
 end
-
-


### PR DESCRIPTION
`string` unhelpfully truncates the dataframe for display.
