### PR TITLE
Logprob refactor

### DIFF
--- a/src/Model.jl
+++ b/src/Model.jl
@@ -9,7 +9,6 @@ export Image, TiledImage, ImageTile,
        PriorParams, UnconstrainedParams,
        CanonicalParams, BrightnessParams, StarPosParams,
        GalaxyPosParams, GalaxyShapeParams,
-       VariationalParams, FreeVariationalParams,
        PsfParams, RawPSF, CatalogEntry,
        init_source, ParamSet
 
@@ -51,14 +50,6 @@ include("model/param_set.jl")
 include("model/imaged_sources.jl")
 include("model/wcs_utils.jl")
 include("model/pixels.jl")
-
-# A vector of variational parameters.  The outer index is
-# of celestial objects, and the inner index is over individual
-# parameters for that object (referenced using ParamIndex).
-
-typealias VariationalParams{NumType <: Number} Vector{Vector{NumType}}
-typealias FreeVariationalParams{NumType <: Number} Vector{Vector{NumType}}
-
 
 import ..SensitiveFloats: SensitiveFloat
 include("bivariate_normals.jl")

--- a/src/Transform.jl
+++ b/src/Transform.jl
@@ -9,7 +9,15 @@ using ..SensitiveFloats
 import ..Log
 
 export DataTransform, ParamBounds, ParamBox, SimplexBox,
-       get_mp_transform, enforce_bounds!
+       get_mp_transform, enforce_bounds!,
+       VariationalParams, FreeVariationalParams
+
+
+# A vector of variational parameters.  The outer index is
+# of celestial objects, and the inner index is over individual
+# parameters for that object (referenced using ParamIndex).
+typealias VariationalParams{NumType <: Number} Vector{Vector{NumType}}
+typealias FreeVariationalParams{NumType <: Number} Vector{Vector{NumType}}
 
 
 ################################

--- a/src/model/fsm_util.jl
+++ b/src/model/fsm_util.jl
@@ -8,7 +8,7 @@ Args:
  - patches (formerly from ElboArgs)
  - vp: (formerly from ElboArgs)
  - active_sources (formerly from ElboArgs)
- - psf: A vector of PSF components
+ - psf_K: Number of psf components (psf from patches object)
  - b: The current band
  - calculate_derivs: Whether to calculate derivatives for active sources.
  - calculate_hessian

