### PR TITLE
Disable bounds checking in 

### DIFF
--- a/src/PSF.jl
+++ b/src/PSF.jl
@@ -415,7 +415,7 @@ function evaluate_psf_pixel_fit!{NumType <: Number}(
 
     K = length(psf_params)
     sigma_ids = (psf_ids.e_axis, psf_ids.e_angle, psf_ids.e_scale)
-    for k = 1:K
+    @inbounds for k = 1:K
         # I will put in the weights later so that the log pdf sensitive float
         # is accurate.
         bvn = bvn_vec[k]
@@ -528,7 +528,7 @@ function evaluate_psf_fit!{NumType <: Number}(
     sigma_vec, sig_sf_vec, bvn_vec = get_sigma_from_params(psf_params)
     clear!(squared_error)
 
-    for x_ind in 1:length(x_mat)
+    @inbounds for x_ind in 1:length(x_mat)
         clear!(pixel_value)
         evaluate_psf_pixel_fit!(
                 x_mat[x_ind], psf_params, sigma_vec, sig_sf_vec, bvn_vec,


### PR DESCRIPTION
`calculate_source_pixel_brightness!`, `add_elbo_log_term!`, `evaluate_psf_pixel_fit!`, `evaluate_psf_fit!`, `and get_bvn_derivs!`.

This gives a decent speedup. Single threaded, I get

#### master
10.146384 seconds (4.08 M allocations: 623.774 MB, 7.43% gc time)

#### PR
8.841830 seconds (4.08 M allocations: 623.774 MB, 8.80% gc time)

This can, of course, hide some errors but we can always run Julia with `--check-bounds=yes` if we see segfaults. Generally, LLVM is much better in vectorizing code when bounds checking is off so this might become even more relevant on KNL. I haven't checked if the code in any of these function is getting vectorized though.