### PR TITLE
make GalSim PSF larger to avoid pdf point sampling problems

### DIFF
--- a/benchmark/galsim/GalsimBenchmark.jl
+++ b/benchmark/galsim/GalsimBenchmark.jl
@@ -15,7 +15,7 @@ const FILENAME = "output/galsim_test_images.fits"
 function make_psf()
     alphaBar = [1.; 0.]
     xiBar = [0.; 0.]
-    tauBar = [1. 0.; 0. 1.]
+    tauBar = [16. 0.; 0. 16.]
     [
         Model.PsfComponent(
             alphaBar[k],

--- a/benchmark/galsim/galsim_truth.csv
+++ b/benchmark/galsim/galsim_truth.csv
@@ -5,13 +5,13 @@ world_center_x,world_center_y,star_or_galaxy,angle_degrees,minor_major_axis_rati
 18,18,star,,,,20,0.01,0,dim star
 18,18,star,,,,80,0.01,0,bright star
 17,19,star,,,,40,0.1,1,star with noise
-18,18,galaxy,15,0.2,1,10,0.01,0,angle and axis ratio 1
-18,18,galaxy,160,0.4,1,10,0.01,0,angle and axis ratio 2
-18,18,galaxy,0,1,0.5,10,0.01,0,radius 1
-18,18,galaxy,0,1,1.5,10,0.01,0,radius 2
-18,18,galaxy,0,1,1,5,0.01,0,flux 1
-18,18,galaxy,0,1,1,20,0.01,0,flux 2
-18.3,17.3,galaxy,15,0.4,1.5,15,0.01,0,everything
-18.3,17.3,galaxy,15,0.4,1.5,15,0.01,1,everything with noise
-18.3,17.3,galaxy,15,0.4,1.5,15,0.1,1,everything with noise and low background
-18.3,17.3,galaxy,15,0.4,1.5,15,0.3,1,everything with noise and high background
+18,18,galaxy,15,0.2,6,10,0.01,0,angle and axis ratio 1
+18,18,galaxy,160,0.4,6,10,0.01,0,angle and axis ratio 2
+18,18,galaxy,0,1,3,10,0.01,0,radius 1
+18,18,galaxy,0,1,10,10,0.01,0,radius 2
+18,18,galaxy,0,1,6,5,0.01,0,flux 1
+18,18,galaxy,0,1,6,20,0.01,0,flux 2
+18.3,17.3,galaxy,15,0.4,9,15,0.01,0,everything
+18.3,17.3,galaxy,15,0.4,9,15,0.01,1,everything with noise
+18.3,17.3,galaxy,15,0.4,9,15,0.1,1,everything with noise and low background
+18.3,17.3,galaxy,15,0.4,9,15,0.3,1,everything with noise and high background

--- a/benchmark/galsim/generate_test_image.py
+++ b/benchmark/galsim/generate_test_image.py
@@ -10,7 +10,7 @@ _logger = logging.getLogger(__name__)
 
 ARCSEC_PER_PIXEL = 0.75
 SHIFT_RADIUS_ARCSEC = ARCSEC_PER_PIXEL
-PSF_SIGMA_PIXELS = 1
+PSF_SIGMA_PIXELS = 4
 STAMP_SIZE_PX = 48
 COUNTS_PER_NMGY = 1000.0 # a.k.a. "iota" in Celeste
 
@@ -18,19 +18,19 @@ COUNTS_PER_NMGY = 1000.0 # a.k.a. "iota" in Celeste
 # see GalsimBenchmark.typical_band_relative_intensities()
 # these are taken from the current dominant component of the lognormal prior on c_s for stars
 STAR_RELATIVE_INTENSITIES = [
-    1 / (4.986 * 2.049),
-    1 / 2.049,
+    0.1330,
+    0.5308,
     1,
-    1.350,
-    1.350 * 1.184,
+    1.3179,
+    1.5417,
 ]
 # these are taken from the current dominant component of the lognormal prior on c_s for galaxies
 GALAXY_RELATIVE_INTENSITIES = [
-    1 / (2.117 * 2.152),
-    1 / 2.152,
+    0.4013,
+    0.4990,
     1,
-    1.421,
-    1.421 * 1.299,
+    1.4031,
+    1.7750,
 ]
 
 RANDOM_SEED = 1234


### PR DESCRIPTION
Fixes #369. See comments in that issue for all the details.

Also making the colors used in GalSim match the prior modes rather than prior medians.

I uploaded a new FITS file to the portal.nersc site.