### PR TITLE
Estimate box runtime

### DIFF
--- a/bin/estimate-box-runtime.jl
+++ b/bin/estimate-box-runtime.jl
@@ -1,0 +1,21 @@
+#!/usr/bin/env julia
+
+import Celeste.ParallelRun: BoundingBox, estimate_box_runtime
+
+
+const usage_info =
+"""
+Usage:
+  estimate-box-runtime.jl <ramin> <ramax> <decmin> <decmax>
+"""
+
+const stagedir = ENV["CELESTE_STAGE_DIR"]
+
+if length(ARGS) != 4
+    println(usage_info)
+else
+    box = BoundingBox(ARGS...)
+    num_active = estimate_box_runtime(box, stagedir)
+    println("The specified region contains $num_active active pixels.")
+end
+

--- a/bin/estimate-box-runtime.jl
+++ b/bin/estimate-box-runtime.jl
@@ -16,6 +16,7 @@ if length(ARGS) != 4
 else
     box = BoundingBox(ARGS...)
     num_active = estimate_box_runtime(box, stagedir)
-    println("The specified region contains $num_active active pixels.")
+    box_str = "[$(box.ramin), $(box.ramax)] x [$(box.decmin), $(box.decmax)]"
+    println("The region $box_str contains $num_active active pixels.")
 end
 

--- a/bin/infer-box.jl
+++ b/bin/infer-box.jl
@@ -6,7 +6,7 @@ import Celeste.ParallelRun: BoundingBox, infer_box
 const usage_info =
 """
 Usage:
-  infer-box <ramin> <ramax> <decmin> <decmax>
+  infer-box.jl <ramin> <ramax> <decmin> <decmax>
 """
 
 const stagedir = ENV["CELESTE_STAGE_DIR"]

--- a/bin/infer-rcf.jl
+++ b/bin/infer-rcf.jl
@@ -7,7 +7,7 @@ import Celeste.SDSSIO: RunCamcolField
 const usage_info =
 """
 Usage:
-  infer-rcf <run> <camcol> <field>
+  infer-rcf.jl <run> <camcol> <field>
 """
 
 const stagedir = ENV["CELESTE_STAGE_DIR"]

--- a/src/Celeste.jl
+++ b/src/Celeste.jl
@@ -8,6 +8,7 @@ include("Log.jl")
 include("SensitiveFloats.jl")
 
 include("Model.jl")
+include("Infer.jl")
 include("Transform.jl")
 include("PSF.jl")
 include("SDSSIO.jl")
@@ -16,7 +17,6 @@ include("DeterministicVI.jl")
 include("StochasticVI.jl")
 include("MCMC.jl")
 
-include("Infer.jl")
 include("ParallelRun.jl")
 
 include("Stripe82Score.jl")

--- a/src/DeterministicVI.jl
+++ b/src/DeterministicVI.jl
@@ -5,9 +5,10 @@ module DeterministicVI
 
 using ..Model
 import ..Model: BivariateNormalDerivatives, BvnComponent, GalaxyCacheComponent,
-                GalaxySigmaDerivs,
+                GalaxySigmaDerivs, SkyPatch,
                 get_bvn_cov, eval_bvn_pdf!, get_bvn_derivs!,
                 transform_bvn_derivs!
+import ..Infer
 using ..SensitiveFloats
 import ..SensitiveFloats.clear!
 import ..Log
@@ -25,6 +26,36 @@ include("deterministic_vi/source_brightness.jl")
 include("deterministic_vi/elbo_objective_pixelated_psf.jl")
 include("deterministic_vi/elbo_objective.jl")
 include("deterministic_vi/maximize_elbo.jl")
+
+
+"""
+Infers one light source. This routine is intended to be called in parallel,
+once per target light source.
+
+Arguments:
+    images: a collection of astronomical images
+    neighbors: the other light sources near `entry`
+    entry: the source to infer
+"""
+function infer_source(images::Vector{Image},
+                      neighbors::Vector{CatalogEntry},
+                      entry::CatalogEntry)
+    if length(neighbors) > 100
+        Log.warn("Excessive number ($(length(neighbors))) of neighbors")
+    end
+
+    # It's a bit inefficient to call the next 5 lines every time we optimize_f.
+    # But, as long as runtime is dominated by the call to maximize_f, that
+    # isn't a big deal.
+    cat_local = vcat(entry, neighbors)
+    vp = Vector{Float64}[init_source(ce) for ce in cat_local]
+    patches = Infer.get_sky_patches(images, cat_local)
+    ea = ElboArgs(images, vp, patches, [1], [1])
+    Infer.load_active_pixels!(images, patches)
+
+    f_evals, max_f, max_x, nm_result = maximize_f(elbo, ea)
+    vp[1], max_f
+end
 
 
 end

