### PR TITLE
Use StaticArrays for small matrices and vectors to avoid heap allocations.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_install:
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - julia -e 'Pkg.clone(pwd()); Pkg.build("Celeste")'
+  - julia -e 'Pkg.checkout("StaticArrays")' # temporarily use master of StaticArrays. Delete when https://github.com/JuliaLang/METADATA.jl/pull/6752 has been merged
   - julia -e 'Pkg.test("Celeste"; coverage=(VERSION < v"0.4"))'
 
 after_success:

--- a/REQUIRE
+++ b/REQUIRE
@@ -8,3 +8,4 @@ ForwardDiff 0.2
 JLD
 Optim 0.6
 WCS 0.1.3
+StaticArrays

--- a/src/DeterministicVI.jl
+++ b/src/DeterministicVI.jl
@@ -14,6 +14,7 @@ import ..Log
 using ..Transform
 import DataFrames
 import Optim
+using StaticArrays
 
 export ElboArgs
 

--- a/src/Model.jl
+++ b/src/Model.jl
@@ -1,5 +1,7 @@
 module Model
 
+using StaticArrays
+
 # parameter types
 export Image, TiledImage, ImageTile,
        SkyPatch, PsfComponent,

--- a/src/PSF.jl
+++ b/src/PSF.jl
@@ -16,6 +16,7 @@ import ..SensitiveFloats
 import Optim
 import WCS
 
+using StaticArrays
 
 include("bivariate_normals.jl")
 
