### PR TITLE
adds a new speed benchmark, benchmark_rcf.jl

### DIFF
--- a/benchmark/speed/benchmark_infer.jl
+++ b/benchmark/speed/benchmark_infer.jl
@@ -29,10 +29,10 @@ function benchmark_infer()
     box = ParallelRun.BoundingBox(164.39, 164.41, 39.11, 39.13)
     field_triplets = [RunCamcolField(3900, 6, 269),]
 
-    # takes 6.4 seconds as of 11/5/2016 on an Intel Core i5-6600 processor
-    @time ParallelRun.one_node_infer(field_triplets, datadir; box=box)
-
-    if !isempty(ARGS) && ARGS[1] == "--profile"
+    if isempty(ARGS)
+        # takes 6.4 seconds as of 11/5/2016 on an Intel Core i5-6600 processor
+        @time ParallelRun.one_node_infer(field_triplets, datadir; box=box)
+    elseif ARGS[1] == "--profile"
         Profile.clear_malloc_data()
         # about half the run time is psf fitting, the other half is elbo evaluation
         @profile ParallelRun.one_node_infer(field_triplets, datadir; box=box)

--- a/benchmark/speed/benchmark_rcf.jl
+++ b/benchmark/speed/benchmark_rcf.jl
@@ -1,0 +1,80 @@
+#!/usr/bin/env julia
+
+import Celeste: ParallelRun
+import Celeste.SDSSIO: RunCamcolField
+
+
+const rcfs = [
+    RunCamcolField(3900,1,177),
+    RunCamcolField(3900,1,178),
+    RunCamcolField(3900,1,179),
+    RunCamcolField(3900,2,178),
+    RunCamcolField(4469,1,251),
+    RunCamcolField(4469,1,252),
+    RunCamcolField(4469,1,253),
+    RunCamcolField(4469,1,254),
+    RunCamcolField(4392,6,36),
+    RunCamcolField(4392,6,37),
+    RunCamcolField(4392,6,38),
+    RunCamcolField(4516,6,148),
+    RunCamcolField(4516,6,149),
+    RunCamcolField(4516,6,150),
+    RunCamcolField(4518,6,145),
+    RunCamcolField(4518,6,146),
+    RunCamcolField(4518,6,147),
+    RunCamcolField(3900,1,177),
+    RunCamcolField(3900,1,178),
+    RunCamcolField(3900,1,179),
+    RunCamcolField(3900,2,178),
+    RunCamcolField(4469,1,251),
+    RunCamcolField(4469,1,252),
+    RunCamcolField(4469,1,253),
+    RunCamcolField(4469,1,254),
+    RunCamcolField(4392,6,36),
+    RunCamcolField(4392,6,37),
+    RunCamcolField(4392,6,38),
+    RunCamcolField(4516,6,148),
+    RunCamcolField(4516,6,149),
+    RunCamcolField(4516,6,150),
+    RunCamcolField(4518,6,145),
+    RunCamcolField(4518,6,146),
+    RunCamcolField(4518,6,147)]
+
+const datadir = joinpath(Pkg.dir("Celeste"), "test", "data")
+wd = pwd()
+cd(datadir)
+for rcf in rcfs
+    run(`make RUN=$(rcf.run) CAMCOL=$(rcf.camcol) FIELD=$(rcf.field)`)
+end
+cd(wd)
+
+"""
+This benchmark optimizes all the light sources listed as primary detections
+for a particular "target" RCF. (Primary detections are unique--no light
+source is a primary detection in more than one RCF.)
+This RCF has only 30 light sources in it, whereas 400 light sources
+is more standard. So this benchmark overstates the cost of loading images
+as a proportion of total runtime. On the other hand, in production, 
+loading sources is single threaded, whereas optimizing sources is
+multithreaded.
+"""
+function benchmark_infer_rcf()
+    # This is the "target" run/camcol/field (RCF).
+    rcf = RunCamcolField(4518,6,146)
+
+    # Warm up---this compiles the code
+    ParallelRun.infer_rcf(rcf, datadir, datadir; objid="1237664880489791577")
+
+    # resets runtime profiler *and* count for --track-allocation
+    Profile.clear_malloc_data()
+
+    if isempty(ARGS)
+        @time ParallelRun.infer_rcf(rcf, datadir, datadir)
+    elseif ARGS[1] == "--profile"
+        @profile ParallelRun.infer_rcf(rcf, datadir, datadir)
+        Profile.print(format=:flat, sortedby=:count)
+    end
+end
+
+
+benchmark_infer_rcf()

--- a/benchmark/stripe82/validate_on_stripe82.jl
+++ b/benchmark/stripe82/validate_on_stripe82.jl
@@ -1,7 +1,5 @@
 #!/usr/bin/env julia
 
-using DocOpt
-
 import Celeste.ParallelRun: BoundingBox, infer_field
 import Celeste.Stripe82Score: score_field_disk, score_object_disk
 import Celeste.SDSSIO: RunCamcolField


### PR DESCRIPTION
This new script, `benchmark_rcf.jl`, matches how I'm running Celeste lately on the supercomputer. The script `benchmark_infer.jl` is still good too, and it's a lot faster than `benchmark_rcf.jl`, while still testing the same main processing loop. Only `benchmark_rcf.jl` tests inference with multiple run-camcol-fields.