### PR TITLE
Disallow epsilon = 0, and try to catch NaNs earlier

### DIFF
--- a/src/Celeste.jl
+++ b/src/Celeste.jl
@@ -1,6 +1,7 @@
 module Celeste
 
 # submodules
+include("Exceptions.jl")
 include("Log.jl")
 
 include("SensitiveFloats.jl")

--- a/src/DeterministicVI.jl
+++ b/src/DeterministicVI.jl
@@ -3,6 +3,7 @@ Calculate value, gradient, and hessian of the variational ELBO.
 """
 module DeterministicVI
 
+import ..Exceptions
 using ..Model
 import ..Model: BivariateNormalDerivatives, BvnComponent, GalaxyCacheComponent,
                 GalaxySigmaDerivs,
@@ -16,7 +17,6 @@ import DataFrames
 import Optim
 
 export ElboArgs
-
 
 """
 ElboArgs stores the arguments needed to evaluate the variational objective
@@ -59,6 +59,13 @@ function ElboArgs{NumType <: Number}(
     @assert length(tile_source_map) == N
     @assert size(patches, 1) == S
     @assert size(patches, 2) == N
+    for tiled_image in images
+        for tile in tiled_image.tiles
+            if any(tile.epsilon_mat .<= 0)
+                throw(Exceptions.InvalidInputError("You must set all values of epsilon_mat > 0"))
+            end
+        end
+    end
     ElboArgs(S, N, psf_K, images, vp, tile_source_map, patches,
              active_sources, num_allowed_sd)
 end

--- a/src/Exceptions.jl
+++ b/src/Exceptions.jl
@@ -1,0 +1,14 @@
+"""
+Custom exception types used throughout Celeste.
+"""
+module Exceptions
+
+"""
+Some parameter to a function has invalid values. The message should explain what parameter is
+invalid and why.
+"""
+type InvalidInputError <: Exception
+    message::String
+end
+
+end

--- a/src/deterministic_vi/elbo.jl
+++ b/src/deterministic_vi/elbo.jl
@@ -693,6 +693,7 @@ function process_active_pixels!{NumType <: Number}(
         # the optimization convergence criterion, so I will leave it in for now.
         elbo_vars.elbo.v[1] -= lfact(this_pixel)
     end
+    assert_all_finite(elbo_vars.elbo)
 end
 
 
@@ -813,4 +814,12 @@ function elbo{NumType <: Number}(
     # TODO: subtract the kl with the hessian.
     subtract_kl!(ea, elbo, calculate_derivs=calculate_derivs)
     elbo
+end
+
+# If Infs/NaNs have crept into the ELBO evaluation (a symptom of poorly conditioned optimization),
+# this helps catch them immediately.
+function assert_all_finite{ParamType}(sf::SensitiveFloat{ParamType, Float64})
+    @assert all(isfinite(sf.v)) "Value is Inf/NaNs"
+    @assert all(isfinite(sf.d)) "Gradient contains Inf/NaNs"
+    @assert all(isfinite(sf.h)) "Hessian contains Inf/NaNs"
 end


### PR DESCRIPTION
@jeff-regier What do you think of these? Does the check on epsilon seem reasonable? Is this a good place to check it? Are the asserts going to be too much of a performance hit? I'm not sure if Julia optimizes out asserts under certain conditions or what...I can research it.