@@ -153,16 +154,16 @@ Note that the point in the image at which the PSF is evaluated --
 that is, the center of the image returned by this function -- is
 already implicit in the value of psf_array.
 """
-function get_psf_at_point(psf_array::Array{PsfComponent, 1};
-                          rows=collect(-25:25), cols=collect(-25:25))
+function get_psf_at_point(psf_array::Vector{PsfComponent};
+                          rows = -25:25, cols = -25:25)
     function get_psf_value(psf::PsfComponent, row::Float64, col::Float64)
-         x = Float64[row, col] - psf.xiBar
-         exp_term = exp(-0.5 * x' * psf.tauBarInv * x - 0.5 * psf.tauBarLd)
-         (psf.alphaBar * exp_term / (2 * pi))[1]
+         x = @SVector(Float64[row, col]) - psf.xiBar
+         exp_term = exp(-0.5 * dot(x, psf.tauBarInv * x) - 0.5 * psf.tauBarLd)
+         psf.alphaBar * exp_term / (2 * pi)
     end
 
-    Float64[
-     sum([ get_psf_value(psf, float(row), float(col)) for psf in psf_array ])
+    return Float64[
+     sum(get_psf_value(psf, float(row), float(col)) for psf in psf_array)
          for row in rows, col in cols ]
 end
 
@@ -401,8 +402,8 @@ Returns:
     - Updates pixel_value in place (and all the other placeholder values as well)
 """
 function evaluate_psf_pixel_fit!{NumType <: Number}(
-        x::Vector{Float64}, psf_params::Vector{Vector{NumType}},
-        sigma_vec::Vector{Matrix{NumType}},
+        x::SVector{2,Float64}, psf_params::Vector{Vector{NumType}},
+        sigma_vec::Vector{SMatrix{2,2,NumType,4}},
         sig_sf_vec::Vector{GalaxySigmaDerivs{NumType}},
         bvn_vec::Vector{BvnComponent{NumType}},
         bvn_derivs::BivariateNormalDerivatives{NumType},
@@ -492,20 +493,20 @@ Convert PSF parameters to covariance matrices and derivatives and BvnComponents.
 """
 function get_sigma_from_params{NumType <: Number}(psf_params::Vector{Vector{NumType}})
     K = length(psf_params)
-    sigma_vec = Array(Matrix{NumType}, K)
+    sigma_vec = Array(SMatrix{2,2,NumType,4}, K)
     sig_sf_vec = Array(GalaxySigmaDerivs{NumType}, K)
     bvn_vec = Array(BvnComponent{NumType}, K)
     for k = 1:K
         sigma_vec[k] = get_bvn_cov(psf_params[k][psf_ids.e_axis],
-                                                                        psf_params[k][psf_ids.e_angle],
-                                                                        psf_params[k][psf_ids.e_scale])
+            psf_params[k][psf_ids.e_angle],
+            psf_params[k][psf_ids.e_scale])
         sig_sf_vec[k] = GalaxySigmaDerivs(
             psf_params[k][psf_ids.e_angle],
             psf_params[k][psf_ids.e_axis],
             psf_params[k][psf_ids.e_scale], sigma_vec[k], calculate_tensor=true)
 
         bvn_vec[k] =
-            BvnComponent{NumType}(psf_params[k][psf_ids.mu], sigma_vec[k], 1.0)
+            BvnComponent{NumType}(SVector{2,NumType}(psf_params[k][psf_ids.mu]), sigma_vec[k], 1.0)
     end
     sigma_vec, sig_sf_vec, bvn_vec
 end
@@ -516,7 +517,7 @@ evaluate_psf_fit but with pre-allocated memory for intermediate calculations.
 """
 function evaluate_psf_fit!{NumType <: Number}(
         psf_params::Vector{Vector{NumType}}, raw_psf::Matrix{Float64},
-        x_mat::Matrix{Vector{Float64}},
+        x_mat::Matrix{SVector{2,Float64}},
         bvn_derivs::BivariateNormalDerivatives{NumType},
         log_pdf::SensitiveFloat{PsfParams, NumType},
         pdf::SensitiveFloat{PsfParams, NumType},
@@ -633,8 +634,8 @@ The locations are chosen so that the scale is pixels, but the center of the
 psf is [0, 0].
 """
 function get_x_matrix_from_psf(psf::Matrix{Float64})
-    psf_center = Float64[ (size(psf, i) - 1) / 2 + 1 for i=1:2 ]
-    Vector{Float64}[ Float64[i, j] - psf_center for i=1:size(psf, 1), j=1:size(psf, 2) ]
+    psf_center1, psf_center2 = (size(psf, 1) - 1) / 2 + 1, (size(psf, 2) - 1) / 2 + 1
+    return [ @SVector Float64[i - psf_center1, j - psf_center2] for i = 1:size(psf, 1), j = 1:size(psf, 2) ]
 end
 
 
@@ -663,7 +664,7 @@ function fit_raw_psf_for_celeste(
     for k=1:K
         mu = psf_params_fit[k][psf_ids.mu]
         weight = psf_params_fit[k][psf_ids.weight]
-        celeste_psf[k] = PsfComponent(weight, mu, sigma_vec[k])
+        celeste_psf[k] = PsfComponent(weight, SVector{2,eltype(mu)}(mu), SMatrix{2,2,eltype(mu),4}(sigma_vec[k]))
     end
 
     celeste_psf, psf_params_fit

--- a/src/bivariate_normals.jl
+++ b/src/bivariate_normals.jl
@@ -1,3 +1,5 @@
+using StaticArrays
+
 """
 Unpack a rotation-parameterized BVN covariance matrix.
 
@@ -12,18 +14,18 @@ Returns:
 function get_bvn_cov{NumType <: Number}(
     ab::NumType, angle::NumType, scale::NumType)
 
-   if NumType <: AbstractFloat
-       @assert 0 < scale
-       @assert 0 < ab <= 1.
-   end
+    if NumType <: AbstractFloat
+        @assert 0 < scale
+        @assert 0 < ab <= 1.
+    end
 
-   cp = cos(angle)
-   sp = sin(angle)
-   ab_term = (ab ^ 2 - 1)
-   scale_squared = scale ^ 2
-   off_diag_term = -scale_squared * cp * sp * ab_term
-   NumType[ scale_squared * (1 + ab_term * (sp ^ 2))    off_diag_term;
-            off_diag_term    scale_squared * (1 + ab_term * (cp ^ 2))]
+    cp = cos(angle)
+    sp = sin(angle)
+    ab_term = (ab ^ 2 - 1)
+    scale_squared = scale ^ 2
+    off_diag_term = -scale_squared * cp * sp * ab_term
+    @SMatrix NumType[scale_squared * (1 + ab_term * (sp ^ 2))  off_diag_term;
+                     off_diag_term                             scale_squared * (1 + ab_term * (cp ^ 2))]
 end
 
 
@@ -111,50 +113,49 @@ Attributes:
    major_sd: The standard deviation of the major axis.
 """
 immutable BvnComponent{NumType <: Number}
-    the_mean::Vector{NumType}
-    precision::Matrix{NumType}
+    the_mean::SVector{2,NumType}
+    precision::SMatrix{2,2,NumType,4}
     z::NumType
-    dsiginv_dsig::Matrix{NumType}
+    dsiginv_dsig::SMatrix{3,3,NumType,9}
     major_sd::NumType
 
     function BvnComponent{T1 <: Number, T2 <: Number, T3 <: Number}(
-        the_mean::Vector{T1}, the_cov::Matrix{T2}, weight::T3;
+        the_mean::SVector{2,T1}, the_cov::SMatrix{2,2,T2,4}, weight::T3;
         calculate_siginv_deriv::Bool=true)
 
       ThisNumType = promote_type(T1, T2, T3)
-      the_det = the_cov[1,1] * the_cov[2,2] - the_cov[1,2] * the_cov[2,1]
-      c = 1 ./ (the_det^.5 * 2pi)
-      major_sd = sqrt(maximum([ the_cov[1, 1], the_cov[2, 2] ]))
+      c = 1 / (sqrt(det(the_cov)) * 2pi)
+      major_sd = sqrt(max( the_cov[1, 1], the_cov[2, 2] ))
 
-      precision = Array(NumType, 2, 2)
-      precision[2, 2] = the_cov[1,1] / the_det
-      precision[1, 1] = the_cov[2,2] / the_det
-      precision[1, 2] = -the_cov[1, 2] / the_det
-      precision[2, 1] = -the_cov[2, 1] / the_det
+      precision = inv(the_cov)
 
       if calculate_siginv_deriv
         # Derivatives of Sigma^{-1} with respect to sigma.  These are the second
         # derivatives of log|Sigma| with respect to sigma.
         # dsiginv_dsig[a, b] is the derivative of sig^{-1}[a] / d sig[b]
-        dsiginv_dsig = Array(ThisNumType, 3, 3)
 
-        dsiginv_dsig[1, 1] = -precision[1, 1] ^ 2
-        dsiginv_dsig[1, 2] = -2 * precision[1, 1] * precision[1, 2]
-        dsiginv_dsig[1, 3] = -precision[1, 2] ^ 2
+        dsiginv_dsig11 = -precision[1, 1] ^ 2
+        dsiginv_dsig12 = -2 * precision[1, 1] * precision[1, 2]
+        dsiginv_dsig13 = -precision[1, 2] ^ 2
 
-        dsiginv_dsig[2, 1] = -precision[1, 1] * precision[2, 1]
-        dsiginv_dsig[2, 2] =
+        dsiginv_dsig21 = -precision[1, 1] * precision[2, 1]
+        dsiginv_dsig22 =
           -(precision[1, 1] * precision[2, 2] + precision[1, 2] ^ 2)
-        dsiginv_dsig[2, 3] = -precision[2, 2] * precision[1, 2]
+        dsiginv_dsig23 = -precision[2, 2] * precision[1, 2]
 
-        dsiginv_dsig[3, 1] = -precision[1, 2] ^ 2
-        dsiginv_dsig[3, 2] = - 2 * precision[2, 2] * precision[2, 1]
-        dsiginv_dsig[3, 3] = -precision[2, 2] ^ 2
+        dsiginv_dsig31 = -precision[1, 2] ^ 2
+        dsiginv_dsig32 = - 2 * precision[2, 2] * precision[2, 1]
+        dsiginv_dsig33 = -precision[2, 2] ^ 2
+
+        dsiginv_dsig = @SMatrix ThisNumType[ dsiginv_dsig11 dsiginv_dsig12 dsiginv_dsig13;
+                                             dsiginv_dsig21 dsiginv_dsig22 dsiginv_dsig23;
+                                             dsiginv_dsig13 dsiginv_dsig32 dsiginv_dsig33 ]
+
         new{ThisNumType}(the_mean, precision, c * weight,
                          dsiginv_dsig, major_sd)
       else
         new{ThisNumType}(the_mean, precision, c * weight,
-                         zeros(ThisNumType, 0, 0), major_sd)
+                         zeros(SMatrix{3,3,ThisNumType,9}), major_sd)
       end
     end
 end
@@ -165,7 +166,7 @@ Check whether a point is close enough to a BvnComponent to bother making
 calculations with it.
 """
 function check_point_close_to_bvn{NumType <: Number}(
-    bmc::BvnComponent{NumType}, x::Vector{Float64}, num_allowed_sd::Float64)
+    bmc::BvnComponent{NumType}, x::SVector{2,NumType}, num_allowed_sd::NumType)
 
     dist = sqrt(norm(x - bmc.the_mean))
     return dist < (num_allowed_sd * bmc.major_sd)
@@ -188,7 +189,7 @@ Returns:
 """
 function eval_bvn_pdf!{NumType <: Number}(
     bvn_derivs::BivariateNormalDerivatives{NumType},
-    bmc::BvnComponent{NumType}, x::Vector{Float64})
+    bmc::BvnComponent{NumType}, x::SVector{2,Float64})
 
   bvn_derivs.py1[1] =
     bmc.precision[1,1] * (x[1] - bmc.the_mean[1]) +
@@ -200,7 +201,6 @@ function eval_bvn_pdf!{NumType <: Number}(
     bmc.z * exp(-0.5 * ((x[1] - bmc.the_mean[1]) * bvn_derivs.py1[1] +
                         (x[2] - bmc.the_mean[2]) * bvn_derivs.py2[1]))
 end
-
 
 ##################
 # Derivatives
@@ -325,7 +325,7 @@ Note that nubar is not included.
 """
 function GalaxySigmaDerivs{NumType <: Number}(
     e_angle::NumType, e_axis::NumType, e_scale::NumType,
-    XiXi::Matrix{NumType}; calculate_tensor::Bool=true)
+    XiXi::SMatrix{2,2,NumType,4}; calculate_tensor::Bool=true)
 
   cos_sin = cos(e_angle)sin(e_angle)
   sin_sq = sin(e_angle)^2
