### PR TITLE
Large galaxy

### DIFF
--- a/bin/benchmark_large_galaxy.jl
+++ b/bin/benchmark_large_galaxy.jl
@@ -1,0 +1,29 @@
+#!/usr/bin/env julia
+
+import Celeste: ParallelRun
+import Celeste.SDSSIO: RunCamcolField
+
+
+const datadir = joinpath(Pkg.dir("Celeste"), "test", "data")
+wd = pwd()
+cd(datadir)
+run(`make`)
+run(`make RUN=3893 CAMCOL=2 FIELD=261`)
+cd(wd)
+
+
+function benchmark_infer()
+    # this box contains a couple of small sources--just use it to compile the code
+    box_compile = ParallelRun.BoundingBox(164.40, 164.41, 39.12, 39.125)
+    field_triplets_compile = [RunCamcolField(3900, 6, 269),]
+    ParallelRun.one_node_infer(field_triplets_compile, datadir; box=box_compile)
+
+    # this box contains just objid 1237662193995284525--a really big galaxy!
+    box = ParallelRun.BoundingBox(202.1093, 202.1094, 40.7294, 40.7296)
+    field_triplets = [RunCamcolField(3893, 2, 261),]
+    @time ParallelRun.one_node_infer(field_triplets, datadir; box=box)
+    @time ParallelRun.one_node_infer(field_triplets, datadir; box=box)
+end
+
+
+benchmark_infer()

--- a/src/model/imaged_sources.jl
+++ b/src/model/imaged_sources.jl
@@ -150,7 +150,8 @@ function choose_patch_radius(ce::CatalogEntry,
                              b::Int64,
                              psf_width::AbstractFloat,
                              epsilon::AbstractFloat;
-                             width_scale=1.0)
+                             width_scale=1.0,
+                             max_radius=25)
     # The galaxy scale is the point with half the light -- if the light
     # were entirely in a univariate normal, this would be at 0.67 standard
     # deviations.  We are being a bit conservative here.
@@ -166,7 +167,8 @@ function choose_patch_radius(ce::CatalogEntry,
     pdf_90 = exp(-0.5 * (1.64)^2) / (sqrt(2pi) * obj_width)
     pdf_target = min(pdf_90, epsilon / (20 * flux))
     rhs = log(pdf_target) + 0.5 * log(2pi) + log(obj_width)
-    sqrt(-2 * (obj_width ^ 2) * rhs)
+    radius = sqrt(-2 * (obj_width ^ 2) * rhs)
+    min(radius, max_radius)
 end
 
 


### PR DESCRIPTION
This PR to the `src_div_par` branch brings the runtime for the largest galaxies down to about 100 seconds.
