### PR TITLE
now list_rcfs.jl takes a bounding box

### DIFF
--- a/bin/celeste.jl
+++ b/bin/celeste.jl
@@ -39,11 +39,8 @@ function main()
 #    set_logging_level(args["--logging"])
     stagedir = ENV["CELESTE_STAGE_DIR"]
     if args["infer-box"]
-        ramin = parse(Float64, args["<ramin>"])
-        ramax = parse(Float64, args["<ramax>"])
-        decmin = parse(Float64, args["<decmin>"])
-        decmax = parse(Float64, args["<decmax>"])
-        box = BoundingBox(ramin, ramax, decmin, decmax)
+        box = BoundingBox(args["<ramin>"], args["<ramax>"],
+                          args["<decmin>"], args["<decmax>"])
         outdir = args["<outdir>"]
         infer_box(box, stagedir, outdir)
     else

--- a/src/ParallelRun.jl
+++ b/src/ParallelRun.jl
@@ -92,6 +92,14 @@ immutable BoundingBox
 end
 
 
+function BoundingBox(ramin::String, ramax::String, decmin::String, decmax::String)
+    BoundingBox(parse(Float64, ramin),
+                parse(Float64, ramax),
+                parse(Float64, decmin),
+                parse(Float64, decmax))
+end
+
+
 @inline nputs(nid, s) = ccall(:puts, Cint, (Ptr{Int8},), string("[$nid] ", s))
 @inline phalse(b) = b[] = false
 


### PR DESCRIPTION
I modified `list_rcfs.jl` to take a bounding box as arguments, rather than returning all the rcfs every time. (Before I just needed a list of all rcfs for staging, but now I needed to get a dataset to Kiran for testing.)