--- a/src/model/fsm_util.jl
+++ b/src/model/fsm_util.jl
@@ -27,7 +27,7 @@ Returns:
 function load_bvn_mixtures{NumType <: Number}(
                     S::Int64,
                     patches::Matrix{SkyPatch},
-                    vp::VariationalParams{NumType},
+                    source_params::Vector{Vector{NumType}},
                     active_sources::Vector{Int},
                     psf_K::Int64,
                     b::Int;
@@ -40,9 +40,9 @@ function load_bvn_mixtures{NumType <: Number}(
     # active_sources.
     for s in 1:S
         psf = patches[s, b].psf
-        vs = vp[s]
+        sp  = source_params[s]
 
-        world_loc = vs[[ids.u[1], ids.u[2]]]
+        world_loc = sp[lidx.u]
         m_pos = Model.linear_world_to_pix(patches[s, b].wcs_jacobian,
                                           patches[s, b].center,
                                           patches[s, b].pixel_center, world_loc)
@@ -59,58 +59,15 @@ function load_bvn_mixtures{NumType <: Number}(
         # Convolve the galaxy representations with the PSF.
         for i = 1:2 # i indexes dev vs exp galaxy types.
             e_dev_dir = (i == 1) ? 1. : -1.
-            e_dev_i = (i == 1) ? vs[ids.e_dev] : 1. - vs[ids.e_dev]
+            e_dev_i = (i == 1) ? sp[lidx.e_dev] : 1. - sp[lidx.e_dev]
 
             # Galaxies of type 1 have 8 components, and type 2 have 6 components.
             for j in 1:[8,6][i]
                 for k = 1:psf_K
                     gal_mcs[k, j, i, s] = GalaxyCacheComponent(
                         e_dev_dir, e_dev_i, galaxy_prototypes[i][j], psf[k],
-                        m_pos, vs[ids.e_axis], vs[ids.e_angle], vs[ids.e_scale],
-                        calculate_derivs && (s in active_sources),
-                        calculate_hessian)
-                end
-            end
-        end
-    end
-
-    star_mcs, gal_mcs
-
-
-    star_mcs = Array(BvnComponent{NumType}, psf_K, S)
-    gal_mcs = Array(GalaxyCacheComponent{NumType}, psf_K, 8, 2, S)
-
-    # TODO: do not keep any derviative information if the sources are not in
-    # active_sources.
-    for s in 1:S
-        psf = patches[s, b].psf
-        vs = vp[s]
-
-        world_loc = vs[[ids.u[1], ids.u[2]]]
-        m_pos = Model.linear_world_to_pix(patches[s, b].wcs_jacobian,
-                                          patches[s, b].center,
-                                          patches[s, b].pixel_center, world_loc)
-
-        # Convolve the star locations with the PSF.
-        for k in 1:psf_K
-            pc = psf[k]
-            mean_s = [pc.xiBar[1] + m_pos[1], pc.xiBar[2] + m_pos[2]]
-            star_mcs[k, s] =
-              BvnComponent{NumType}(
-                mean_s, pc.tauBar, pc.alphaBar, calculate_siginv_deriv=false)
-        end
-
-        # Convolve the galaxy representations with the PSF.
-        for i = 1:2 # i indexes dev vs exp galaxy types.
-            e_dev_dir = (i == 1) ? 1. : -1.
-            e_dev_i = (i == 1) ? vs[ids.e_dev] : 1. - vs[ids.e_dev]
-
-            # Galaxies of type 1 have 8 components, and type 2 have 6 components.
-            for j in 1:[8,6][i]
-                for k = 1:psf_K
-                    gal_mcs[k, j, i, s] = GalaxyCacheComponent(
-                        e_dev_dir, e_dev_i, galaxy_prototypes[i][j], psf[k],
-                        m_pos, vs[ids.e_axis], vs[ids.e_angle], vs[ids.e_scale],
+                        m_pos,
+                        sp[lidx.e_axis], sp[lidx.e_angle], sp[lidx.e_scale],
                         calculate_derivs && (s in active_sources),
                         calculate_hessian)
                 end

--- a/src/model/log_prob.jl
+++ b/src/model/log_prob.jl
@@ -3,7 +3,7 @@
 using Distributions
 import ..SensitiveFloats: SensitiveFloat, zero_sensitive_float, clear!
 
-EPS = 1e-6
+const eps_prob_a = 1e-6
 
 ###################################
 # log likelihood function makers  #
@@ -347,10 +347,10 @@ end
 function constrain_gal_shape(unc_gal_shape::Vector{Float64})
     gdev, gaxis, gangle, gscale = unc_gal_shape
     constr_shape    = Array(Float64, 4)
-    constr_shape[1] = clamp(sigmoid(gdev), EPS, 1-EPS)
-    constr_shape[2] = clamp(sigmoid(gaxis), EPS, 1-EPS)
+    constr_shape[1] = clamp(sigmoid(gdev), eps_prob_a, 1-eps_prob_a)
+    constr_shape[2] = clamp(sigmoid(gaxis), eps_prob_a, 1-eps_prob_a)
     constr_shape[3] = gangle       # TODO put this between [0, 2pi]
-    constr_shape[4] = clamp(exp(gscale), EPS, Inf)
+    constr_shape[4] = clamp(exp(gscale), eps_prob_a, Inf)
     return constr_shape
 end
 
@@ -381,10 +381,10 @@ function init_galaxy_state(entry::CatalogEntry)
     brightness, colors = fluxes_to_colors(entry.gal_fluxes)
     #gdev, gaxis, gangle, gscale = gal_shape
     gal_shape = unconstrain_gal_shape([
-                    clamp(entry.gal_frac_dev, EPS, 1.-EPS),
-                    clamp(entry.gal_ab, EPS, 1.-EPS),
+                    clamp(entry.gal_frac_dev, eps_prob_a, 1.-eps_prob_a),
+                    clamp(entry.gal_ab, eps_prob_a, 1.-eps_prob_a),
                     entry.gal_angle,
-                    clamp(entry.gal_scale, EPS, Inf)
+                    clamp(entry.gal_scale, eps_prob_a, Inf)
                     ])
     param_vec = [brightness; colors; entry.pos; gal_shape]
     return param_vec
@@ -408,7 +408,7 @@ function catalog_entry_to_latent_state_params(ce::CatalogEntry)
     ret[lidx.c]         = hcat([star_cols, gal_cols]...)
 
     # set the prob star/prob gal
-    ret[lidx.a] = clamp(ce.is_star, EPS, 1-EPS)
+    ret[lidx.a] = clamp(ce.is_star, eps_prob_a, 1-eps_prob_a)
     ret
 end
 

--- a/src/model/log_prob.jl
+++ b/src/model/log_prob.jl
@@ -203,12 +203,15 @@ function state_log_likelihood(is_star::Bool,                # source is star
         background_rate    = tile.epsilon_mat[pixel.h, pixel.w]
         background_sources = tile_sources[tile_sources.!=1]
         for s in background_sources
-            println("background s: ", s)
-            #TODO: compute background rate conditional on source_params
-            #flux_s = variational_params_to_fluxes(s, vp)
-            #rate_s = is_star ? model_vars.fs0m_vec[s].v : model_vars.fs1m_vec[s].v
-            #rate_s *= flux_s[pixel_band]
-            #background_rate += rate_s
+            # determine if background source is star/gal; get fluxes
+            params_s  = source_params[s]
+            s_is_star = params_s[lidx.a[1,1]] > .5
+            type_idx  = s_is_star ? 1 : 2
+            flux_s    = colors_to_fluxes(params_s[lidx.r[type_idx]],
+                                         params_s[lidx.c[:,type_idx]])
+            rate_s = s_is_star ? model_vars.fs0m_vec[s].v : model_vars.fs1m_vec[s].v
+            rate_s *= flux_s[pixel_band]
+            background_rate += rate_s
         end
 
         # this source's rate, add to background for total

--- a/src/model/log_prob.jl
+++ b/src/model/log_prob.jl
@@ -84,14 +84,13 @@ function make_galaxy_logpdf(images::Vector{TiledImage},
                             active_pixels::Vector{ActivePixel},
                             S::Int64,
                             N::Int64,
-                            source_params::Vector{GalaxyPosParams}, #vp::VariationalParams{Float64},
+                            source_params::Vector{Vector{Float64}},
                             tile_source_map::Vector{Matrix{Vector{Int}}},
                             patches::Matrix{SkyPatch},
                             active_sources::Vector{Int},
                             psf_K::Int64,
                             num_allowed_sd::Float64)
-
-    # define star prior log probability density function
+    # define galaxy prior function
     prior    = construct_prior()
     subprior = prior.galaxy
 
@@ -105,13 +104,11 @@ function make_galaxy_logpdf(images::Vector{TiledImage},
         return ll_b + ll_s
     end
 
-    # define star log joint probability density function
+    # define galaxy log joint probability density function
     function galaxy_logpdf(state::Vector{Float64})
         ll_prior = galaxy_logprior(state)
-
         brightness, colors, position, gal_shape =
             state[1], state[2:5], state[6:7], state[8:end]
-
         ll_like  = state_log_likelihood(false, brightness, colors, position,
                                         constrain_gal_shape(gal_shape), images,
                                         active_pixels,
@@ -403,6 +400,7 @@ function catalog_entry_to_latent_state_params(ce::CatalogEntry)
     ret[lidx.e_dev]   = ce.gal_frac_dev
     ret[lidx.e_axis]  = ce.gal_ab
     ret[lidx.e_scale] = ce.gal_scale
+    ret[lidx.e_angle] = ce.gal_angle
 
     # star, gal r flux
     star_lnr, star_cols = fluxes_to_colors(ce.star_fluxes)

--- a/src/model/log_prob.jl
+++ b/src/model/log_prob.jl
@@ -436,15 +436,27 @@ function variational_params_to_latent_state_params(vp::Array{Float64, 1})
 end
 
 
-#function variational_params_to_fluxes(i::Int, vs::Array{Array{Float64,1}})
-#    ret = Array(Float64, 5)
-#    ret[3] = exp(vs[ids.r1[i]] + 0.5 * vs[ids.r2[i]])
-#    ret[4] = ret[3] * exp(vs[ids.c1[3, i]])
-#    ret[5] = ret[4] * exp(vs[ids.c1[4, i]])
-#    ret[2] = ret[3] / exp(vs[ids.c1[2, i]])
-#    ret[1] = ret[2] / exp(vs[ids.c1[1, i]])
-#    ret
-#end
+function catalog_entry_to_latent_state_params(ce::CatalogEntry)
+    # create a float array of the appropriate length
+    ret = Array(Float64, length(lidx))
+
+    # galaxy shape params
+    ret[lidx.u]       = ce.pos
+    ret[lidx.e_dev]   = ce.gal_frac_dev
+    ret[lidx.e_axis]  = ce.gal_ab
+    ret[lidx.e_scale] = ce.gal_scale
+
+    # star, gal r flux
+    star_lnr, star_cols = fluxes_to_colors(ce.star_fluxes)
+    gal_lnr, gal_cols   = fluxes_to_colors(ce.gal_fluxes)
+    ret[lidx.r]         = [star_lnr, gal_lnr]
+    ret[lidx.c]         = hcat([star_cols, gal_cols]...)
+
+    # set the prob star/prob gal
+    ret[lidx.a] = clamp(ce.is_star, EPS, 1-EPS)
+    ret
+end
+
 
 function variational_params_to_fluxes(vs::Array{Float64,1}, i::Int)
     ret = Array(Float64, 5)

--- a/src/model/param_set.jl
+++ b/src/model/param_set.jl
@@ -93,6 +93,30 @@ getids(::Type{CanonicalParams}) = ids
 length(::Type{CanonicalParams}) = 6 + 3*Ia + 2*(B-1)*Ia + D*Ia
 
 
+type LatentStateIndexes <: ParamSet
+    u::Vector{Int}        # world coordinate ra/dec location
+    e_dev::Int            # gal dev/exp proportion
+    e_axis::Int           # gal minor/major axis ratio
+    e_angle::Int          # gal angle (east of north?)
+    e_scale::Int          # gal scale (in world or pixels?)
+    r::Vector{Int}        # [star_log_r_flux, gal_log_r_flux]
+    c::Matrix{Int}        # c[1] = star colors, c[2] = gal colors
+    a::Matrix{Int}        # a[1,1] = prob star
+    k::Matrix{Int}        # color prior component indicators (not needed, i think)
+
+    LatentStateIndexes() =
+        new([1, 2], 3, 4, 5, 6,
+            collect(7:(7+Ia-1)),  # r
+            reshape((7+Ia):(7+Ia+(B-1)*Ia-1), (B-1, Ia)),  # c
+            reshape((7+Ia+(B-1)*Ia):(7+2Ia+(B-1)*Ia-1), (Ia, 1)),  # a
+            reshape((7+2Ia+(B-1)*Ia):(7+2Ia+(B-1)*Ia+D*Ia-1), (D, Ia))) # k
+end
+
+const lidx = LatentStateIndexes()
+getlidx(::Type{LatentStateIndexes}) = lidx
+length(::Type{LatentStateIndexes}) = 22 #6 + 3*Ia + 2*(B-1)*Ia + D*Ia
+
+
 type UnconstrainedParams <: ParamSet
     u::Vector{Int}
     e_dev::Int

--- a/src/model/pixels.jl
+++ b/src/model/pixels.jl
@@ -14,3 +14,31 @@ type ActivePixel
     w::Int
 end
 
+
+"""
+Get the active pixels (pixels for which the active sources are present).
+TODO: move this to pre-processing and use it instead of setting low-signal
+pixels to NaN.
+"""
+function get_active_pixels(
+                      N::Int64,
+                      images::Vector{TiledImage},
+                      tile_source_map::Vector{Matrix{Vector{Int}}},
+                      active_sources::Vector{Int})
+    active_pixels = ActivePixel[]
+
+    for n in 1:N, tile_ind in 1:length(images[n].tiles)
+        tile_sources = tile_source_map[n][tile_ind]
+        if length(intersect(tile_sources, active_sources)) > 0
+            tile = images[n].tiles[tile_ind]
+            h_width, w_width = size(tile.pixels)
+            for w in 1:w_width, h in 1:h_width
+                if !Base.isnan(tile.pixels[h, w])
+                    push!(active_pixels, ActivePixel(n, tile_ind, h, w))
+                end
+            end
+        end
+    end
+
+    active_pixels
+end

--- a/src/model/pixels.jl
+++ b/src/model/pixels.jl
@@ -13,32 +13,3 @@ type ActivePixel
     h::Int
     w::Int
 end
-
-
-"""
-Get the active pixels (pixels for which the active sources are present).
-TODO: move this to pre-processing and use it instead of setting low-signal
-pixels to NaN.
-"""
-function get_active_pixels(
-                      N::Int64,
-                      images::Vector{TiledImage},
-                      tile_source_map::Vector{Matrix{Vector{Int}}},
-                      active_sources::Vector{Int})
-    active_pixels = ActivePixel[]
-
-    for n in 1:N, tile_ind in 1:length(images[n].tiles)
-        tile_sources = tile_source_map[n][tile_ind]
-        if length(intersect(tile_sources, active_sources)) > 0
-            tile = images[n].tiles[tile_ind]
-            h_width, w_width = size(tile.pixels)
-            for w in 1:w_width, h in 1:h_width
-                if !Base.isnan(tile.pixels[h, w])
-                    push!(active_pixels, ActivePixel(n, tile_ind, h, w))
-                end
-            end
-        end
-    end
-
-    active_pixels
-end

--- a/test/test_log_prob.jl
+++ b/test/test_log_prob.jl
@@ -64,9 +64,73 @@ function test_that_star_truth_is_most_likely_log_prob()
 end
 
 
-function test_that_gal_truth_is_most_likely()
-    # TODO run same tests as above, but with galaxy logpdf
-    error("unimplemented")
+function test_that_gal_truth_is_most_likely_log_prob()
+    # init ground truth star
+    blob, ea, body = gen_sample_galaxy_dataset()
+    blob_tiles     = [Model.TiledImage(b; tile_width=b.W) for b in blob]
+    active_pixels  = ea.active_pixels
+
+    # turn list of catalog entries a list of LatentStateParams
+    source_states = [Model.catalog_entry_to_latent_state_params(body[s])
+                     for s in 1:length(body)]
+    println("  active source params: ", body[1])
+    println("  corresponding ls    : ", source_states[1])
+
+    # create logpdf function handle
+    gal_logpdf, gal_logprior =
+        Model.make_galaxy_logpdf(ea.images, active_pixels, ea.S, ea.N,
+                                 source_states, ea.tile_source_map,
+                                 ea.patches, ea.active_sources,
+                                 ea.psf_K, ea.num_allowed_sd)
+
+    # extract the star-specific parameters from source_states[1] for the
+    # logpdf function
+    gal_state = Model.extract_galaxy_state(source_states[1])
+    println(gal_state)
+    best_ll = gal_logpdf(gal_state)
+    println("Best ll ", best_ll)
+
+    # unpack true gal parameters
+    lnr, col, u, shape = gal_state[1], gal_state[2:5],
+                         gal_state[6:7], gal_state[8:11]
+
+    # perterb lnr
+    for bad_lnr in [lnr*.1, lnr*.5, 1.5*lnr, 2.0*lnr]
+        bad_state = deepcopy(gal_state)
+        bad_state[1] = bad_lnr
+        @test best_ll > gal_logpdf(bad_state)
+    end
+
+    # perturb location
+    ra, dec = u[1], u[2]
+    for bad_ra in [.5*ra, .8*ra, 1.1*ra, 1.5*ra]
+        bad_state = deepcopy(gal_state)
+        bad_state[6] = bad_ra
+        @test best_ll > gal_logpdf(bad_state)
+    end
+
+    # perturb colors
+    for scale in [.5, 2.2]
+      # generate a random direction in param space
+      r = randn(length(gal_state))
+      r = r / sqrt(sum(r.*r))
+
+      bad_state = gal_state + scale * r
+      @test best_ll > gal_logpdf(bad_state)
+    end
+
+    # perturb galaxy shape parameters
+    gdev, gab, gangle, gscale = shape
+    for bad_shape_scale in [.5, .8, 1.2, 1.3]
+        # generate a random direction in param space
+        r = randn(length(shape))
+        r = r / sqrt(sum(r.*r))
+        bad_shape = shape + bad_shape_scale * r
+
+        bad_state = deepcopy(gal_state)
+        bad_state[8:11] = bad_shape
+        @test best_ll > gal_logpdf(bad_state)
+    end
 end
 
 
@@ -117,4 +181,4 @@ test_sigmoid_logit()
 test_gal_shape_constrain()
 test_color_flux_transform()
 test_that_star_truth_is_most_likely_log_prob()
-#test_that_gal_truth_is_most_likely()
+test_that_gal_truth_is_most_likely_log_prob()

--- a/test/test_log_prob.jl
+++ b/test/test_log_prob.jl
@@ -30,10 +30,16 @@ function test_that_star_truth_is_most_likely()
     active_pixels = Model.get_active_pixels(ea.N, ea.images,
                                             ea.tile_source_map, ea.active_sources)
 
+    # turn variational params into a list of LatentStateParams
+    source_states = [Model.variational_params_to_latent_state_params(ea.vp[s])
+                     for s in 1:length(ea.vp)]
+    println("SOURCE STATES:\n", source_states)
+
     star_logpdf, star_logprior =
         Model.make_star_logpdf(ea.images, active_pixels, ea.S, ea.N,
-                               ea.vp, ea.tile_source_map,
-                               ea.patches, ea.active_sources, ea.psf_K, ea.num_allowed_sd)
+                               source_states, ea.tile_source_map,
+                               ea.patches, ea.active_sources,
+                               ea.psf_K, ea.num_allowed_sd)
 
     ## convert ea.vp[1] to star state, and cache elbo args
     star_state = Model.elbo_args_vp_to_star_state(ea.vp[1])


### PR DESCRIPTION
Removes reference to `VariationalParams` and `FreeVariationalParams` from the `Model` module, and places them in the `Transform` module.  

Creates `LatentStateIndexes` in `model/param_set.jl`, which indexes into a flat array that holds the state of star and galaxy parameters.  I add a conversion function for `CatalogEntry` objects to the `LatentStateParams`-ordered arrays.  

This closes #327
