### PR TITLE
fix missing var in optimization verbose printing

### DIFF
--- a/src/deterministic_vi/maximize_elbo.jl
+++ b/src/deterministic_vi/maximize_elbo.jl
@@ -57,6 +57,7 @@ function maximize_f(f::Function,
         end
 
         if verbose
+            iter_vp = ea.vp[ea.active_sources]
             S = length(iter_vp)
 
             if length(iter_vp[1]) == length(ids_names)


### PR DESCRIPTION
Looks like a function was inlined and this parameter name wasn't updated. This is a minimal fix.
