### PR TITLE
fixes off-by-one error; removes sources_to_visit

### DIFF
--- a/src/CelesteEDA.jl
+++ b/src/CelesteEDA.jl
@@ -40,7 +40,7 @@ function source_pixel_location(ea::ElboArgs, s::Int, n::Int)
         p.center,
         p.pixel_center,
         ea.vp[s][lidx.u])
-    return pix_loc - p.bitmap_corner
+    return pix_loc - p.bitmap_offset
 end
 
 
@@ -62,8 +62,8 @@ function render_source(ea::ElboArgs, s::Int, n::Int;
     H2, W2 = size(p.active_pixel_bitmap)
     for w2 in 1:W2, h2 in 1:H2
         # (h2, w2) index the local patch, while (h, w) index the image
-        h = p.bitmap_corner[1] + h2
-        w = p.bitmap_corner[2] + w2
+        h = p.bitmap_offset[1] + h2
+        w = p.bitmap_offset[2] + w2
 
         if !p.active_pixel_bitmap[h2, w2]
             continue
@@ -137,8 +137,8 @@ function render_source_fft(
     H2, W2 = size(p.active_pixel_bitmap)
     for w2 in 1:W2, h2 in 1:H2
         # (h2, w2) index the local patch, while (h, w) index the image
-        h = p.bitmap_corner[1] + h2
-        w = p.bitmap_corner[2] + w2
+        h = p.bitmap_offset[1] + h2
+        w = p.bitmap_offset[2] + w2
 
         if !p.active_pixel_bitmap[h2, w2]
             continue
@@ -168,8 +168,8 @@ function show_source_image(ea::ElboArgs, s::Int, n::Int)
     image = fill(NaN, H2, W2);
     for w2 in 1:W2, h2 in 1:H2
         # (h2, w2) index the local patch, while (h, w) index the image
-        h = p.bitmap_corner[1] + h2
-        w = p.bitmap_corner[2] + w2
+        h = p.bitmap_offset[1] + h2
+        w = p.bitmap_offset[2] + w2
 
         if !p.active_pixel_bitmap[h2, w2]
             continue

--- a/src/DeterministicVI.jl
+++ b/src/DeterministicVI.jl
@@ -49,9 +49,9 @@ function infer_source(images::Vector{Image},
     cat_local = vcat(entry, neighbors)
     vp = Vector{Float64}[init_source(ce) for ce in cat_local]
     patches = Infer.get_sky_patches(images, cat_local)
-    ea = ElboArgs(images, vp, patches, [1], [1])
     Infer.load_active_pixels!(images, patches)
 
+    ea = ElboArgs(images, vp, patches, [1])
     f_evals, max_f, max_x, nm_result = maximize_f(elbo, ea)
     vp[1]
 end

--- a/src/Infer.jl
+++ b/src/Infer.jl
@@ -58,7 +58,7 @@ function find_neighbors(target_sources::Vector{Int64},
 
     # If this loop isn't super fast in pratice, we can tile (the sky, not the
     # images) or build a spatial index with a library before distributing
-    for ts in 1:length(target_sources)
+    Threads.@threads for ts in 1:length(target_sources)
         s = target_sources[ts]
         ce = catalog[s]
 

--- a/src/Infer.jl
+++ b/src/Infer.jl
@@ -58,7 +58,7 @@ function find_neighbors(target_sources::Vector{Int64},
 
     # If this loop isn't super fast in pratice, we can tile (the sky, not the
     # images) or build a spatial index with a library before distributing
-    Threads.@threads for ts in 1:length(target_sources)
+    for ts in 1:length(target_sources)
         s = target_sources[ts]
         ce = catalog[s]
 

--- a/src/Infer.jl
+++ b/src/Infer.jl
@@ -102,10 +102,10 @@ function get_sky_patches(images::Vector{Image},
                 radius_pix = radius_override_pix
             end
 
-            hmin = max(1, floor(Int, pixel_center[1] - radius_pix))
-            hmax = min(img.H, ceil(Int, pixel_center[1] + radius_pix))
-            wmin = max(1, floor(Int, pixel_center[2] - radius_pix))
-            wmax = min(img.W, ceil(Int, pixel_center[2] + radius_pix))
+            hmin = max(0, floor(Int, pixel_center[1] - radius_pix - 1))
+            hmax = min(img.H - 1, ceil(Int, pixel_center[1] + radius_pix - 1))
+            wmin = max(0, floor(Int, pixel_center[2] - radius_pix - 1))
+            wmax = min(img.W - 1, ceil(Int, pixel_center[2] + radius_pix - 1))
 
             # some light sources are so far from some images that they don't
             # overlap at all
@@ -151,8 +151,8 @@ function load_active_pixels!(images::Vector{Image},
         # (h2, w2) index the local patch, while (h, w) index the image
         H2, W2 = size(p.active_pixel_bitmap)
         for w2 in 1:W2, h2 in 1:H2
-            h = p.bitmap_corner[1] + h2 - 1
-            w = p.bitmap_corner[2] + w2 - 1
+            h = p.bitmap_offset[1] + h2
+            w = p.bitmap_offset[2] + w2
 
             # skip masked pixels
             if isnan(img.pixels[h, w]) && exclude_nan

--- a/src/ParallelRun.jl
+++ b/src/ParallelRun.jl
@@ -12,8 +12,8 @@ import ..PSF
 
 import ..DeterministicVI: infer_source
 
-
 include("cyclades.jl")
+
 
 #set this to false to use source-division parallelism
 const SKY_DIVISION_PARALLELISM=true
@@ -322,6 +322,7 @@ function infer_init(rcfs::Vector{RunCamcolField},
 
     return catalog, target_sources
 end
+
 
 """
 Use mulitple threads on one node to fit the Celeste model to sources in a given

--- a/src/deterministic_vi/elbo_args.jl
+++ b/src/deterministic_vi/elbo_args.jl
@@ -202,9 +202,6 @@ type ElboArgs{NumType <: Number}
     # the sources to optimize
     active_sources::Vector{Int}
 
-    # the sources whose patches we visit we computing the elbo
-    sources_to_visit::Vector{Int}
-
     # Bivarite normals will not be evaulated at points further than this many
     # standard deviations away from their mean.  See its usage in the ELBO and
     # bivariate normals for details.
@@ -221,8 +218,7 @@ function ElboArgs{NumType <: Number}(
             images::Vector{Image},
             vp::VariationalParams{NumType},
             patches::Matrix{SkyPatch},
-            active_sources::Vector{Int},
-            sources_to_visit::Vector{Int};
+            active_sources::Vector{Int};
             psf_K::Int=2,
             num_allowed_sd::Float64=Inf)
     N = length(images)
@@ -248,5 +244,5 @@ function ElboArgs{NumType <: Number}(
                                 calculate_hessian=true)
 
     ElboArgs(S, N, psf_K, images, vp, patches,
-             active_sources, sources_to_visit, num_allowed_sd, elbo_vars)
+             active_sources, num_allowed_sd, elbo_vars)
 end

--- a/src/deterministic_vi/elbo_objective.jl
+++ b/src/deterministic_vi/elbo_objective.jl
@@ -206,24 +206,6 @@ function calculate_source_pixel_brightness!{NumType <: Number}(
 end
 
 
-# function calculate_source_pixel_brightness!{NumType <: Number}(
-#                     elbo_vars::ElboIntermediateVariables{NumType},
-#                     ea::ElboArgs{NumType},
-#                     sbs::Vector{SourceBrightness{NumType}},
-#                     s::Int, b::Int)
-#     calculate_source_pixel_brightness!(
-#         elbo_vars,
-#         ea,
-#         elbo_vars.E_G_s,
-#         elbo_vars.var_G_s,
-#         elbo_vars.fs0m_vec[s],
-#         elbo_vars.fs1m_vec[s],
-#         sbs[s],
-#         b, s,
-#         s in ea.active_sources)
-# end
-
-
 """
 Calculate the variance var_G_s as a function of (E_G_s, E_G2_s).
 
@@ -496,14 +478,14 @@ function elbo_likelihood{NumType <: Number}(
         # hasn't been visited before, so no need to allocate memory.
         # currently length(ea.active_sources) > 1 only in unit tests, never
         # when invoked from `bin`.
-        already_visited = length(ea.sources_to_visit) == 1 ?
+        already_visited = length(ea.active_sources) == 1 ?
                               falses(0, 0) :
                               falses(size(img.pixels))
 
         # iterate over the pixels by iterating over the patches, and visiting
         # all the pixels in the patch that are active and haven't already been
         # visited
-        for s in ea.sources_to_visit
+        for s in ea.active_sources
             p = ea.patches[s, n]
             H2, W2 = size(p.active_pixel_bitmap)
             for w2 in 1:W2, h2 in 1:H2
@@ -516,7 +498,7 @@ function elbo_likelihood{NumType <: Number}(
                 end
 
                 # if there's only one source to visit, we know this pixel is new
-                if length(ea.sources_to_visit) != 1
+                if length(ea.active_sources) != 1
                     if already_visited[h,w]
                         continue
                     end

--- a/src/deterministic_vi/elbo_objective.jl
+++ b/src/deterministic_vi/elbo_objective.jl
@@ -424,8 +424,8 @@ function add_pixel_term!{NumType <: Number}(
     for s in 1:size(ea.patches, 1)
         p = ea.patches[s,n]
 
-        h2 = h - p.bitmap_corner[1] - 1
-        w2 = w - p.bitmap_corner[2] - 1
+        h2 = h - p.bitmap_offset[1]
+        w2 = w - p.bitmap_offset[2]
 
         H2, W2 = size(p.active_pixel_bitmap)
         if 1 <= h2 <= H2 && 1 <= w2 < W2 && p.active_pixel_bitmap[h2, w2]
@@ -508,8 +508,8 @@ function elbo_likelihood{NumType <: Number}(
             H2, W2 = size(p.active_pixel_bitmap)
             for w2 in 1:W2, h2 in 1:H2
                 # (h2, w2) index the local patch, while (h, w) index the image
-                h = p.bitmap_corner[1] + h2 - 1
-                w = p.bitmap_corner[2] + w2 - 1
+                h = p.bitmap_offset[1] + h2
+                w = p.bitmap_offset[2] + w2
 
                 if !p.active_pixel_bitmap[h2, w2]
                     continue

--- a/src/deterministic_vi_image_psf/elbo_image_psf.jl
+++ b/src/deterministic_vi_image_psf/elbo_image_psf.jl
@@ -136,8 +136,8 @@ function populate_gal_fsm_image!(
     p = ea.patches[s, n]
     H_patch, W_patch = size(p.active_pixel_bitmap)
     for w_patch in 1:W_patch, h_patch in 1:H_patch
-        h_image = h_patch + p.bitmap_corner[1]
-        w_image = w_patch + p.bitmap_corner[2]
+        h_image = h_patch + p.bitmap_offset[1]
+        w_image = w_patch + p.bitmap_offset[2]
 
         h_fsm = h_image - fsms.h_lower + 1
         w_fsm = w_image - fsms.w_lower + 1
@@ -207,8 +207,8 @@ function accumulate_source_image_brightness!(
     p = ea.patches[s, n]
     H_patch, W_patch = size(p.active_pixel_bitmap)
     for w_patch in 1:W_patch, h_patch in 1:H_patch
-        h_fsm = h_patch + p.bitmap_corner[1] - fsms.h_lower + 1
-        w_fsm = w_patch + p.bitmap_corner[2] - fsms.w_lower + 1
+        h_fsm = h_patch + p.bitmap_offset[1] - fsms.h_lower + 1
+        w_fsm = w_patch + p.bitmap_offset[2] - fsms.w_lower + 1
         accumulate_source_pixel_brightness!(
                             ea.elbo_vars,
                             ea,
@@ -246,8 +246,8 @@ function accumulate_band_in_elbo!(
         p = ea.patches[s, n]
         H_patch, W_patch = size(p.active_pixel_bitmap)
         for w_patch in 1:W_patch, h_patch in 1:H_patch
-            h_image = h_patch + p.bitmap_corner[1]
-            w_image = w_patch + p.bitmap_corner[2]
+            h_image = h_patch + p.bitmap_offset[1]
+            w_image = w_patch + p.bitmap_offset[2]
 
             image = ea.images[n]
             this_pixel = image.pixels[h_image, w_image]

--- a/src/deterministic_vi_image_psf/fsm_matrices.jl
+++ b/src/deterministic_vi_image_psf/fsm_matrices.jl
@@ -120,8 +120,8 @@ function initialize_fsm_sf_matrices!(
     #.the fsm matrices as big as the total number of active pixels.
     for s in 1:ea.S, n in 1:ea.N
         p = ea.patches[s, n]
-        h1 = p.bitmap_corner[1] + 1
-        w1 = p.bitmap_corner[2] + 1
+        h1 = p.bitmap_offset[1]
+        w1 = p.bitmap_offset[2]
         h2 = h1 + size(p.active_pixel_bitmap, 1) - 1
         w2 = w1 + size(p.active_pixel_bitmap, 2) - 1
         h_lower_vec[n] = min(h_lower_vec[n], h1)

--- a/src/model/fsm_util.jl
+++ b/src/model/fsm_util.jl
@@ -246,8 +246,8 @@ function populate_fsm_vecs!{NumType <: Number}(
     @inbounds for s in 1:size(patches, 1)
         p = patches[s,n]
 
-        h2 = h - p.bitmap_corner[1] - 1
-        w2 = w - p.bitmap_corner[2] - 1
+        h2 = h - p.bitmap_offset[1]
+        w2 = w - p.bitmap_offset[2]
 
         H2, W2 = size(p.active_pixel_bitmap)
 

--- a/src/model/imaged_sources.jl
+++ b/src/model/imaged_sources.jl
@@ -23,7 +23,7 @@ immutable SkyPatch
     wcs_jacobian::Matrix{Float64}
     pixel_center::Vector{Float64}
 
-    bitmap_corner::SVector{2, Int64}  # lower left corner index
+    bitmap_offset::SVector{2, Int64}  # lower left corner index offset
     active_pixel_bitmap::Matrix{Bool}
 end
 
@@ -66,4 +66,3 @@ function choose_patch_radius(ce::CatalogEntry,
 
     min(radius_req, max_radius)
 end
-

--- a/src/model/log_prob.jl
+++ b/src/model/log_prob.jl
@@ -179,8 +179,8 @@ function state_log_likelihood(is_star::Bool,                # source is star
         H2, W2 = size(p.active_pixel_bitmap)
         for w2 in 1:W2, h2 in 1:H2
             # (h2, w2) index the local patch, while (h, w) index the image
-            h = p.bitmap_corner[1] + h2 - 1
-            w = p.bitmap_corner[2] + w2 - 1
+            h = p.bitmap_offset[1] + h2
+            w = p.bitmap_offset[2] + w2
 
             if !p.active_pixel_bitmap[h2, w2]
                 continue

--- a/test/DerivativeTestUtils.jl
+++ b/test/DerivativeTestUtils.jl
@@ -22,8 +22,7 @@ function forward_diff_model_params{T<:Number}(::Type{T}, ea0::ElboArgs{Float64})
         vp[s][i] = ea0.vp[s][i]
     end
 
-    ElboArgs(ea0.images, vp, ea0.patches, ea0.active_sources,
-             ea0.sources_to_visit)
+    ElboArgs(ea0.images, vp, ea0.patches, ea0.active_sources)
 end
 
 

--- a/test/SampleData.jl
+++ b/test/SampleData.jl
@@ -47,7 +47,7 @@ function make_elbo_args(images::Vector{Image},
     S = length(catalog)
     active_sources = active_source > 0 ? [active_source] :
                                           S <= 3 ? collect(1:S) : [1,2,3]
-    ElboArgs(images, vp, patches, active_sources, collect(1:S))
+    ElboArgs(images, vp, patches, active_sources)
 end
 
 
@@ -192,7 +192,6 @@ function empty_model_params(S::Int)
     ElboArgs(Image[],
              vp,
              Array(SkyPatch, S, 0),
-             collect(1:S),
              collect(1:S))
 end
 

--- a/test/test_derivatives.jl
+++ b/test/test_derivatives.jl
@@ -1300,7 +1300,7 @@ function test_real_image()
     cat_local = vcat(catalog[sa], catalog[neighbors])
     vp = Vector{Float64}[init_source(ce) for ce in cat_local]
     patches = Infer.get_sky_patches(images, cat_local)
-    ea = ElboArgs(images, vp, patches, [1], [1])
+    ea = ElboArgs(images, vp, patches, [1])
 
     Infer.load_active_pixels!(ea.images, ea.patches)
     @test sum(ea.patches[1,1].active_pixel_bitmap) > 0

--- a/test/test_elbo.jl
+++ b/test/test_elbo.jl
@@ -72,7 +72,7 @@ function test_active_sources()
 
     # this patch is huge, the bottom left corner should be the
     # bottom left of the image
-    @test p.bitmap_corner == [1, 1]
+    @test p.bitmap_offset == [0, 0]
 
     # this patch is huge, all the pixels should be active pixels
     @test size(p.active_pixel_bitmap) == size(images[n].pixels)
@@ -88,6 +88,10 @@ function test_active_sources()
     # now on to the main test
     ea12 = ElboArgs(ea.images, ea.vp, ea.patches, [1, 2], [1, 2])
     elbo_lik_12 = DeterministicVI.elbo_likelihood(ea12)
+
+    ea21 = ElboArgs(ea.images, ea.vp, ea.patches, [1, 2], [2, 1])
+    elbo_lik_21 = DeterministicVI.elbo_likelihood(ea21)
+    @test_approx_eq elbo_lik_12.v[] elbo_lik_21.v[]
 
     ea1 = ElboArgs(ea.images, ea.vp, ea.patches, [1,], [1, 2])
     elbo_lik_1 = DeterministicVI.elbo_likelihood(ea1)

--- a/test/test_infer.jl
+++ b/test/test_infer.jl
@@ -78,8 +78,8 @@ function test_load_active_pixels()
         total_pixels += length(img.pixels)
         for w2 in 1:W2, h2 in 1:H2
             # (h2, w2) index the local patch, while (h, w) index the image
-            h = p.bitmap_corner[1] + h2 - 1
-            w = p.bitmap_corner[2] + w2 - 1
+            h = p.bitmap_offset[1] + h2
+            w = p.bitmap_offset[2] + w2
             num_active_photons += img.pixels[h, w] - img.epsilon_mat[h, w]
             num_active_pixels += 1
         end

--- a/test/test_log_prob.jl
+++ b/test/test_log_prob.jl
@@ -112,7 +112,7 @@ function test_that_gal_truth_is_most_likely_log_prob()
       r = r / sqrt(sum(r.*r))
 
       bad_state = gal_state + scale * r
-      #@test best_ll > gal_logpdf(bad_state)
+      @test best_ll > gal_logpdf(bad_state)
     end
 
     # perturb galaxy shape parameters


### PR DESCRIPTION
This PR fixes an off-by-one error, to close #422. Sky patches now report the offset of the patch (0-based indexing) rather than the lower left corner index (1-based indexing). It's a lot more straight forward that way. Otherwise, you have to either add 1 or subtract 1, depending on whether you're going from patch coordinates to image coordinates, or image coordinates to patch coordinates. 

This PR also removes the `sources_to_visit` field from `ElboArgs`. That field gave us more flexibility than we need (credit: @rgiordan). Only one test required that much flexibility. I was too focused on restoring that test along with my notiles PR. @agnusmaximus -- I updated your code to work without `sources_to_visit` in this PR too. 