### PR TITLE
Reduce the number of allocations

### DIFF
--- a/src/Infer.jl
+++ b/src/Infer.jl
@@ -154,6 +154,39 @@ function get_tile_source_map(images::Vector{TiledImage},
     patches, tile_source_map
 end
 
+"""
+Test if the there are any intersections between two vectors.
+"""
+function isintersection_sorted(x::AbstractVector, y::AbstractVector)
+    nx, ny = length(x), length(y)
+    if nx == 0 || ny == 0
+        return false
+    end
+    @inbounds begin
+        i = j = 1
+        xi, yj = x[1], y[1]
+        while true
+            if xi < yj
+                if i == nx
+                    return false
+                else
+                    i += 1
+                    xi = x[i]
+                end
+            elseif xi > yj
+                if j == ny
+                    return false
+                else
+                    j += 1
+                    yj = y[j]
+                end
+            else
+                return true
+            end
+        end
+    end
+end
+
 
 """
 Updates patches in place with fitted psfs for each active source.
@@ -178,7 +211,7 @@ function fit_object_psfs!{NumType <: Number}(
         for tile_source_map in ea.tile_source_map[i]
             # check if *any* of this tile's sources are a target, and
             # if so, add *all* the tile sources to the output.
-            if length(intersect(target_sources, tile_source_map)) > 0
+            if isintersection_sorted(target_sources, tile_source_map)
                 relevant_sources = union(relevant_sources, tile_source_map)
             end
         end

--- a/src/PSF.jl
+++ b/src/PSF.jl
@@ -503,7 +503,7 @@ function get_sigma_from_params{NumType <: Number}(psf_params::Vector{Vector{NumT
         sig_sf_vec[k] = GalaxySigmaDerivs(
             psf_params[k][psf_ids.e_angle],
             psf_params[k][psf_ids.e_axis],
-            psf_params[k][psf_ids.e_scale], sigma_vec[k], calculate_tensor=true)
+            psf_params[k][psf_ids.e_scale], sigma_vec[k], true)
 
         bvn_vec[k] =
             BvnComponent{NumType}(SVector{2,NumType}(psf_params[k][psf_ids.mu]), sigma_vec[k], 1.0)

--- a/src/PSF.jl
+++ b/src/PSF.jl
@@ -617,7 +617,6 @@ function transform_psf_sensitive_float!{NumType <: Number}(
                     (jacobian_diag[ind1] * jacobian_diag[ind2]) * sf.h[ind1, ind2]
                 if ind1 == ind2
                     sf_free.h[ind1, ind2] +=    hessian_values[ind1] * sf.d[ind1]
-                    diagm(hessian_values .* sf.d[:])
                 end
             end
         end

--- a/src/SensitiveFloats.jl
+++ b/src/SensitiveFloats.jl
@@ -160,7 +160,7 @@ function combine_sfs!{ParamType <: ParamSet,
         sf1::SensitiveFloat{ParamType, T1},
         sf2::SensitiveFloat{ParamType, T1},
         sf_result::SensitiveFloat{ParamType, T1},
-        v::T1, g_d::Vector{T2}, g_h::Matrix{T3};
+        v::T1, g_d::Vector{T2}, g_h::Matrix{T3},
         calculate_hessian::Bool=true)
     # You have to do this in the right order to not overwrite needed terms.
     if calculate_hessian
@@ -191,7 +191,7 @@ function combine_sfs!{ParamType <: ParamSet,
         v::T1, g_d::Vector{T2}, g_h::Matrix{T3};
         calculate_hessian::Bool=true)
 
-    combine_sfs!(sf1, sf2, sf1, v, g_d, g_h, calculate_hessian=calculate_hessian)
+    combine_sfs!(sf1, sf2, sf1, v, g_d, g_h, calculate_hessian)
 end
 
 # Decalare outside to avoid allocating memory.

--- a/src/bivariate_normals.jl
+++ b/src/bivariate_normals.jl
@@ -328,7 +328,7 @@ Note that nubar is not included.
 """
 function GalaxySigmaDerivs{NumType <: Number}(
     e_angle::NumType, e_axis::NumType, e_scale::NumType,
-    XiXi::SMatrix{2,2,NumType,4}; calculate_tensor::Bool=true)
+    XiXi::SMatrix{2,2,NumType,4}, calculate_tensor::Bool=true)
 
   cos_sin = cos(e_angle)sin(e_angle)
   sin_sq = sin(e_angle)^2
