### PR TITLE
Enable Mac OS X support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,12 @@
 language: julia
 os:
   - linux
+  - osx
 julia:
   - 0.5
   - nightly
 notifications:
   email: false
-
-before_install:
-  - sudo apt-get update -qq -y
-  - sudo apt-get install libwcs4 -y
-  - sudo apt-get install libcfitsio3 -y
-  - sudo apt-get install mpich2 libmpich2-3 libmpich2-dev -y
-  - sudo apt-get install openmpi-bin openmpi-common libopenmpi-dev mpi-default-dev -qq -y
 
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,7 +1,6 @@
 julia 0.5-
 DataFrames
 Distributions
-Dtree
 FITSIO 0.8.4
 ForwardDiff 0.2
 JLD


### PR DESCRIPTION
Most astronomers seem to use macs. Supporting mac is a step towards getting that community involved. (Also, David S installed Julia and wanted to run Celeste. Also, the department gave me a mac.) This PR adds "osx" to travis, ends our use of apt-get to meet dependencies, and no longer requires Dtree. (Dtree wasn't needed for the unit tests of single node operation.)