--- a/src/Infer.jl
+++ b/src/Infer.jl
@@ -1,14 +1,19 @@
+"""
+Routines for single-node inference that aren't specific
+to any particular method of inference (e.g MCMC, DeterministicVI),
+yet are also not about the statistical model (i.e., the Model
+module).
+Currently what's in here are routines that effectively
+truncate the Gaussians in the model.
+TODO: rename this module to something more meaningful
+"""
 module Infer
 
 import WCS
 using StaticArrays
 
 using ..Model
-import ..PSF
 import ..Log
-
-using ..DeterministicVI
-import ..DeterministicVI: elbo, maximize_f
 
 
 """
@@ -72,40 +77,6 @@ end
 
 
 """
-Infers one light source. This routine is intended to be called in parallel,
-once per target light source.
-
-Currently `infer_source()` only does (deterministic) variational inference.
-In the future, `infer_source()` might take a call back function as an
-argument, to let it's user run either deterministic VI, stochastic VI,
-or MCMC.
-
-Arguments:
-    images: a collection of astronomical images
-    neighbors: the other light sources near `entry`
-    entry: the source to infer
-"""
-function infer_source(images::Vector{Image},
-                      neighbors::Vector{CatalogEntry},
-                      entry::CatalogEntry)
-    if length(neighbors) > 100
-        Log.warn("Excessive number ($(length(neighbors))) of neighbors")
-    end
-
-    # It's a bit inefficient to call the next 5 lines every time we optimize_f.
-    # But, as long as runtime is dominated by the call to maximize_f, that 
-    # isn't a big deal.
-    cat_local = vcat(entry, neighbors)
-    vp = Vector{Float64}[init_source(ce) for ce in cat_local]
-    patches = get_sky_patches(images, cat_local)
-    ea = ElboArgs(images, vp, patches, [1], [1])
-    load_active_pixels!(ea)
-
-    f_evals, max_f, max_x, nm_result = maximize_f(elbo, ea)
-    vp[1], max_f
-end
-
-"""
   noise_fraction: The proportion of the noise below which we will remove pixels.
   min_radius_pix: A minimum pixel radius to be included.
 """
@@ -159,19 +130,22 @@ end
 
 
 """
-Get pixels significantly above background noise.
+Record which pixels in each patch will be considered when computing the
+objective function.
 
-Arguments:
-  ea: The ElboArgs object
+Non-standard arguments:
   noise_fraction: The proportion of the noise below which we will remove pixels.
   min_radius_pix: A minimum pixel radius to be included.
 """
-function load_active_pixels!(ea::ElboArgs{Float64};
-                            noise_fraction=0.5,
-                            min_radius_pix=8.0)
-    for n = 1:ea.N, s=1:ea.S
-        img = ea.images[n]
-        p = ea.patches[s,n]
+function load_active_pixels!(images::Vector{Image},
+                             patches::Matrix{SkyPatch};
+                             noise_fraction=0.5,
+                             min_radius_pix=8.0)
+    S, N = size(patches)
+
+    for n = 1:N, s=1:S
+        img = images[n]
+        p = patches[s,n]
 
         # (h2, w2) index the local patch, while (h, w) index the image
         H2, W2 = size(p.active_pixel_bitmap)

--- a/src/ParallelRun.jl
+++ b/src/ParallelRun.jl
@@ -21,8 +21,8 @@ const SKY_DIVISION_PARALLELISM=true
 const MIN_FLUX = 2.0
 
 # In production mode, rather the development mode, always catch exceptions
-const is_prod = haskey(ENV, "CELESTE_PROD") && ENV["CELESTE_PROD"] != ""
-
+const is_production_run = haskey(ENV, "CELESTE_PROD") &&
+                          ENV["CELESTE_PROD"] != ""
 
 # Use distributed parallelism (with Dtree)
 if haskey(ENV, "USE_DTREE") && ENV["USE_DTREE"] != ""
@@ -466,8 +466,9 @@ function one_node_single_infer(catalog::Vector{CatalogEntry},
                     Log.info("objid $(entry.objid) took $rt1 seconds")
                     Log.info("========================")
                 catch ex
-                    Log.error(string(ex))
-                    if !is_prod
+                    if is_production_run || nthreads() > 1
+                        Log.error(string(ex))
+                    else
                         rethrow(ex)
                     end
                 end
@@ -595,7 +596,7 @@ function infer_rcf(rcf::RunCamcolField,
 
     rcf_bounds = this_fe[1][2]
     overlapping_rcfs = get_overlapping_fields(rcf_bounds, stagedir)
-    @assert rcf in overlapping_rcfs
+    @assert(rcf in overlapping_rcfs, "$rcf doesn't overlap with itself?")
 
     tic()
     println(rcf_bounds)

--- a/src/ParallelRun.jl
+++ b/src/ParallelRun.jl
@@ -279,28 +279,6 @@ function divide_sky_and_infer(
 end
 
 
-function load_images(rcfs, stagedir)
-    images = Image[]
-    image_names = String[]
-    image_count = 0
-
-    for i in 1:length(rcfs)
-        Log.info("reading field $(rcfs[i])")
-        rcf = rcfs[i]
-        field_images = SDSSIO.load_field_images(rcf, stagedir)
-        for b=1:length(field_images)
-            image_count += 1
-            push!(image_names,
-                "$image_count run=$(rcf.run) camcol=$(rcf.camcol) field=$(rcf.field) b=$b")
-            push!(images, field_images[b])
-        end
-    end
-    gc()
-
-    images
-end
-
-
 function infer_init(rcfs::Vector{RunCamcolField},
                     stagedir::String;
                     objid="",
@@ -348,7 +326,7 @@ function infer_init(rcfs::Vector{RunCamcolField},
         neighbor_map = Vector{Int}[]
     else
         # Read in images for all (run, camcol, field).
-        images = load_images(rcfs, stagedir)
+        images = SDSSIO.load_field_images(rcfs, stagedir)
 
         tic()
         neighbor_map = Infer.find_neighbors(target_sources, catalog, images)

--- a/src/ParallelRun.jl
+++ b/src/ParallelRun.jl
@@ -580,6 +580,7 @@ function infer_rcf(rcf::RunCamcolField,
     @assert rcf in overlapping_rcfs
 
     tic()
+    println(rcf_bounds)
     results = one_node_infer(overlapping_rcfs,
                              stagedir;
                              objid=objid,  # just for making unit tests run fast
@@ -661,8 +662,10 @@ end
 Estimates the amount of computation required to call `infer_box` on a
 particular region of the sky.
 """
