### PR TITLE
Adjust to upcoming changes in Optim

### DIFF
--- a/src/PSF.jl
+++ b/src/PSF.jl
@@ -657,7 +657,7 @@ function fit_raw_psf_for_celeste(
     optim_result = psf_optimizer.fit_psf(raw_psf, initial_psf_params)
     psf_params_fit =
         constrain_psf_params(
-            unwrap_psf_params(optim_result.minimum), psf_optimizer.psf_transform)
+            unwrap_psf_params(Optim.minimizer(optim_result)), psf_optimizer.psf_transform)
 
     sigma_vec = get_sigma_from_params(psf_params_fit)[1]
     celeste_psf = Array(PsfComponent, K)

--- a/src/deterministic_vi/maximize_elbo.jl
+++ b/src/deterministic_vi/maximize_elbo.jl
@@ -142,10 +142,10 @@ function maximize_f(f::Function,
                                tr_method,
                                options)
 
-    transform.array_to_vp!(reshape(nm_result.minimum, size(x0)),
+    transform.array_to_vp!(reshape(Optim.minimizer(nm_result), size(x0)),
                            ea.vp, omitted_ids)
-    max_f = -1.0 * nm_result.f_minimum
-    max_x = nm_result.minimum
+    max_f = -1.0 * Optim.minimum(nm_result)
+    max_x = Optim.minimizer(nm_result)
 
     Log.info(string("elbo is $max_f after $(nm_result.iterations) Newton steps"))
     f_evals, max_f, max_x, nm_result

--- a/test/test_psf.jl
+++ b/test/test_psf.jl
@@ -243,15 +243,15 @@ function test_psf_optimizer()
 
   nm_result = psf_optimizer.fit_psf(raw_psf, psf_params)
   psf_params_fit =
-    constrain_psf_params(unwrap_psf_params(nm_result.minimum), psf_transform)
+    constrain_psf_params(unwrap_psf_params(Optim.minimizer(nm_result)), psf_transform)
 
   # Could this test be tighter?
-  @test 0.0 < nm_result.f_minimum < 1e-3
+  @test 0.0 < Optim.minimum(nm_result) < 1e-3
 
   celeste_psf = fit_raw_psf_for_celeste(raw_psf, K)[1]
   rendered_psf = get_psf_at_point(celeste_psf);
 
-  @test_approx_eq nm_result.f_minimum sum((raw_psf - rendered_psf) .^ 2)
+  @test_approx_eq Optim.minimum(nm_result) sum((raw_psf - rendered_psf) .^ 2)
 
   # Make sure that re-using the optimizer gets the same results.
   raw_psf_10_10 = load_raw_psf(x=10., y=10.);


### PR DESCRIPTION
They finally correct the use of `minimum` which breaks code that explicitly accesses the field. Using accessor functions works on both the released version and the master branch of Optim.

~~Notice, this PR includes commits that are also in #392 so that PR should get merged before this one.~~ Rebased to only include the `Optim` fixes.