### PR TITLE
replace raw psf fitting with img.psf for debugging

### DIFF
--- a/src/Infer.jl
+++ b/src/Infer.jl
@@ -166,10 +166,10 @@ function fit_object_psfs!{NumType <: Number}(
 
     for i in 1:length(ea.images)
         # Get a starting point in the middle of the image.
-        pixel_loc = Float64[ ea.images[i].H / 2.0, ea.images[i].W / 2.0 ]
-        raw_central_psf = Model.eval_psf(ea.images[i].raw_psf_comp, pixel_loc[1], pixel_loc[2])
-        central_psf, central_psf_params = PSF.fit_raw_psf_for_celeste(
-            raw_central_psf, psf_optimizer, initial_psf_params)
+        #pixel_loc = Float64[ ea.images[i].H / 2.0, ea.images[i].W / 2.0 ]
+        #raw_central_psf = Model.eval_psf(ea.images[i].raw_psf_comp, pixel_loc[1], pixel_loc[2])
+        #central_psf, central_psf_params = PSF.fit_raw_psf_for_celeste(
+        #    raw_central_psf, psf_optimizer, initial_psf_params)
 
         # Get all relevant sources *in this image*
         relevant_sources = Int[]
@@ -184,9 +184,9 @@ function fit_object_psfs!{NumType <: Number}(
         for s in relevant_sources
             patch = ea.patches[s, i]
             # Set the starting point at the center's PSF.
-            psf, psf_params = PSF.get_source_psf(
-                patch.center, ea.images[i], psf_optimizer, central_psf_params)
-            ea.patches[s, i] = SkyPatch(patch, psf)
+            #psf, psf_params = PSF.get_source_psf(
+            #    patch.center, ea.images[i], psf_optimizer, central_psf_params)
+            ea.patches[s, i] = SkyPatch(patch, img.psf)
         end
     end
 end


### PR DESCRIPTION
@kpamnany -- This patch to the src_div_par branch comments out the code that generates errors, and uses `img.psf` as the psf. It's useful for debugging. After verifying that this version runs well, we can start commenting code in gradually, while leaving `img.psf` as the psf for each neighbor, until we find the source of the segfault.

`img.psf` is fit from the raw psf while the images are being load from disk. Perhaps it doesn't crash then because multiple threads aren't being used yet.