-function estimate_box_runtime(box::BoundingBox, stagedir::String, outdir::String)
+function estimate_box_runtime(box::BoundingBox, stagedir::String)
     rcfs = get_overlapping_fields(box, stagedir)
+
+    42
 end
 
 end

--- a/src/cyclades.jl
+++ b/src/cyclades.jl
@@ -262,7 +262,7 @@ function one_node_joint_infer(catalog, target_sources, neighbor_map, images;
                         init_source(catalog[x]) for x in ids_local]
             patches = Infer.get_sky_patches(images, cat_local)
             ea = ElboArgs(images, vp, patches, [1], [1])
-            Infer.load_active_pixels!(ea)
+            Infer.load_active_pixels!(ea.images, ea.patches)
             model[cur_source_index] = ea
         end
     end

--- a/src/source_division_inference.jl
+++ b/src/source_division_inference.jl
@@ -200,7 +200,7 @@ function optimize_sources(images, catalog, tasks,
             neighbor_indexes = Infer.find_neighbors([i,], local_catalog, flat_images)[1]
             neighbors = local_catalog[neighbor_indexes]
 
-            vs_opt, obj_value = Infer.infer_source(flat_images, neighbors, entry)
+            vs_opt, obj_value = infer_source(flat_images, neighbors, entry)
             # TODO: write vs_opt (the results) to disk, to a global array of size num_tasks,
             # or to a local array, and then flush the array to disk later.
 

--- a/staging/list_quarters.jl
+++ b/staging/list_quarters.jl
@@ -1,0 +1,13 @@
+#!/usr/bin/env julia
+
+# Lists all of the quarters of square degrees around the area
+# imaged by SDSS. Output in this format can be piped to either infer-box.jl
+# or estimate-box-runtime.jl, e.g.
+# 
+#   ./list_quarters.jl | sort -R | xargs -n 4 estimate-box-runtime.jl
+
+for ra in 0:.5:380, dec in -30:.5:90
+    println("$(ra - 0.5) $ra $(dec - 0.5) $dec")
+end
+
+

--- a/test/test_derivatives.jl
+++ b/test/test_derivatives.jl
@@ -1293,7 +1293,7 @@ function test_real_image()
     patches = Infer.get_sky_patches(images, cat_local)
     ea = ElboArgs(images, vp, patches, [1], [1])
 
-    Infer.load_active_pixels!(ea)
+    Infer.load_active_pixels!(ea.images, ea.patches)
     @test sum(ea.patches[1,1].active_pixel_bitmap) > 0
 
     elbo = DeterministicVI.elbo(ea)

--- a/test/test_infer.jl
+++ b/test/test_infer.jl
@@ -60,7 +60,7 @@ function test_load_active_pixels()
     # the star is bright but it doesn't cover the whole image.
     # it's hard to say exactly how many pixels should be active,
     # but not all of them, and not none of them.
-    Infer.load_active_pixels!(ea; min_radius_pix=0.0)
+    Infer.load_active_pixels!(ea.images, ea.patches; min_radius_pix=0.0)
 
     # most star light (>90%) should be recorded by the active pixels
     num_active_photons = 0.0
@@ -97,7 +97,7 @@ function test_load_active_pixels()
 
     # only 2 pixels per image are within 0.6 pixels of the
     # source's center (10.9, 11.5)
-    Infer.load_active_pixels!(ea; min_radius_pix=0.6)
+    Infer.load_active_pixels!(ea.images, ea.patches; min_radius_pix=0.6)
 
     for n in 1:ea.N
 #  FIXME: is load active pixels off by (0.5, 0.5)?

--- a/test/test_infer.jl
+++ b/test/test_infer.jl
@@ -119,9 +119,11 @@ function test_estimate_box_runtime()
 
     num_active = ParallelRun.estimate_box_runtime(box, datadir)   
 
-    # This box contains about 13 sources, and each source should have at
-    # least 50 active pixels, and at most about 2000 active pixels
-    @test 13 * 50 < num_active < 13 * 2000
+    # This box contains about 1000 sources to optimize, and each source
+    # should have at least 50 active pixels per image it appears in, and at most about
+    # 2000 active pixels per image it appears in. Most sources only appear
+    # in 1 or 2 frames. Each frame has 5 bands.
+    @test 1000 * 50 * 1 * 5 < num_active < 1000 * 2000 * 3 * 5
 end
 
 

--- a/test/test_infer.jl
+++ b/test/test_infer.jl
@@ -15,7 +15,7 @@ function test_infer_single()
 end
 
 
-function test_infer_rcf()
+function load_surrounding_rcfs()
     wd = pwd()
     cd(datadir)
  
@@ -30,6 +30,11 @@ function test_infer_rcf()
     run(`make RUN=4469 CAMCOL=6 FIELD=344`)
 
     cd(wd)
+end
+
+
+function test_infer_rcf()
+    load_surrounding_rcfs()
 
     resfile = joinpath(datadir, "celeste-003900-6-0269.jld")
     rm(resfile, force=true)
@@ -106,10 +111,26 @@ function test_load_active_pixels()
 end
 
 
+function test_estimate_box_runtime()
+    load_surrounding_rcfs()
+
+    # This box is contained in (3900, 6, 269)
+    box = ParallelRun.BoundingBox(164.29, 164.55, 39.00, 39.25)
+
+    num_active = ParallelRun.estimate_box_runtime(box, datadir)   
+
+    # This box contains about 13 sources, and each source should have at
+    # least 50 active pixels, and at most about 2000 active pixels
+    @test 13 * 50 < num_active < 13 * 2000
+end
+
+
+if test_long_running
+    test_estimate_box_runtime()
+    test_infer_rcf()
+end
+
 test_load_active_pixels()
 test_source_division_parallelism()
 test_infer_single()
 
-if test_long_running
-    test_infer_rcf()
-end


### PR DESCRIPTION
This PR implements a new script, `bin/estimate-box-runtime.jl`, that counts the number of active pixels in the specified bounding box. It closes #421. Pixels that are active for 2 sources are double counted, by design. Pixels that are active for a source that won't be optimized are excluded from the tally.

Here are some examples.

This is from a region where the stripes are pretty spread out, near the middle of the arcs. (See the [SDSS coverage map](http://classic.sdss.org/dr7/coverage/).)
```
$ ./estimate-box-runtime.jl 200 200.5 40 40.5
The specified region contains 3,253,336 active pixels.
```

Less spread out, but still near the center.
```
$ ./estimate-box-runtime.jl 150 150.5 40 40.5
The specified region contains 7,119,292 active pixels.
```

Near one of the "poles".
```
$ ./estimate-box-runtime.jl 240 240.5 30 30.5
The specified region contains 14,198,395 active pixels.
```

From stripe 82:
```
$ ./estimate-box-runtime.jl 0 0.5 0 0.5
The specified region contains 53,177,432 active pixels.
```

------
Some changes to the code base included with the script:
- To estimate box runtime without creating an `ElboArgs` instance, or doing anything specific to one particular time of approximate inference, this PR changes `load_active_pixels!` to take `images` and `patches` as its arguments.
- The PR moves `infer_source` from `Infer` to `DeterministicVI` so that everything in `Infer` can be used by `MCMC` just as it is used by `DeterministicVI`. `Infer` is now loaded in `Celeste.jl` immediately after `Model`, because any inference routine is loaded.
- The PR splits `one_node_infer` into several smaller functions, but preserves the original inference to `one_node_infer`.