### PR TITLE
added a test for load_active_pixels!

### DIFF
--- a/src/Infer.jl
+++ b/src/Infer.jl
@@ -235,8 +235,8 @@ function load_active_pixels!(ea::ElboArgs{Float64};
 
                     bright_pixel = pred_tile_pixels[h_im, w_im] >
                        tile.iota_vec[h_im] * tile.epsilon_mat[h_im, w_im] * noise_fraction
-                    close_pixel =
-                        (h - pix_loc[1]) ^ 2 + (w - pix_loc[2])^2 < min_radius_pix^2
+                    sq_dist = (h - pix_loc[1])^2 + (w - pix_loc[2])^2 
+                    close_pixel = sq_dist < min_radius_pix^2
 
                     if (bright_pixel || close_pixel) && !isnan(tile.pixels[h_im, w_im])
                         push!(ea.active_pixels, ActivePixel(n, t, h_im, w_im))

--- a/src/Infer.jl
+++ b/src/Infer.jl
@@ -214,11 +214,26 @@ function load_active_pixels!(ea::ElboArgs{Float64};
         for t in 1:length(tiles)
             tile = tiles[t]
 
-            local_active_sources = Int64[]
-            local_centers = Vector{Float64}[]
+            # we're checking up front whether this tile matters,
+            # *before* we allocate memory for local_active_sources
+            # and local_active_centers
+            ignore_tile = true
             for s in ea.active_sources
                 # `intersect(ea.active_sources, tile_source_map)` allocates
                 # huge amounts of memory, so now we don't do that here
+                if s in ea.tile_source_map[n][t]
+                    ignore_tile = false
+                    break
+                end
+            end
+
+            if ignore_tile
+                continue
+            end
+
+            local_active_sources = Int64[]
+            local_centers = Vector{Float64}[]
+            for s in ea.active_sources
                 if s in ea.tile_source_map[n][t]
                     push!(local_active_sources, s)
 
@@ -229,10 +244,6 @@ function load_active_pixels!(ea::ElboArgs{Float64};
                                                         ea.vp[s][ids.u])
                     push!(local_centers, pix_loc)
                 end
-            end
-
-            if isempty(local_active_sources)
-                continue
             end
 
             # TODO; use log_prob.jl in the Model module to get the

--- a/src/Model.jl
+++ b/src/Model.jl
@@ -4,7 +4,7 @@ using StaticArrays
 
 # parameter types
 export Image, TiledImage, ImageTile,
-       SkyPatch, PsfComponent,
+       SkyPatch, PsfComponent, ActivePixel,
        GalaxyComponent, GalaxyPrototype,
        PriorParams, UnconstrainedParams,
        CanonicalParams, BrightnessParams, StarPosParams,

--- a/test/test_infer.jl
+++ b/test/test_infer.jl
@@ -23,5 +23,20 @@ function test_source_division_parallelism()
 end
 
 
+function test_load_active_pixels()
+    images, ea, one_body = gen_sample_star_dataset()
+
+    ea.active_pixels = ActivePixel[]
+    Infer.load_active_pixels!(ea; min_radius_pix=0.0)
+
+   # these images have 20 * 23 * 5 = 2300 pixels in total.
+   # the star is bright but it doesn't cover the whole image.
+   # it's hard to say exactly how many pixels should be active,
+   # but not all of them, and not none of them.
+   @test 100 < length(ea.active_pixels) < 2000
+end
+
+
+test_load_active_pixels()
 test_source_division_parallelism()
 test_infer_single()


### PR DESCRIPTION
I added a basic test for `load_active_pixels!`. The thing about testing this function is that it isn't well defined what the function is supposed to do, beyond what the code that implements it says it does. Sometimes really dim pixels are informative because we expect them to be bright (based on initial parameters); sometimes really bright pixels are informative because we expect them to be dim (based on our initial estimates of the parameters). We might want to think more about how to select active pixels. Maybe something about the log probability changes, given the initial estimates of the parameters, if a particular pixel (or set of pixels) is censored. Perhaps subsampling pixels for large galaxies could be a special case of our procedure for selecting active pixels.

This closes #355.