@@ -434,7 +434,7 @@ function GalaxyCacheComponent{NumType <: Number}(
 
   if calculate_derivs
     sig_sf = GalaxySigmaDerivs(
-      e_angle, e_axis, e_scale, XiXi, calculate_tensor=calculate_hessian)
+      e_angle, e_axis, e_scale, XiXi, calculate_hessian)
     sig_sf.j .*= gc.nuBar
     if calculate_hessian
       # The tensor is only needed for the Hessian.

--- a/src/bivariate_normals.jl
+++ b/src/bivariate_normals.jl
@@ -120,7 +120,7 @@ immutable BvnComponent{NumType <: Number}
     major_sd::NumType
 
     function BvnComponent{T1 <: Number, T2 <: Number, T3 <: Number}(
-        the_mean::SVector{2,T1}, the_cov::SMatrix{2,2,T2,4}, weight::T3;
+        the_mean::SVector{2,T1}, the_cov::SMatrix{2,2,T2,4}, weight::T3,
         calculate_siginv_deriv::Bool=true)
 
       ThisNumType = promote_type(T1, T2, T3)
@@ -430,8 +430,7 @@ function GalaxyCacheComponent{NumType <: Number}(
 
   # d siginv / dsigma is only necessary for the Hessian.
   bmc = BvnComponent{NumType}(
-    mean_s, var_s, weight,
-    calculate_siginv_deriv=calculate_derivs && calculate_hessian)
+    mean_s, var_s, weight, calculate_derivs && calculate_hessian)
 
   if calculate_derivs
     sig_sf = GalaxySigmaDerivs(

--- a/src/bivariate_normals.jl
+++ b/src/bivariate_normals.jl
@@ -435,10 +435,10 @@ function GalaxyCacheComponent{NumType <: Number}(
   if calculate_derivs
     sig_sf = GalaxySigmaDerivs(
       e_angle, e_axis, e_scale, XiXi, calculate_hessian)
-    sig_sf.j .*= gc.nuBar
+    scale!(sig_sf.j, gc.nuBar)
     if calculate_hessian
       # The tensor is only needed for the Hessian.
-      sig_sf.t .*= gc.nuBar
+      scale!(sig_sf.t, gc.nuBar)
     end
   else
     sig_sf = empty_sig_sf

--- a/src/deterministic_vi/elbo_objective.jl
+++ b/src/deterministic_vi/elbo_objective.jl
@@ -547,7 +547,7 @@ function add_elbo_log_term!{NumType <: Number}(
             combine_sfs!(
                 var_G, E_G, elbo_vars.elbo_log_term,
                 log_term_value, elbo_vars.combine_grad, elbo_vars.combine_hess,
-                calculate_hessian=elbo_vars.calculate_hessian)
+                elbo_vars.calculate_hessian)
 
             # Add to the ELBO.
             for ind in 1:length(elbo.d)

--- a/src/model/fsm_util.jl
+++ b/src/model/fsm_util.jl
@@ -215,7 +215,7 @@ function populate_fsm_vecs!{NumType <: Number}(
                     gal_mcs::Array{GalaxyCacheComponent{NumType}, 4},
                     star_mcs::Array{BvnComponent{NumType}, 2})
 
-    x = @SVector Float64[tile.h_range[h], tile.w_range[w]]
+    x = SVector{2,Float64}(tile.h_range[h], tile.w_range[w])
     for s in tile_sources
         # ensure tile.b is a filter band, not an image's index
         @assert 1 <= tile.b <= B

--- a/src/model/fsm_util.jl
+++ b/src/model/fsm_util.jl
@@ -53,7 +53,7 @@ function load_bvn_mixtures{NumType <: Number}(
             mean_s = @SVector NumType[pc.xiBar[1] + m_pos[1], pc.xiBar[2] + m_pos[2]]
             star_mcs[k, s] =
               BvnComponent{NumType}(
-                mean_s, pc.tauBar, pc.alphaBar, calculate_siginv_deriv=false)
+                mean_s, pc.tauBar, pc.alphaBar, false)
         end
 
         # Convolve the galaxy representations with the PSF.

--- a/test/test_psf.jl
+++ b/test/test_psf.jl
@@ -115,7 +115,7 @@ function test_psf_fit()
     #   sig_sf_vec[k] = GalaxySigmaDerivs(
     #     psf_params[k][psf_ids.e_angle],
     #     psf_params[k][psf_ids.e_axis],
-    #     psf_params[k][psf_ids.e_scale], sigma_vec[k], calculate_tensor=calculate_derivs);
+    #     psf_params[k][psf_ids.e_scale], sigma_vec[k], calculate_derivs);
     #
     # end
 


### PR DESCRIPTION
I've been looking into reducing the number of allocations and thereby hopefully reduce the GC work. My idea was that the output from `--track-allocation` might be a little distorted since it is dominated by large data allocations. I was more interested in finding the small allocations that are repeated many times so I tweaked `--track-allocation` to report `1` whenever a positive allocation happened. I'll post the results below but first the overall results by commit for single threaded runs

#### Current master
10.174977 seconds (4.08 M allocations: 623.774 MB, 7.60% gc time)
10.149520 seconds (4.08 M allocations: 623.774 MB, 7.68% gc time)

#### This PR
9.980523 seconds (2.83 M allocations: 543.700 MB, 6.86% gc time)
10.027899 seconds (2.83 M allocations: 543.700 MB, 7.42% gc time)

So the total number of allocations is reduced quite a bit with these commits. Unfortunately, the effect on the running time is not that big but I still hope that this will help for larger runs. I think most of these changes are harmless but you can judge the changes one-by-one to see if you are okay with them.

There are still some big allocators left in the code. The allocations from master are shown below. Among the most frequently allocating lines, I've only fixed the lines that uses `intersect`. It will require more substantial changes to the code if we want to get rid of the rest. I think the challenge is frequent use of complicated data structures. E.g. an array of composite types. There the gc will have to register all the elements, but when extracting an element there is a new reference to a heap allocated object and the gc will have to register it again. Julia will probably become better in handling such situations over time but we might also want to think about how we structure the data.

```
    10872     positive_constraint = (pb.ub == Inf)
    11200     sig_sf.j .*= gc.nuBar
    11200       sig_sf.t .*= gc.nuBar
    12648   cos_sin = cos(e_angle)sin(e_angle)
    12648   GalaxySigmaDerivs(j, t)
    12648   j = Array(NumType, 3, length(gal_shape_ids))
    12648   t = Array(NumType, 3, length(gal_shape_ids), length(gal_shape_ids))
    16056                 jac, hess = Transform.box_derivatives(
    19992   bmc = BvnComponent{NumType}(
    19992     e_dev_dir::Float64
    20792         var_G.v[1] += elbo_vars.var_G_s.v[1]
    22868       ThisNumType = promote_type(T1, T2, T3)
    24084                     diagm(hessian_values .* sf.d[:])
    37944     j[i, gal_shape_ids.e_angle] =
    37944     j[i, gal_shape_ids.e_axis] =
    37944     j[i, gal_shape_ids.e_scale] = (2XiXi ./ e_scale)[[1, 2, 4][i]]
    37944       t[i, gal_shape_ids.e_angle, gal_shape_ids.e_angle] =
    37944       t[i, gal_shape_ids.e_angle, gal_shape_ids.e_axis] =
    37944       t[i, gal_shape_ids.e_axis, gal_shape_ids.e_axis] =
    37944       t[i, gal_shape_ids.e_scale, gal_shape_ids.e_scale] =
    38623     pixels = img.pixels[h_range, w_range]
    38625     epsilon_mat = img.epsilon_mat[h_range, w_range]
    38625     ImageTile(img.b,
    59976   const empty_sig_sf =
    79048         combine_sfs!(
    79048         elbo_vars.E_G.v[1] += tile.epsilon_mat[h, w]
    81288     if calculate_hessian
   117836     x = @SVector Float64[tile.h_range[h], tile.w_range[w]]
   154500     @assert length(patch_ctrs) == length(patch_radii_px)
   154500         idx = get_local_sources(image_tiles[hh, ww],
   154500             if length(intersect(target_sources, tile_source_map)) > 0
   154500         out[hh, ww] = cands[idx]
   154500     ret = Int[]
   154500     tile_source_map = Int[]
```