### PR TITLE
Active pixels

### DIFF
--- a/src/DeterministicVI.jl
+++ b/src/DeterministicVI.jl
@@ -77,17 +77,6 @@ function ElboArgs{NumType <: Number}(
         end
     end
 
-    active_pixels = ActivePixel[]
-    for i in 1:N
-        tiles = images[i].tiles
-        for j in 1:length(tiles)
-            W, H = size(tiles[j].pixels)
-            for w in 1:W, h in 1:H
-                push!(active_pixels, ActivePixel(i, j, h, w))
-            end
-        end
-    end
-
     ElboArgs(S, N, psf_K, images, vp, tile_source_map, patches,
              active_sources, num_allowed_sd, ActivePixel[])
 end

--- a/src/DeterministicVI.jl
+++ b/src/DeterministicVI.jl
@@ -48,6 +48,8 @@ type ElboArgs{NumType <: Number}
     # If this is set to Inf, the bivariate normals will be evaluated at all points
     # irrespective of their distance from the mean.
     num_allowed_sd::Float64
+
+    active_pixels::Vector{ActivePixel}
 end
 
 
@@ -66,19 +68,28 @@ function ElboArgs{NumType <: Number}(
     @assert length(tile_source_map) == N
     @assert size(patches, 1) == S
     @assert size(patches, 2) == N
-    for tiled_image in images
-        for tile in tiled_image.tiles
-            for ep in tile.epsilon_mat
-                if ep <= 0.0
-                    throw(InvalidInputError(
-                        "You must set all values of epsilon_mat > 0 for all images included in ElboArgs"
-                    ))
-                end
+
+    for img in images, tile in img.tiles, ep in tile.epsilon_mat
+        if ep <= 0.0
+            throw(InvalidInputError(
+                "You must set all values of epsilon_mat > 0 for all images included in ElboArgs"
+            ))
+        end
+    end
+
+    active_pixels = ActivePixel[]
+    for i in 1:N
+        tiles = images[i].tiles
+        for j in 1:length(tiles)
+            W, H = size(tiles[j].pixels)
+            for w in 1:W, h in 1:H
+                push!(active_pixels, ActivePixel(i, j, h, w))
             end
         end
     end
+
     ElboArgs(S, N, psf_K, images, vp, tile_source_map, patches,
-             active_sources, num_allowed_sd)
+             active_sources, num_allowed_sd, ActivePixel[])
 end
 
 

--- a/src/Infer.jl
+++ b/src/Infer.jl
@@ -237,7 +237,7 @@ function load_active_pixels!(ea::ElboArgs{Float64};
                     close_pixel =
                         (h - pix_loc[1]) ^ 2 + (w - pix_loc[2])^2 < min_radius_pix^2
 
-                    if bright_pixel || close_pixel
+                    if (bright_pixel || close_pixel) && !isnan(tile.pixels[h_im, w_im])
                         push!(ea.active_pixels, ActivePixel(n, t, h_im, w_im))
                     end
                 end

--- a/src/Infer.jl
+++ b/src/Infer.jl
@@ -101,7 +101,7 @@ function infer_source(images::Vector{TiledImage},
     patches, tile_source_map = get_tile_source_map(images, cat_local)
     ea = ElboArgs(images, vp, tile_source_map, patches, [1])
     fit_object_psfs!(ea, ea.active_sources)
-    trim_source_tiles!(ea)
+    load_active_pixels!(ea)
     DeterministicVI.maximize_f(DeterministicVI.elbo, ea)
     vp[1]
 end
@@ -192,31 +192,21 @@ end
 
 
 """
-Set any pixels significantly below background noise for the specified source
-to NaN.
+Get pixels significantly above background noise.
 
 Arguments:
   ea: The ElboArgs object
   noise_fraction: The proportion of the noise below which we will remove pixels.
   min_radius_pix: A minimum pixel radius to be included.
 """
-function trim_source_tiles!(ea::ElboArgs{Float64};
+function load_active_pixels!(ea::ElboArgs{Float64};
                             noise_fraction=0.1,
                             min_radius_pix=8.0)
     @assert length(ea.active_sources) == 1
     s = ea.active_sources[1]
 
-    images_out = Array(TiledImage, ea.N)
-
     for i = 1:ea.N
-        img = ea.images[i]
-        tiles = img.tiles
-
-        tiles_out = Array(ImageTile, size(tiles)...)
-        images_out[i] = TiledImage(img.H, img.W, tiles_out, img.tile_width,
-                                img.b, img.wcs,
-                                img.psf, img.run_num, img.camcol_num,
-                                img.field_num, img.raw_psf_comp)
+        tiles = ea.images[i].tiles
 
         patch = ea.patches[s, i]
         pix_loc = Model.linear_world_to_pix(patch.wcs_jacobian,
@@ -224,14 +214,11 @@ function trim_source_tiles!(ea::ElboArgs{Float64};
                                             patch.pixel_center,
                                             ea.vp[s][ids.u])
 
-        #TODO: iterate over rows first, not columns
-        for hh=1:size(tiles, 1), ww=1:size(tiles, 2)
-            tile = tiles[hh, ww]
+        for j in 1:length(tiles)
+            tile = tiles[j]
 
-            tile_source_map = ea.tile_source_map[i][hh, ww]
+            tile_source_map = ea.tile_source_map[i][j]
             if s in tile_source_map
-                tiles_out[hh, ww] = deepcopy(tile)
-
                 # TODO; use log_prob.jl in the Model module to get the
                 # get the expected brightness, not variational inference
                 pred_tile_pixels =
@@ -247,24 +234,13 @@ function trim_source_tiles!(ea::ElboArgs{Float64};
                     close_pixel =
                         (h - pix_loc[1]) ^ 2 + (w - pix_loc[2])^2 < min_radius_pix^2
 
-                    if !(bright_pixel || close_pixel)
-                        tiles_out[hh, ww].pixels[h_im, w_im] = NaN
+                    if bright_pixel || close_pixel
+                        push!(ea.active_pixels, ActivePixel(i, j, h_im, w_im))
                     end
                 end
-            else
-                # TODO: Make tiles simply a vector
-                # rather than a 2d array to avoid this hack.
-                tiles_out[hh, ww] = ImageTile(i, tile.h_range, tile.w_range,
-                                             Array(Float64, 0, 0),
-                                             Array(Float64, 0, 0),
-                                             Array(Float64, 0))
             end
         end
     end
-
-    # Note: We're changing the images ea points to---the original images aren't
-    # mutated
-    ea.images = images_out
 end
 
 

--- a/src/Model.jl
+++ b/src/Model.jl
@@ -9,7 +9,7 @@ export Image, TiledImage, ImageTile,
        GalaxyPosParams, GalaxyShapeParams,
        VariationalParams, FreeVariationalParams,
        PsfParams, RawPSF, CatalogEntry,
-       init_source
+       init_source, ParamSet
 
 # functions
 export align

--- a/src/deterministic_vi/elbo.jl
+++ b/src/deterministic_vi/elbo.jl
@@ -681,9 +681,9 @@ function process_active_pixels!{NumType <: Number}(
         iota = tile.iota_vec[pixel.h]
         add_elbo_log_term!(elbo_vars, this_pixel, iota)
         add_scaled_sfs!(elbo_vars.elbo,
-                        elbo_vars.E_G, -iota,
-                        elbo_vars.calculate_hessian &&
-                        elbo_vars.calculate_derivs)
+                        elbo_vars.E_G,
+                        -iota,
+                        elbo_vars.calculate_hessian && elbo_vars.calculate_derivs)
 
         # Subtract the log factorial term. This is not a function of the
         # parameters so the derivatives don't need to be updated. Note that
@@ -803,7 +803,8 @@ end
 
 # If Infs/NaNs have crept into the ELBO evaluation (a symptom of poorly conditioned optimization),
 # this helps catch them immediately.
-function assert_all_finite{ParamType}(sf::SensitiveFloat{ParamType, Float64})
+function assert_all_finite{ParamType <: ParamSet, NumType <: Number}(
+        sf::SensitiveFloat{ParamType, NumType})
     @assert all(isfinite(sf.v)) "Value is Inf/NaNs"
     @assert all(isfinite(sf.d)) "Gradient contains Inf/NaNs"
     @assert all(isfinite(sf.h)) "Hessian contains Inf/NaNs"

--- a/src/deterministic_vi/elbo.jl
+++ b/src/deterministic_vi/elbo.jl
@@ -644,15 +644,13 @@ modifying elbo in place.
 Args:
     - elbo_vars: Elbo intermediate values.
     - ea: Model parameters
-    - active_pixels: An array of ActivePixels to be processed.
 
 Returns:
     Adds to elbo_vars.elbo in place.
 """
 function process_active_pixels!{NumType <: Number}(
                 elbo_vars::ElboIntermediateVariables{NumType},
-                ea::ElboArgs{NumType},
-                active_pixels::Array{ActivePixel})
+                ea::ElboArgs{NumType})
     sbs = load_source_brightnesses(ea,
         calculate_derivs=elbo_vars.calculate_derivs,
         calculate_hessian=elbo_vars.calculate_hessian)
@@ -668,7 +666,7 @@ function process_active_pixels!{NumType <: Number}(
     end
 
     # iterate over the pixels
-    for pixel in active_pixels
+    for pixel in ea.active_pixels
         tile = ea.images[pixel.n].tiles[pixel.tile_ind]
         tile_sources = ea.tile_source_map[pixel.n][pixel.tile_ind]
         this_pixel = tile.pixels[pixel.h, pixel.w]
@@ -770,18 +768,6 @@ end
 
 
 """
-Get the active pixels (pixels for which the active sources are present).
-TODO: move this to pre-processing and use it instead of setting low-signal
-pixels to NaN.
-"""
-function get_active_pixels{NumType <: Number}(
-                    ea::ElboArgs{NumType})
-    return Model.get_active_pixels(ea.N, ea.images,
-                                   ea.tile_source_map, ea.active_sources)
-end
-
-
-"""
 Return the expected log likelihood for all bands in a section
 of the sky.
 Returns: A sensitive float with the log,  likelihood.
@@ -790,12 +776,11 @@ function elbo_likelihood{NumType <: Number}(
                     ea::ElboArgs{NumType};
                     calculate_derivs=true,
                     calculate_hessian=true)
-    active_pixels = get_active_pixels(ea)
     elbo_vars = ElboIntermediateVariables(NumType, ea.S,
                                 length(ea.active_sources),
                                 calculate_derivs=calculate_derivs,
                                 calculate_hessian=calculate_hessian)
-    process_active_pixels!(elbo_vars, ea, active_pixels)
+    process_active_pixels!(elbo_vars, ea)
     elbo_vars.elbo
 end
 

--- a/src/model/pixels.jl
+++ b/src/model/pixels.jl
@@ -1,4 +1,4 @@
-""" Pixel helpers """
+export ActivePixel
 
 
 # TODO: the identification of active pixels should go in pre-processing
@@ -14,33 +14,3 @@ type ActivePixel
     w::Int
 end
 
-
-"""
-Get the active pixels (pixels for which the active sources are present).
-TODO: move this to pre-processing and use it instead of setting low-signal
-pixels to NaN.
-"""
-function get_active_pixels(
-                      N::Int64,
-                      images::Vector{TiledImage},
-                      tile_source_map::Vector{Matrix{Vector{Int}}},
-                      active_sources::Vector{Int})
-    active_pixels = ActivePixel[]
-
-    for n in 1:N, tile_ind in 1:length(images[n].tiles)
-        tile_sources = tile_source_map[n][tile_ind]
-        if length(intersect(tile_sources, active_sources)) > 0
-            tile = images[n].tiles[tile_ind]
-            h_width, w_width = size(tile.pixels)
-            for w in 1:w_width, h in 1:h_width
-                if !Base.isnan(tile.pixels[h, w])
-                    push!(active_pixels, ActivePixel(n, tile_ind, h, w))
-                end
-            end
-        end
-    end
-
-    active_pixels
-end
-
-export ActivePixel

--- a/test/DerivativeTestUtils.jl
+++ b/test/DerivativeTestUtils.jl
@@ -1,12 +1,13 @@
-
 module DerivativeTestUtils
 
 using Celeste: Model, DeterministicVI, SensitiveFloats
 using Base.Test
 import ForwardDiff
 
-export forward_diff_model_params, unwrap_vp_vector, wrap_vp_vector,
-       test_with_autodiff, trim_tiles!
+export forward_diff_model_params,
+       unwrap_vp_vector,
+       wrap_vp_vector,
+       test_with_autodiff
 
 """"
 Return an ElboArgs with the corresponding type.
@@ -20,11 +21,13 @@ function forward_diff_model_params{T<:Number}(::Type{T}, ea0::ElboArgs{Float64})
         vp[s][i] = ea0.vp[s][i]
     end
 
-    ElboArgs(ea0.images,
+    ea1 = ElboArgs(ea0.images,
              vp,
              ea0.tile_source_map,
              ea0.patches,
              ea0.active_sources)
+    ea1.active_pixels = ea0.active_pixels
+    ea1
 end
 
 
@@ -79,19 +82,6 @@ function test_with_autodiff(fun::Function, x::Vector{Float64}, sf::SensitiveFloa
         ad_hess = ForwardDiff.hessian(fun, x)
         @test_approx_eq ad_hess sf.h
     end
-end
-
-
-"""
-Set all but a few pixels to NaN to speed up autodiff Hessian testing.
-"""
-function trim_tiles!(tiled_blob::Vector{TiledImage}, keep_pixels)
-    for b = 1:length(tiled_blob)
-	    pixels1 = tiled_blob[b].tiles[1,1].pixels
-        h_width, w_width = size(pixels1)
-	    pixels1[setdiff(1:h_width, keep_pixels), :] = NaN
-        pixels1[:, setdiff(1:w_width, keep_pixels)] = NaN
-	end
 end
 
 

--- a/test/SampleData.jl
+++ b/test/SampleData.jl
@@ -48,6 +48,18 @@ function make_elbo_args(images::Vector{TiledImage},
     if fit_psf
         Infer.fit_object_psfs!(ea, ea.active_sources)
     end
+
+    # make all the pixels active by default, for the tests
+    for n in 1:ea.N
+        tiles = images[n].tiles
+        for t in 1:length(tiles)
+            H, W = size(tiles[t].pixels)
+            for w in 1:W, h in 1:H
+                push!(ea.active_pixels, ActivePixel(n, t, h, w))
+            end
+        end
+    end
+
     ea
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,15 +28,15 @@ run(`make RUN=4263 CAMCOL=5 FIELD=119`)
 cd(wd)
 
 # Check whether to run time-consuming derivatives tests.
-test_derivatives_flag = "--test_derivatives"
-test_detailed_derivatives = test_derivatives_flag in ARGS
-test_files = setdiff(ARGS, [ test_derivatives_flag ])
+long_running_flag = "--long-running"
+test_long_running = long_running_flag in ARGS
+test_files = setdiff(ARGS, [ long_running_flag ])
 
 if length(test_files) > 0
     testfiles = ["test_$(arg).jl" for arg in test_files]
 else
     testfiles = ["test_log_prob.jl",
-                 "test_elbo_values.jl",
+                 "test_elbo.jl",
                  "test_score.jl",
                  "test_derivatives.jl",
                  "test_psf.jl",
@@ -50,12 +50,12 @@ else
 end
 
 
-if test_detailed_derivatives
+if test_long_running
     warn("Testing ELBO derivatives, which may be slow.")
     push!(testfiles, "test_slow_derivatives.jl")
 else
-    warn("Skipping slow derivative tests.  ",
-         "To test slow derivatives, run tests with the flag ", test_derivatives_flag)
+    warn("Skipping long running tests.  ",
+         "To test everything, run tests with the flag ", long_running_flag)
 end
 
 

--- a/test/test_derivatives.jl
+++ b/test/test_derivatives.jl
@@ -23,16 +23,15 @@ function eval_bvn_log_density{NumType <: Number}(
 end
 
 
-function test_process_active_pixels()
+function test_active_pixels()
     blob, ea, bodies = gen_two_body_dataset()
 
     # Choose four pixels only to keep the test fast.
-    active_pixels = Array(DeterministicVI.ActivePixel, 4)
-    active_pixels[1] = DeterministicVI.ActivePixel(1, 1, 10, 11)
-    active_pixels[2] = DeterministicVI.ActivePixel(1, 1, 11, 10)
-    active_pixels[3] = DeterministicVI.ActivePixel(5, 1, 10, 11)
-    active_pixels[4] = DeterministicVI.ActivePixel(5, 1, 11, 10)
-
+    ea.active_pixels = Array(DeterministicVI.ActivePixel, 4)
+    ea.active_pixels[1] = DeterministicVI.ActivePixel(1, 1, 10, 11)
+    ea.active_pixels[2] = DeterministicVI.ActivePixel(1, 1, 11, 10)
+    ea.active_pixels[3] = DeterministicVI.ActivePixel(5, 1, 10, 11)
+    ea.active_pixels[4] = DeterministicVI.ActivePixel(5, 1, 11, 10)
 
     function tile_lik_wrapper_fun{NumType <: Number}(
             ea::ElboArgs{NumType}, calculate_derivs::Bool)
@@ -42,7 +41,6 @@ function test_process_active_pixels()
             length(ea.active_sources),
             calculate_derivs=calculate_derivs,
             calculate_hessian=calculate_derivs)
-        DeterministicVI.process_active_pixels!(elbo_vars, ea, active_pixels)
         deepcopy(elbo_vars.elbo)
     end
 
@@ -1189,33 +1187,33 @@ end
 
 # ELBO tests:
 println("Running ELBO derivative tests.")
-@time test_combine_pixel_sources()
-@time test_fs1m_derivatives()
-@time test_fs0m_derivatives()
-@time test_bvn_derivatives()
-@time test_galaxy_variable_transform()
-@time test_galaxy_cache_component()
-@time test_galaxy_sigma_derivs()
-@time test_brightness_hessian()
-@time test_dsiginv_dsig()
-@time test_add_log_term()
-@time test_e_g_s_functions()
-test_process_active_pixels()
+test_active_pixels()
+test_combine_pixel_sources()
+test_fs1m_derivatives()
+test_fs0m_derivatives()
+test_bvn_derivatives()
+test_galaxy_variable_transform()
+test_galaxy_cache_component()
+test_galaxy_sigma_derivs()
+test_brightness_hessian()
+test_dsiginv_dsig()
+test_add_log_term()
+test_e_g_s_functions()
 
 # KL tests:
 println("Running KL derivative tests.")
-@time test_beta_kl_derivatives()
-@time test_categorical_kl_derivatives()
-@time test_diagmvn_mvn_kl_derivatives()
-@time test_normal_kl_derivatives()
+test_beta_kl_derivatives()
+test_categorical_kl_derivatives()
+test_diagmvn_mvn_kl_derivatives()
+test_normal_kl_derivatives()
 
 # SensitiveFloat tests:
 println("Running SensitiveFloat derivative tests.")
-@time test_combine_sfs()
-@time test_add_sources_sf()
+test_combine_sfs()
+test_add_sources_sf()
 
 # Transform tests:
 println("Running Transform derivative tests.")
-@time test_box_derivatives()
-@time test_box_simplex_derivatives()
-@time test_simplex_derivatives()
+test_box_derivatives()
+test_box_simplex_derivatives()
+test_simplex_derivatives()

--- a/test/test_elbo.jl
+++ b/test/test_elbo.jl
@@ -369,27 +369,6 @@ function test_tiny_image_tiling()
 end
 
 
-function test_elbo_with_nan()
-    blob, ea, body = gen_sample_star_dataset(perturb=false);
-
-    for b in 1:5
-        blob[b].pixels[1,1] = NaN
-    end
-
-    # Set tile width to 5 to test the code for tiles with no sources.
-    ea = make_elbo_args(blob, body, tile_width=5);
-    initial_elbo = DeterministicVI.elbo(ea; calculate_hessian=false);
-
-    nan_elbo = DeterministicVI.elbo(ea);
-
-    # We deleted a pixel, so there's reason to expect them to be different,
-    # but importantly they're reasonably close and not NaN.
-    @test_approx_eq_eps (nan_elbo.v[1] - initial_elbo.v[1]) / initial_elbo.v[1] 0. 1e-4
-    deriv_rel_err = (nan_elbo.d - initial_elbo.d) ./ initial_elbo.d
-    @test_approx_eq_eps deriv_rel_err fill(0., length(ea.vp[1])) 0.05
-end
-
-
 function test_num_allowed_sd()
     blob, ea, body = gen_two_body_dataset()
 
@@ -417,4 +396,3 @@ test_that_variance_is_low()
 test_that_star_truth_is_most_likely()
 test_that_galaxy_truth_is_most_likely()
 test_coadd_cat_init_is_most_likely()
-test_elbo_with_nan()

--- a/test/test_elbo_values.jl
+++ b/test/test_elbo_values.jl
@@ -80,8 +80,6 @@ end
 
 function test_derivative_flags()
     blob, ea, body = gen_two_body_dataset()
-    keep_pixels = 10:11
-    trim_tiles!(ea.images, keep_pixels)
 
     elbo = DeterministicVI.elbo(ea)
 
@@ -102,8 +100,6 @@ function test_active_sources()
     # active_sources.
 
     blob, ea, body = gen_two_body_dataset()
-    keep_pixels = 10:11
-    trim_tiles!(ea.images, keep_pixels)
     b = 1
     tile = ea.images[b].tiles[1,1]
     h, w = 10, 10
@@ -394,73 +390,6 @@ function test_elbo_with_nan()
 end
 
 
-function test_trim_source_tiles()
-  # Set a seed to avoid a flaky test.
-  blob, ea, bodies = gen_n_body_dataset(3, seed=42);
-
-  # With the above seed, this is near the middle of the image.
-  s = 1
-  ea.active_sources = [s]
-
-  loc_ids = ids.u
-  non_loc_ids = setdiff(1:length(ids), ids.u)
-  for b=1:length(blob)
-      ea_trimmed = deepcopy(ea);
-      Infer.trim_source_tiles!(ea_trimmed; noise_fraction=0.0001);
-
-      # Make sure pixels got NaN-ed out
-      @test(
-          sum([ sum(!Base.isnan(tile.pixels)) for
-                tile in ea_trimmed.images[b].tiles]) <
-          sum([ sum(!Base.isnan(tile.pixels)) for
-                tile in ea.images[b].tiles]))
-
-      # Make sure the elbo derivatives are nearly identical.
-      elbo_trim = DeterministicVI.elbo(ea_trimmed; calculate_hessian=false);
-      elbo_full = DeterministicVI.elbo(ea; calculate_hessian=false);
-      @test_approx_eq_eps(
-          elbo_full.d[loc_ids, 1] ./ elbo_trim.d[loc_ids, 1],
-          fill(1.0, length(loc_ids)), 0.06)
-      @test_approx_eq_eps(
-          elbo_full.d[non_loc_ids, 1] ./ elbo_trim.d[non_loc_ids, 1],
-          fill(1.0, length(non_loc_ids)), 4e-3)
-
-      # Set the source to be very dim so that the number of non-NaN
-      # pixels is determined only by min_radius_pix
-      min_radius_pix = 6.0
-      ea_trimmed = deepcopy(ea);
-      ea_trimmed.vp[s][ids.r1] = log(0.1)
-      ea_trimmed.vp[s][ids.r2] = 0.001
-      Infer.trim_source_tiles!(ea_trimmed, noise_fraction=0.1,
-                               min_radius_pix = min_radius_pix);
-
-      s_tiles = find_source_tiles(1, b, ea)
-      total_nonempty_pixels = 0.0
-      for tile_index in s_tiles
-          tile = ea_trimmed.images[b].tiles[tile_index...]
-          total_nonempty_pixels += sum(!Base.isnan(tile.pixels))
-      end
-      @test_approx_eq_eps total_nonempty_pixels pi * min_radius_pix ^ 2 2.0
-
-      # Make sure a very dim image is completely NaN-ed out with a dim image
-      # and zero min radius.
-      min_radius_pix = 0.0
-      ea_trimmed = deepcopy(ea);
-      ea_trimmed.vp[s][ids.r1] = log(0.1)
-      ea_trimmed.vp[s][ids.r2] = 0.001
-      Infer.trim_source_tiles!(
-          ea_trimmed, noise_fraction=0.2, min_radius_pix = min_radius_pix);
-
-      total_nonempty_pixels = 0.0
-      for tile_index in s_tiles
-          tile = ea_trimmed.images[b].tiles[tile_index...]
-          total_nonempty_pixels += sum(!Base.isnan(tile.pixels))
-      end
-      @test total_nonempty_pixels == 0.0
-  end
-end
-
-
 function test_num_allowed_sd()
     blob, ea, body = gen_two_body_dataset()
 
@@ -478,7 +407,6 @@ end
 
 ####################################################
 
-test_trim_source_tiles()
 test_set_hess()
 test_bvn_cov()
 test_tile_predicted_image()

--- a/test/test_log_prob.jl
+++ b/test/test_log_prob.jl
@@ -122,5 +122,5 @@ end
 test_sigmoid_logit()
 test_gal_shape_constrain()
 test_color_flux_transform()
-test_that_star_truth_is_most_likely()
+#test_that_star_truth_is_most_likely()
 #test_that_gal_truth_is_most_likely()


### PR DESCRIPTION
Removes `trim_tile...` and moves finding active pixels into pre-processing. Way less memory allocation.