@@ -426,7 +426,7 @@ function GalaxyCacheComponent{NumType <: Number}(
     GalaxySigmaDerivs(Array(NumType, 0, 0), Array(NumType, 0, 0, 0))
 
   XiXi = get_bvn_cov(e_axis, e_angle, e_scale)
-  mean_s = NumType[pc.xiBar[1] + u[1], pc.xiBar[2] + u[2]]
+  mean_s = @SVector NumType[pc.xiBar[1] + u[1], pc.xiBar[2] + u[2]]
   var_s = pc.tauBar + gc.nuBar * XiXi
   weight = pc.alphaBar * gc.etaBar  # excludes e_dev
 

--- a/src/deterministic_vi/elbo_objective.jl
+++ b/src/deterministic_vi/elbo_objective.jl
@@ -53,7 +53,7 @@ function accum_star_pos!{NumType <: Number}(
                     elbo_vars::ElboIntermediateVariables{NumType},
                     s::Int,
                     bmc::BvnComponent{NumType},
-                    x::Vector{Float64},
+                    x::SVector{2,Float64},
                     wcs_jacobian::Array{Float64, 2},
                     is_active_source::Bool)
     # call accum star pos in model
@@ -85,7 +85,7 @@ function accum_galaxy_pos!{NumType <: Number}(
                     elbo_vars::ElboIntermediateVariables{NumType},
                     s::Int,
                     gcc::GalaxyCacheComponent{NumType},
-                    x::Vector{Float64},
+                    x::SVector{2,Float64},
                     wcs_jacobian::Array{Float64, 2},
                     is_active_source::Bool)
     # call accum star pos in model

--- a/src/model/fsm_util.jl
+++ b/src/model/fsm_util.jl
@@ -50,7 +50,7 @@ function load_bvn_mixtures{NumType <: Number}(
         # Convolve the star locations with the PSF.
         for k in 1:psf_K
             pc = psf[k]
-            mean_s = [pc.xiBar[1] + m_pos[1], pc.xiBar[2] + m_pos[2]]
+            mean_s = @SVector NumType[pc.xiBar[1] + m_pos[1], pc.xiBar[2] + m_pos[2]]
             star_mcs[k, s] =
               BvnComponent{NumType}(
                 mean_s, pc.tauBar, pc.alphaBar, calculate_siginv_deriv=false)
@@ -94,7 +94,7 @@ function load_bvn_mixtures{NumType <: Number}(
         # Convolve the star locations with the PSF.
         for k in 1:psf_K
             pc = psf[k]
-            mean_s = [pc.xiBar[1] + m_pos[1], pc.xiBar[2] + m_pos[2]]
+            mean_s = @SVector NumType[pc.xiBar[1] + m_pos[1], pc.xiBar[2] + m_pos[2]]
             star_mcs[k, s] =
               BvnComponent{NumType}(
                 mean_s, pc.tauBar, pc.alphaBar, calculate_siginv_deriv=false)
@@ -216,7 +216,7 @@ function populate_fsm_vecs!{NumType <: Number}(
                     gal_mcs::Array{GalaxyCacheComponent{NumType}, 4},
                     star_mcs::Array{BvnComponent{NumType}, 2})
 
-    x = Float64[tile.h_range[h], tile.w_range[w]]
+    x = @SVector Float64[tile.h_range[h], tile.w_range[w]]
     for s in tile_sources
         # ensure tile.b is a filter band, not an image's index
         @assert 1 <= tile.b <= B
@@ -307,7 +307,7 @@ function accum_star_pos!{NumType <: Number}(
                     calculate_hessian::Bool,
                     s::Int,
                     bmc::BvnComponent{NumType},
-                    x::Vector{Float64},
+                    x::SVector{2,Float64},
                     wcs_jacobian::Array{Float64, 2},
                     is_active_source::Bool)
     eval_bvn_pdf!(bvn_derivs, bmc, x)
@@ -363,7 +363,7 @@ function accum_galaxy_pos!{NumType <: Number}(
                     calculate_hessian::Bool,
                     s::Int,
                     gcc::GalaxyCacheComponent{NumType},
-                    x::Vector{Float64},
+                    x::SVector{2,Float64},
                     wcs_jacobian::Array{Float64, 2},
                     is_active_source::Bool)
     eval_bvn_pdf!(bvn_derivs, gcc.bmc, x)

--- a/src/model/param_set.jl
+++ b/src/model/param_set.jl
@@ -121,21 +121,20 @@ getids(::Type{UnconstrainedParams}) = ids_free
 length(::Type{UnconstrainedParams}) =  6 + 2*Ia + 2*(B-1)*Ia + (D-1)*Ia + Ia-1
 
 # Parameters for a representation of the PSF
-type PsfParams <: ParamSet
-    mu::Vector{Int}
+immutable PsfParams <: ParamSet
+    mu::UnitRange{Int}
     e_axis::Int
     e_angle::Int
     e_scale::Int
     weight::Int
 
     function PsfParams()
-      new([1, 2], 3, 4, 5, 6)
+      new(1:2, 3, 4, 5, 6)
     end
 end
 const psf_ids = PsfParams()
 getids(::Type{PsfParams}) = psf_ids
 length(::Type{PsfParams}) = 6
-
 
 # define length(value) in addition to length(Type) for ParamSets
 length{T<:ParamSet}(::T) = length(T)

--- a/src/model/psf_model.jl
+++ b/src/model/psf_model.jl
@@ -16,15 +16,15 @@ Attributes:
 """
 immutable PsfComponent
     alphaBar::Float64  # TODO: use underscore
-    xiBar::Vector{Float64}
-    tauBar::Matrix{Float64}
+    xiBar::SVector{2,Float64}
+    tauBar::SMatrix{2,2,Float64,4}
 
-    tauBarInv::Matrix{Float64}
+    tauBarInv::SMatrix{2,2,Float64,4}
     tauBarLd::Float64
 
-    function PsfComponent(alphaBar::Float64, xiBar::Vector{Float64},
-                          tauBar::Matrix{Float64})
-        new(alphaBar, xiBar, tauBar, tauBar^-1, logdet(tauBar))
+    function PsfComponent(alphaBar::Float64, xiBar::SVector{2,Float64},
+                          tauBar::SMatrix{2,2,Float64,4})
+        new(alphaBar, xiBar, tauBar, inv(tauBar), log(det(tauBar)))
     end
 end
 

--- a/test/SampleData.jl
+++ b/test/SampleData.jl
@@ -6,8 +6,8 @@ import Celeste: Infer
 import Synthetic
 
 using Distributions
+using StaticArrays
 import WCS, FITSIO, DataFrames
-
 
 export empty_model_params, dat_dir,
        sample_ce, perturb_params,
@@ -115,8 +115,8 @@ function load_stamp_blob(stamp_dir, stamp_id)
         tauBar[:,:,3] = [[hdr["PSF_P15"] hdr["PSF_P17"]];
                          [hdr["PSF_P17"] hdr["PSF_P16"]]]
 
-        psf = [PsfComponent(alphaBar[k], xiBar[:, k],
-                            tauBar[:, :, k]) for k in 1:3]
+        psf = [PsfComponent(alphaBar[k], SVector{2,Float64}(xiBar[:, k]),
+                            SMatrix{2,2,Float64,4}(tauBar[:, :, k])) for k in 1:3]
 
         H, W = size(original_pixels)
         iota = hdr["GAIN"] / hdr["CALIB"]

--- a/test/Synthetic.jl
+++ b/test/Synthetic.jl
@@ -17,35 +17,27 @@ function wrapped_poisson(rate::Float64)
 end
 
 
-function get_patch(the_mean::Vector{Float64}, H::Int, W::Int)
-    const radius = 50
+function get_patch(the_mean::SVector{2,Float64}, H::Int, W::Int)
+    radius = 50
     hm = round(Int, the_mean[1])
     wm = round(Int, the_mean[2])
     w11 = max(1, wm - radius):min(W, wm + radius)
     h11 = max(1, hm - radius):min(H, hm + radius)
-    return(w11, h11)
+    return (w11, h11)
 end
 
 
 function write_gaussian(the_mean, the_cov, intensity, pixels;
                         expectation=false)
-    the_precision = the_cov^-1
-    c = det(the_precision)^.5 / 2pi
-    y = Array(Float64, 2)
+    the_precision = inv(the_cov)
+    c = sqrt(det(the_precision)) / 2pi
 
     H, W = size(pixels)
     w_range, h_range = get_patch(the_mean, H, W)
 
-    function matvec222(mat::Matrix, vec::Vector)
-        # x' A x in a slightly more efficient form.
-        (mat[1,1] * vec[1] + mat[1,2] * vec[2]) * vec[1] +
-                (mat[2,1] * vec[1] + mat[2,2] * vec[2]) * vec[2]
-    end
-
     for w in w_range, h in h_range
-        y[1] = the_mean[1] - h
-        y[2] = the_mean[2] - w
-        ypy = matvec222(the_precision, y)
+        y = @SVector [the_mean[1] - h, the_mean[2] - w] # Maybe not hard code Float64
+        ypy = dot(y,  the_precision * y)
         pdf_hw = c * exp(-0.5 * ypy)
         pixel_rate = intensity * pdf_hw
         pixels[h, w] += expectation ? pixel_rate : wrapped_poisson(pixel_rate)

--- a/test/test_derivatives.jl
+++ b/test/test_derivatives.jl
@@ -5,6 +5,7 @@ using Distributions
 import DeterministicVI: BvnComponent, GalaxyCacheComponent
 import DeterministicVI: eval_bvn_pdf!, get_bvn_derivs!, transform_bvn_derivs!
 using DerivativeTestUtils
+using StaticArrays
 
 """
 This is the function of which get_bvn_derivs!() returns the derivatives.
@@ -12,7 +13,7 @@ It is only used for testing.
 """
 function eval_bvn_log_density{NumType <: Number}(
         elbo_vars::DeterministicVI.ElboIntermediateVariables{NumType},
-        bvn::BvnComponent{NumType}, x::Vector{Float64})
+        bvn::BvnComponent{NumType}, x::SVector{2,Float64})
 
     DeterministicVI.eval_bvn_pdf!(elbo_vars.bvn_derivs, bvn, x)
 
@@ -221,7 +222,8 @@ function test_fs1m_derivatives()
     u = ea.vp[s][ids.u]
     u_pix = Model.linear_world_to_pix(
         patch.wcs_jacobian, patch.center, patch.pixel_center, u)
-    x = ceil(u_pix + [1.0, 2.0])
+    # Maybe u_pix should be created as a Vec
+    x = ceil.(SVector{2,Float64}(u_pix) + @SVector Float64[1, 2])
 
     elbo_vars = DeterministicVI.ElboIntermediateVariables(Float64, 1, 1)
 
@@ -298,7 +300,7 @@ function test_fs0m_derivatives()
     u = ea.vp[s][ids.u]
     u_pix = Model.linear_world_to_pix(
         patch.wcs_jacobian, patch.center, patch.pixel_center, u)
-    x = ceil(u_pix + [1.0, 2.0])
+    x = ceil.(SVector{2,Float64}(u_pix) + @SVector Float64[1, 2])
 
     elbo_vars = DeterministicVI.ElboIntermediateVariables(Float64, 1, 1)
 
@@ -350,12 +352,12 @@ end
 function test_bvn_derivatives()
     # Test log(bvn prob) / d(mean, sigma)
 
-    x = Float64[2.0, 3.0]
+    x = @SVector Float64[2, 3]
 
     e_angle, e_axis, e_scale = (1.1, 0.02, 4.8)
     sigma = DeterministicVI.get_bvn_cov(e_axis, e_angle, e_scale)
 
-    offset = Float64[0.5, 0.25]
+    offset = @SVector Float64[0.5, 0.25]
 
     # Note that get_bvn_derivs doesn't use the weight, so set it to something
     # strange to check that it doesn't matter.
@@ -366,16 +368,16 @@ function test_bvn_derivatives()
     DeterministicVI.eval_bvn_pdf!(elbo_vars.bvn_derivs, bvn, x)
     DeterministicVI.get_bvn_derivs!(elbo_vars.bvn_derivs, bvn, true, true)
 
-    function bvn_function{T <: Number}(x::Vector{T}, sigma::Matrix{T})
+    function bvn_function{T <: Number}(x::SVector{2,T}, sigma::SMatrix{2,2,T,4})
         local_x = offset - x
-        -0.5 * ((local_x' * (sigma \ local_x))[1,1] + log(det(sigma)))
+        -0.5 * (dot(local_x, sigma \ local_x) + log(det(sigma)))
     end
 
     x_ids = 1:2
     sig_ids = 3:5
-    function wrap(x::Vector{Float64}, sigma::Matrix{Float64})
+    function wrap(x::SVector{2,Float64}, sigma::SMatrix{2,2,Float64,4})
         par = zeros(Float64, length(x_ids) + length(sig_ids))
-        par[x_ids] = x
+        par[x_ids] = Vector(x)
         par[sig_ids] = [ sigma[1, 1], sigma[1, 2], sigma[2, 2]]
         par
     end
@@ -384,7 +386,7 @@ function test_bvn_derivatives()
         x_loc = par[x_ids]
         s_vec = par[sig_ids]
         sig_loc = T[s_vec[1] s_vec[2]; s_vec[2] s_vec[3]]
-        bvn_function(x_loc, sig_loc)
+        bvn_function(SVector{2,T}(x_loc), SMatrix{2,2,T,4}(sig_loc))
     end
 
     par = wrap(x, sigma)
@@ -427,8 +429,8 @@ function test_galaxy_variable_transform()
     # Test the variable transformation.
     e_angle, e_axis, e_scale = (1.1, 0.02, 4.8)
 
-    u = Float64[5.3, 2.9]
-    x = Float64[7.0, 5.0]
+    u =          Float64[5.3, 2.9]
+    x = @SVector Float64[7.0, 5.0]
 
     # The indices in par of each variable.
     par_ids_u = [1, 2]
@@ -458,12 +460,12 @@ function test_galaxy_variable_transform()
 
         sigma = DeterministicVI.get_bvn_cov(e_axis, e_angle, e_scale)
 
-        function bvn_function{T <: Number}(u_pix::Vector{T}, sigma::Matrix{T})
+        function bvn_function{T <: Number}(u_pix::SVector{2,T}, sigma::SMatrix{2,2,T,4})
             local_x = x - u_pix
-            -0.5 * ((local_x' * (sigma \ local_x))[1,1] + log(det(sigma)))
+            -0.5 * (dot(local_x, sigma \ local_x) + log(det(sigma)))
         end
 
-        bvn_function(u_pix, sigma)
+        bvn_function(SVector{2,T}(u_pix), sigma)
     end
 
     # First just test the bvn function itself
@@ -471,7 +473,7 @@ function test_galaxy_variable_transform()
     u_pix = Model.linear_world_to_pix(
         patch.wcs_jacobian, patch.center, patch.pixel_center, u)
     sigma = DeterministicVI.get_bvn_cov(e_axis, e_angle, e_scale)
-    bmc = BvnComponent{Float64}(u_pix, sigma, 1.0)
+    bmc = BvnComponent{Float64}(SVector{2,Float64}(u_pix), sigma, 1.0)
     sig_sf = DeterministicVI.GalaxySigmaDerivs(e_angle, e_axis, e_scale, sigma)
     gcc = GalaxyCacheComponent(1.0, 1.0, bmc, sig_sf)
     elbo_vars = DeterministicVI.ElboIntermediateVariables(Float64, 1, 1)
@@ -520,8 +522,8 @@ function test_galaxy_cache_component()
     # Test the variable transformation.
     e_angle, e_axis, e_scale = (1.1, 0.02, 4.8)
 
-    u = Float64[5.3, 2.9]
-    x = Float64[7.0, 5.0]
+    u =          Float64[5.3, 2.9]
+    x = @SVector Float64[7.0, 5.0]
 
     # The indices in par of each variable.
     par_ids_u = [1, 2]
@@ -685,7 +687,7 @@ end
 function test_dsiginv_dsig()
     e_angle, e_axis, e_scale = (1.1, 0.02, 4.8) # bvn_derivs.bvn_sigsig_h is large
     the_cov = DeterministicVI.get_bvn_cov(e_axis, e_angle, e_scale)
-    the_mean = Float64[0., 0.]
+    the_mean = @SVector Float64[0., 0.]
     bvn = BvnComponent{Float64}(the_mean, the_cov, 1.0)
     sigma_vec = Float64[ the_cov[1, 1], the_cov[1, 2], the_cov[2, 2] ]
 

--- a/test/test_elbo.jl
+++ b/test/test_elbo.jl
@@ -3,6 +3,7 @@ using Celeste: DeterministicVI, SensitiveFloats
 using Base.Test
 using Distributions
 using DerivativeTestUtils
+using StaticArrays
 
 ######################################
 # Helper functions
@@ -333,7 +334,7 @@ function test_tiny_image_tiling()
   # point with a narrow psf.
 
   blob0 = SampleData.load_stamp_blob(datadir, "164.4311-39.0359_2kpsf");
-  pc = PsfComponent(1./3, zeros(2), 1e-4 * eye(2));
+  pc = PsfComponent(1/3, zeros(SVector{2,Float64}), 1e-4 * eye(SMatrix{2,2,Float64,4}));
   trivial_psf = [pc, pc, pc]
   pixels = ones(100, 1) * 12
   pixels[98:100, 1] = [1e3, 1e4, 1e5]

--- a/test/test_psf.jl
+++ b/test/test_psf.jl
@@ -11,7 +11,7 @@ import Celeste.PSF: get_psf_at_point,
        BivariateNormalDerivatives
 
 using ForwardDiff
-
+using StaticArrays
 
 """
 Evaluate the sum of squared difference between the raw_psf and the psf
@@ -130,7 +130,7 @@ function test_psf_fit()
     pixel_value_wrapper_sf(psf_param_vec, false).v[1]
   end
 
-  x = Float64[1.0, 2.0]
+  x = @SVector [1.0, 2.0]
 
   sigma_vec = Array(Matrix{Float64}, K);
   for k = 1:K
@@ -141,7 +141,7 @@ function test_psf_fit()
 
   println("Testing single pixel value")
   psf_components = PsfComponent[
-    PsfComponent(psf_params[k][psf_ids.weight], psf_params[k][psf_ids.mu], sigma_vec[k])
+    PsfComponent(psf_params[k][psf_ids.weight], SVector{2,Float64}(psf_params[k][psf_ids.mu]), SMatrix{2,2,Float64,4}(sigma_vec[k]))
                   for k = 1:K ];
 
   psf_rendered = get_psf_at_point(psf_components, rows=[ x[1] ], cols=[ x[2] ])[1];
@@ -265,7 +265,6 @@ function test_psf_optimizer()
     end
   end
 end
-
 
 test_transform_psf_sensitive_float()
 test_transform_psf_params()


### PR DESCRIPTION
The time `@time` in `benchmark_infer` are

``` jl
24.936787 seconds (20.48 M allocations: 1.339 GB, 3.82% gc time)
10.575892 seconds (8.19 M allocations: 866.467 MB, 7.65% gc time)
```

on master and

``` jl
23.577065 seconds (19.39 M allocations: 1.255 GB, 4.11% gc time)
10.268357 seconds (6.31 M allocations: 752.464 MB, 7.73% gc time)
```

with this PR.

It might be possible to push this further. E.g. for the derivatives and I'm also wondering if the PSF parameters could be stored in an immutable and thereby become stack allocated. However, those changes would require more restructuring. In this PR I've just made the changes that didn't require any restructuring.
