### PR TITLE
Memory-efficient SensitiveFloats

### DIFF
--- a/src/Celeste.jl
+++ b/src/Celeste.jl
@@ -13,10 +13,10 @@ include("Transform.jl")
 include("PSF.jl")
 include("SDSSIO.jl")
 
+include("MCMC.jl")
+include("StochasticVI.jl")
 include("DeterministicVI.jl")
 include("DeterministicVIImagePSF.jl")
-include("StochasticVI.jl")
-include("MCMC.jl")
 
 include("ParallelRun.jl")
 

--- a/src/CelesteEDA.jl
+++ b/src/CelesteEDA.jl
@@ -50,11 +50,11 @@ function render_source(ea::ElboArgs, s::Int, n::Int;
     local p = ea.patches[s, n]
     local image = fill(NaN, size(p.active_pixel_bitmap))
     local sbs = load_source_brightnesses(
-        ea, calculate_derivs=false, calculate_hessian=false)
+        ea, calculate_gradient=false, calculate_hessian=false)
     star_mcs, gal_mcs = load_bvn_mixtures(ea.S, ea.patches,
                                 ea.vp, ea.active_sources,
                                 ea.psf_K, n,
-                                calculate_derivs=false,
+                                calculate_gradient=false,
                                 calculate_hessian=false)
 
     p = ea.patches[s,n]
@@ -69,14 +69,12 @@ function render_source(ea::ElboArgs, s::Int, n::Int;
             continue
         end
 
-        clear!(ea.elbo_vars.E_G, false)
-        clear!(ea.elbo_vars.var_G, false)
+        clear!(ea.elbo_vars.E_G)
+        clear!(ea.elbo_vars.var_G)
 
         populate_fsm_vecs!(ea.elbo_vars.bvn_derivs,
                            ea.elbo_vars.fs0m_vec,
                            ea.elbo_vars.fs1m_vec,
-                           false,
-                           false,
                            ea.patches,
                            ea.active_sources,
                            ea.num_allowed_sd,
@@ -119,12 +117,12 @@ function render_source_fft(
     local p = ea.patches[s, n]
     local image = fill(NaN, size(p.active_pixel_bitmap))
     local sbs = load_source_brightnesses(
-        ea, calculate_derivs=false, calculate_hessian=false)
+        ea, calculate_gradient=false, calculate_hessian=false)
     local fsms = fsm_vec[n]
 
     local gal_mcs = load_gal_bvn_mixtures(
             ea.S, ea.patches, ea.vp, ea.active_sources, n,
-            calculate_derivs=false,
+            calculate_gradient=false,
             calculate_hessian=false);
 
     clear_brightness!(fsms)

--- a/src/DeterministicVIImagePSF.jl
+++ b/src/DeterministicVIImagePSF.jl
@@ -20,7 +20,7 @@ import ..Model:
     get_bvn_cov, galaxy_prototypes, linear_world_to_pix
 
 import ..SensitiveFloats:
-    SensitiveFloat, zero_sensitive_float, zero_sensitive_float_array,
+    SensitiveFloat, zero_sensitive_float_array,
     multiply_sfs!, add_scaled_sfs!, clear!
 
 include("deterministic_vi_image_psf/sensitive_float_fft.jl")

--- a/src/Model.jl
+++ b/src/Model.jl
@@ -49,7 +49,7 @@ include("model/param_set.jl")
 include("model/imaged_sources.jl")
 include("model/wcs_utils.jl")
 
-import ..SensitiveFloats: SensitiveFloat
+import ..SensitiveFloats: SensitiveFloat, clear!
 include("bivariate_normals.jl")
 include("model/fsm_util.jl")
 include("model/log_prob.jl")

--- a/src/SensitiveFloats.jl
+++ b/src/SensitiveFloats.jl
@@ -1,7 +1,6 @@
 module SensitiveFloats
 
 export SensitiveFloat,
-       zero_sensitive_float,
        clear!,
        multiply_sfs!,
        add_scaled_sfs!,
@@ -9,8 +8,6 @@ export SensitiveFloat,
        add_sources_sf!,
        set_hess!
 
-
-abstract ParamSet
 
 """
 A function value and its derivative with respect to its arguments.
@@ -24,7 +21,7 @@ Attributes:
       in the same format as d.  This is used for the full Hessian
       with respect to all the sources.
 """
-immutable SensitiveFloat{ParamType <: ParamSet, NumType <: Number}
+immutable SensitiveFloat{NumType}
     v::Base.RefValue{NumType}
 
     # local_P x local_S matrix of gradients
@@ -32,101 +29,80 @@ immutable SensitiveFloat{ParamType <: ParamSet, NumType <: Number}
 
     # h is ordered so that p changes fastest.  For example, the indices
     # of a column of h correspond to the indices of d's stacked columns.
-    h::Matrix{NumType} # (local_P * local_S) x (local_P * local_S)
-    # ids::ParamType
+    h::Matrix{NumType}
+
+    local_P::Int64
+    local_S::Int64
+
+    has_gradient::Bool
+    has_hessian::Bool
+
+    SensitiveFloat(local_P::Int64, local_S::Int64,
+                   has_gradient::Bool, has_hessian::Bool) = begin
+        @assert has_gradient || !has_hessian
+        v = Ref(zero(NumType))
+        d = has_gradient ? zeros(NumType, local_P, local_S) : Array(NumType, 0, 0)
+        h = has_hessian ? zeros(NumType, local_P * local_S, local_P * local_S) :
+                       Array(NumType, 0, 0)
+        new(v, d, h, local_P, local_S, has_gradient, has_hessian)
+    end
 end
 
+
+function SensitiveFloat{NumType <: Number}(prototype_sf::SensitiveFloat{NumType})
+    SensitiveFloat{NumType}(prototype_sf.local_P,
+                            prototype_sf.local_S,
+                            prototype_sf.has_gradient,
+                            prototype_sf.has_hessian)
+end
 
 #########################################################
 
 """
 Set a SensitiveFloat's hessian term, maintaining symmetry.
 """
-function set_hess!{ParamType <: ParamSet, NumType <: Number}(
-                    sf::SensitiveFloat{ParamType, NumType},
+function set_hess!{NumType <: Number}(
+                    sf::SensitiveFloat{NumType},
                     i::Int,
                     j::Int,
                     v::NumType)
+    @assert sf.has_hessian
     # even if i == j, it's probably faster not to branch
     sf.h[i, j] = sf.h[j, i] = v
 end
 
-function zero_sensitive_float{ParamType <: ParamSet}(
-              ::Type{ParamType}, NumType::DataType, local_S::Int)
-    local_P = length(ParamType)
 
-    v = Ref(zero(NumType))
-    d = zeros(NumType, local_P, local_S)
-    h = zeros(NumType, local_P * local_S, local_P * local_S)
+function clear!{NumType <: Number}(sf::SensitiveFloat{NumType})
+    sf.v[] = zero(NumType)
 
-    SensitiveFloat{ParamType, NumType}(v, d, h)
-end
-
-
-function zero_sensitive_float{ParamType <: ParamSet}(
-                    ::Type{ParamType}, NumType::DataType)
-    # Default to a single source.
-    zero_sensitive_float(ParamType, NumType, 1)
-end
-
-
-# If no type is specified, default to using Float64.
-function zero_sensitive_float{ParamType <: ParamSet}(
-            param_arg::Type{ParamType}, local_S::Int)
-    zero_sensitive_float(param_arg, Float64, local_S)
-end
-
-
-function zero_sensitive_float{ParamType <: ParamSet}(
-            param_arg::Type{ParamType})
-    zero_sensitive_float(param_arg, Float64, 1)
-end
-
-
-function zero_sensitive_float_array{ParamType <: ParamSet}(
-    ::Type{ParamType}, NumType::DataType, local_S::Int, d::Integer...)
-
-    sf_array = Array(SensitiveFloat{ParamType, NumType}, d)
-    for ind in 1:length(sf_array)
-        sf_array[ind] = zero_sensitive_float(ParamType, NumType, local_S)
+    if sf.has_gradient
+        fill!(sf.d, zero(NumType))
     end
 
-    sf_array
-end
-
-
-function clear!{ParamType <: ParamSet, NumType <: Number}(
-            sp::SensitiveFloat{ParamType, NumType})
-    clear!(sp, true)
-end
-
-
-function clear!{ParamType <: ParamSet, NumType <: Number}(
-                sp::SensitiveFloat{ParamType, NumType}, clear_hessian::Bool)
-    sp.v[] = zero(NumType)
-    fill!(sp.d, zero(NumType))
-    if clear_hessian
-      fill!(sp.h, zero(NumType))
+    if sf.has_hessian
+        fill!(sf.h, zero(NumType))
     end
-
-    true # Set definite return type
 end
 
 
 """
 Factor out the hessian part of combine_sfs!.
 """
-function combine_sfs_hessian!{ParamType <: ParamSet,
-                 T1 <: Number, T2 <: Number, T3 <: Number}(
-            sf1::SensitiveFloat{ParamType, T1},
-            sf2::SensitiveFloat{ParamType, T1},
-            sf_result::SensitiveFloat{ParamType, T1},
-            g_d::Vector{T2}, g_h::Matrix{T3})
-    @assert g_h[1, 2] == g_h[2, 1]
-
+function combine_sfs_hessian!{T1 <: Number, T2 <: Number, T3 <: Number}(
+            sf1::SensitiveFloat{T1},
+            sf2::SensitiveFloat{T1},
+            sf_result::SensitiveFloat{T1},
+            g_d::Vector{T2},
+            g_h::Matrix{T3})
     p1, p2 = size(sf_result.h)
+
+    @assert size(sf_result.d) == size(sf1.d) == size(sf2.d)
     @assert size(sf_result.h) == size(sf1.h) == size(sf2.h)
-    @assert p1 == p2 == prod(size(sf1.d)) == prod(size(sf2.d))
+    @assert p1 > 0
+    @assert g_h[1, 2] == g_h[2, 1]
+    @assert sf_result.has_hessian
+    @assert sf_result.has_gradient
+
     for ind2 = 1:p2
         sf11_factor = g_h[1, 1] * sf1.d[ind2] + g_h[1, 2] * sf2.d[ind2]
         sf21_factor = g_h[1, 2] * sf1.d[ind2] + g_h[2, 2] * sf2.d[ind2]
@@ -140,8 +116,6 @@ function combine_sfs_hessian!{ParamType <: ParamSet,
             sf_result.h[ind2, ind1] = sf_result.h[ind1, ind2]
         end
     end
-
-    true # Set definite return type
 end
 
 
@@ -154,44 +128,28 @@ each evaluated at (sf1, sf2).
 The result is stored in sf_result.  The order is done in such a way that
 it can overwrite sf1 or sf2 and still be accurate.
 """
-function combine_sfs!{ParamType <: ParamSet,
-                      T1 <: Number, T2 <: Number, T3 <: Number}(
-        sf1::SensitiveFloat{ParamType, T1},
-        sf2::SensitiveFloat{ParamType, T1},
-        sf_result::SensitiveFloat{ParamType, T1},
-        v::T1, g_d::Vector{T2}, g_h::Matrix{T3},
-        calculate_hessian::Bool=true)
+function combine_sfs!{T1 <: Number, T2 <: Number, T3 <: Number}(
+                        sf1::SensitiveFloat{T1},
+                        sf2::SensitiveFloat{T1},
+                        sf_result::SensitiveFloat{T1},
+                        v::T1,
+                        g_d::Vector{T2},
+                        g_h::Matrix{T3})
     # You have to do this in the right order to not overwrite needed terms.
-    if calculate_hessian
+    if sf_result.has_hessian
         combine_sfs_hessian!(sf1, sf2, sf_result, g_d, g_h)
     end
 
-    sf_result.d[:] = sf1.d
-    n = length(sf_result.d)
-    LinAlg.BLAS.scal!(n, g_d[1], sf_result.d, 1)
-    LinAlg.BLAS.axpy!(g_d[2], sf2.d, sf_result.d)
+    if sf_result.has_gradient
+        sf_result.d[:] = sf1.d
+        n = length(sf_result.d)
+        LinAlg.BLAS.scal!(n, g_d[1], sf_result.d, 1)
+        LinAlg.BLAS.axpy!(g_d[2], sf2.d, sf_result.d)
+    end
 
     sf_result.v[] = v
 end
 
-
-"""
-Updates sf1 in place with g(sf1, sf2), where
-g_d = (g_1, g_2) is the gradient of g and
-g_h = (g_11, g_12; g_12, g_22) is the hessian of g,
-each evaluated at (sf1, sf2).
-
-The result is stored in sf1.
-"""
-function combine_sfs!{ParamType <: ParamSet,
-                      T1 <: Number, T2 <: Number, T3 <: Number}(
-        sf1::SensitiveFloat{ParamType, T1},
-        sf2::SensitiveFloat{ParamType, T1},
-        v::T1, g_d::Vector{T2}, g_h::Matrix{T3},
-        calculate_hessian::Bool=true)
-
-    combine_sfs!(sf1, sf2, sf1, v, g_d, g_h, calculate_hessian)
-end
 
 # Decalare outside to avoid allocating memory.
 const multiply_sfs_hess = Float64[0 1; 1 0]
@@ -199,31 +157,32 @@ const multiply_sfs_hess = Float64[0 1; 1 0]
 """
 Updates sf1 in place with sf1 * sf2.
 """
-function multiply_sfs!{ParamType <: ParamSet, NumType <: Number}(
-        sf1::SensitiveFloat{ParamType, NumType},
-        sf2::SensitiveFloat{ParamType, NumType},
-        calculate_hessian::Bool=true)
-
+function multiply_sfs!{NumType <: Number}(sf1::SensitiveFloat{NumType},
+                                          sf2::SensitiveFloat{NumType})
     v = sf1.v[] * sf2.v[]
     g_d = NumType[sf2.v[], sf1.v[]]
-
-    combine_sfs!(sf1, sf2, v, g_d, multiply_sfs_hess, calculate_hessian)
+    combine_sfs!(sf1, sf2, sf1, v, g_d, multiply_sfs_hess)
 end
 
 
 """
 Update sf1 in place with (sf1 + scale * sf2).
 """
-function add_scaled_sfs!{ParamType <: ParamSet, NumType <: Number}(
-        sf1::SensitiveFloat{ParamType, NumType},
-        sf2::SensitiveFloat{ParamType, NumType},
-        scale::AbstractFloat, calculate_hessian::Bool)
-
+function add_scaled_sfs!{NumType <: Number}(
+                    sf1::SensitiveFloat{NumType},
+                    sf2::SensitiveFloat{NumType},
+                    scale::AbstractFloat)
     sf1.v[] += scale * sf2.v[]
 
-    LinAlg.BLAS.axpy!(scale, sf2.d, sf1.d)
+    @assert sf1.has_gradient == sf2.has_gradient
+    @assert sf1.has_hessian == sf2.has_hessian
+    @assert size(sf1.h) == size(sf2.h)
 
-    if calculate_hessian
+    if sf1.has_gradient
+        LinAlg.BLAS.axpy!(scale, sf2.d, sf1.d)
+    end
+
+    if sf1.has_hessian
         p1, p2 = size(sf1.h)
         @assert (p1, p2) == size(sf2.h)
         @inbounds for ind2=1:p2, ind1=1:ind2
@@ -240,28 +199,33 @@ end
 Adds sf2_s to sf1, where sf1 is sensitive to multiple sources and sf2_s is only
 sensitive to source s.
 """
-function add_sources_sf!{ParamType <: ParamSet, NumType <: Number}(
-        sf_all::SensitiveFloat{ParamType, NumType},
-        sf_s::SensitiveFloat{ParamType, NumType},
-        s::Int, calculate_hessian::Bool)
+function add_sources_sf!{NumType <: Number}(
+                    sf_all::SensitiveFloat{NumType},
+                    sf_s::SensitiveFloat{NumType},
+                    s::Int)
+    sf_all.v[] += sf_s.v[]
 
-    # TODO: This line, too, allocates a lot of memory.    Why?
-    sf_all.v[] = sf_all.v[] + sf_s.v[]
+    @assert size(sf_all.d, 1) == size(sf_s.d, 1)
 
-    # TODO: time consuming **************
-    P = length(ParamType)
-    Ph = size(sf_all.h)[1]
+    P = sf_all.local_P
 
-    @assert Ph == prod(size(sf_all.d))
-    @assert Ph == size(sf_all.h)[2]
-    @assert Ph >= P * s
-    @assert size(sf_s.d) == (P, 1)
-    @assert size(sf_s.h) == (P, P)
+    if sf_all.has_gradient
+        @assert size(sf_s.d) == (P, 1)
+        @inbounds for s_ind1 in 1:sf_all.local_P
+            s_all_ind1 = P * (s - 1) + s_ind1
+            sf_all.d[s_all_ind1] = sf_all.d[s_all_ind1] + sf_s.d[s_ind1]
+        end
+    end
 
-    @inbounds for s_ind1 in 1:P
-        s_all_ind1 = P * (s - 1) + s_ind1
-        sf_all.d[s_all_ind1] = sf_all.d[s_all_ind1] + sf_s.d[s_ind1]
-        if calculate_hessian
+    if sf_all.has_hessian
+        Ph = size(sf_all.h)[1]
+        @assert Ph == size(sf_all.h)[2]
+        @assert size(sf_s.h) == (P, P)
+        @assert Ph >= P * s
+
+        @inbounds for s_ind1 in 1:P
+            s_all_ind1 = P * (s - 1) + s_ind1
+
             @inbounds for s_ind2 in 1:s_ind1
                 s_all_ind2 = P * (s - 1) + s_ind2
                 sf_all.h[s_all_ind2, s_all_ind1] =
@@ -271,8 +235,19 @@ function add_sources_sf!{ParamType <: ParamSet, NumType <: Number}(
             end
         end
     end
+end
 
-    true # Set definite return type
+
+function zero_sensitive_float_array(NumType::DataType,
+                                    local_P::Int,
+                                    local_S::Int,
+                                    d::Integer...)
+    sf_array = Array(SensitiveFloat{NumType}, d)
+    for ind in 1:length(sf_array)
+        # Do we always want these arrays to have gradients and hessians?
+        sf_array[ind] = SensitiveFloat{NumType}(local_P, local_S, true, true)
+    end
+    sf_array
 end
 
 end

--- a/src/bivariate_normals.jl
+++ b/src/bivariate_normals.jl
@@ -417,7 +417,7 @@ function GalaxyCacheComponent{NumType <: Number}(
     e_dev_dir::Float64, e_dev_i::NumType,
     gc::GalaxyComponent, pc::PsfComponent, u::Vector{NumType},
     e_axis::NumType, e_angle::NumType, e_scale::NumType,
-    calculate_derivs::Bool, calculate_hessian::Bool)
+    calculate_gradient::Bool, calculate_hessian::Bool)
 
   # Declare in advance to save memory allocation.
   const empty_sig_sf =
@@ -430,9 +430,9 @@ function GalaxyCacheComponent{NumType <: Number}(
 
   # d siginv / dsigma is only necessary for the Hessian.
   bmc = BvnComponent{NumType}(
-    mean_s, var_s, weight, calculate_derivs && calculate_hessian)
+    mean_s, var_s, weight, calculate_gradient && calculate_hessian)
 
-  if calculate_derivs
+  if calculate_gradient
     sig_sf = GalaxySigmaDerivs(
       e_angle, e_axis, e_scale, XiXi, calculate_hessian)
     scale!(sig_sf.j, gc.nuBar)

--- a/src/deterministic_vi/elbo_kl.jl
+++ b/src/deterministic_vi/elbo_kl.jl
@@ -24,7 +24,7 @@ function gen_beta_kl{NumType <: Number}(alpha2::NumType, beta2::NumType)
     const lgamma_alpha2 = lgamma(alpha2)
     const lgamma_beta2 = lgamma(beta2)
     function this_beta_kl{NumType2 <: Number}(
-            alpha1::NumType2, beta1::NumType2, calculate_derivs::Bool)
+            alpha1::NumType2, beta1::NumType2)
 
         alpha_diff = alpha1 - alpha2
         beta_diff = beta1 - beta2
@@ -40,23 +40,21 @@ function gen_beta_kl{NumType <: Number}(alpha2::NumType, beta2::NumType)
         grad = zeros(NumType2, 2)
         hess = zeros(NumType2, 2, 2)
 
-        if calculate_derivs
-            trigamma_alpha1 = trigamma(alpha1)
-            trigamma_beta1 = trigamma(beta1)
-            trigamma_both = trigamma(alpha1 + beta1)
-            grad[1] = alpha_diff * trigamma_alpha1 + both_inv_diff * trigamma_both
-            grad[2] = beta_diff * trigamma_beta1 + both_inv_diff * trigamma_both
+        trigamma_alpha1 = trigamma(alpha1)
+        trigamma_beta1 = trigamma(beta1)
+        trigamma_both = trigamma(alpha1 + beta1)
+        grad[1] = alpha_diff * trigamma_alpha1 + both_inv_diff * trigamma_both
+        grad[2] = beta_diff * trigamma_beta1 + both_inv_diff * trigamma_both
 
-            quadgamma_both = polygamma(2, alpha1 + beta1)
-            hess[1, 1] = alpha_diff * polygamma(2, alpha1) +
-                         both_inv_diff * quadgamma_both +
-                         trigamma_alpha1 - trigamma_both
-            hess[2, 2] = beta_diff * polygamma(2, beta1) +
-                         both_inv_diff * quadgamma_both +
-                         trigamma_beta1 - trigamma_both
-            hess[1, 2] = hess[2, 1] =
-                -trigamma_both + both_inv_diff * quadgamma_both
-        end
+        quadgamma_both = polygamma(2, alpha1 + beta1)
+        hess[1, 1] = alpha_diff * polygamma(2, alpha1) +
+                     both_inv_diff * quadgamma_both +
+                     trigamma_alpha1 - trigamma_both
+        hess[2, 2] = beta_diff * polygamma(2, beta1) +
+                     both_inv_diff * quadgamma_both +
+                     trigamma_beta1 - trigamma_both
+        hess[1, 2] = hess[2, 1] =
+            -trigamma_both + both_inv_diff * quadgamma_both
 
         return kl, grad, hess
     end
@@ -68,7 +66,7 @@ KL divergence between a pair of categorical distributions.
 """
 function gen_categorical_kl{NumType <: Number}(p2::Vector{NumType})
     function this_categorical_kl{NumType2 <: Number}(
-            p1::Vector{NumType2}, calculate_derivs::Bool)
+            p1::Vector{NumType2})
 
         kl = zero(NumType2)
         grad = zeros(NumType2, length(p1))
@@ -77,10 +75,8 @@ function gen_categorical_kl{NumType <: Number}(p2::Vector{NumType})
         for i in 1:length(p1)
             log_ratio = log(p1[i]) - log(p2[i])
             kl += p1[i] * log_ratio
-            if calculate_derivs
-                grad[i] = 1 + log_ratio
-                hess[i, i] = 1 / p1[i]
-            end
+            grad[i] = 1 + log_ratio
+            hess[i, i] = 1 / p1[i]
         end
 
         return kl, grad, hess
@@ -104,19 +100,18 @@ function gen_normal_kl{NumType <: Number}(mu2::NumType, sigma2Sq::NumType)
     const log_sigma2Sq = log(sigma2Sq)
     const precision2 = 1 / sigma2Sq
     function this_normal_kl{NumType2 <: Number}(
-            mu1::NumType2, sigma1Sq::NumType2, calculate_derivs::Bool)
+            mu1::NumType2, sigma1Sq::NumType2)
         diff = mu1 - mu2
         kl = .5 * (log_sigma2Sq - log(sigma1Sq) +
                    (sigma1Sq + (diff)^2) / sigma2Sq - 1)
 
         grad = zeros(NumType2, 2)
         hess = zeros(NumType2, 2, 2)
-        if calculate_derivs
-            grad[1] = precision2 * diff                 # Gradient wrt the mean
-            grad[2] = 0.5 * (precision2 - 1 / sigma1Sq) # Gradient wrt the var
-            hess[1, 1] = precision2
-            hess[2, 2] = 0.5 / (sigma1Sq ^ 2)
-        end
+        grad[1] = precision2 * diff                 # Gradient wrt the mean
+        grad[2] = 0.5 * (precision2 - 1 / sigma1Sq) # Gradient wrt the var
+        hess[1, 1] = precision2
+        hess[2, 2] = 0.5 / (sigma1Sq ^ 2)
+
         return kl, grad, hess
     end
 end
@@ -141,13 +136,13 @@ function gen_diagmvn_mvn_kl{NumType <: Number}(
     const K = length(mean2)
 
     function this_diagmvn_mvn_kl{NumType2 <: Number}(
-        mean1::Vector{NumType2}, vars1::Vector{NumType2}, calculate_derivs::Bool)
+        mean1::Vector{NumType2}, vars1::Vector{NumType2})
 
       diff = mean2 - mean1
 
       kl = sum(diag(precision2) .* vars1) - K
       kl += (diff' * precision2 * diff)[]
-      kl += -sum(log, vars1) + logdet_cov2
+      kl += -sum(log(vars1)) + logdet_cov2
       kl = 0.5 * kl
 
       grad_mean = zeros(NumType2, K)
@@ -155,14 +150,12 @@ function gen_diagmvn_mvn_kl{NumType <: Number}(
       hess_mean = zeros(NumType2, K, K)
       hess_var = zeros(NumType2, K, K)
 
-      if calculate_derivs
-          grad_mean = -1 * precision2 * diff
-          grad_var = 0.5 * (diag(precision2) - 1 ./ vars1)
+      grad_mean = -1 * precision2 * diff
+      grad_var = 0.5 * (diag(precision2) - 1 ./ vars1)
 
-          hess_mean = precision2
-          for k in 1:K
-              hess_var[k, k] = 0.5 ./ (vars1[k] ^ 2)
-          end
+      hess_mean = precision2
+      for k in 1:K
+          hess_var[k, k] = 0.5 ./ (vars1[k] ^ 2)
       end
 
       return kl, grad_mean, grad_var, hess_mean, hess_var
@@ -177,11 +170,12 @@ end
 A sensitive float representing a single term a[i] which can be combined
 with other sensitive floats.
 """
-function get_a_term_sensitive_float{NumType <: Number}(
-        a::NumType, i::Integer, calculate_derivs::Bool)
-    a_term = zero_sensitive_float(CanonicalParams, NumType)
+function get_a_term_sensitive_float{NumType <: Number}(tgt::SensitiveFloat,
+                                                       a::NumType,
+                                                       i::Integer)
+    a_term = SensitiveFloat(tgt)
     a_term.v[] = a
-    if calculate_derivs
+    if tgt.has_gradient
         a_term.d[ids.a[i, 1], 1] = 1
     end
     return a_term
@@ -189,29 +183,13 @@ end
 
 
 """
-A sensitive float representing a single term k[d, i] which can be combined
-with other sensitive floats.
-"""
-function get_k_term_sensitive_float{NumType <: Number}(
-        k::NumType, i::Integer, d::Integer, calculate_derivs::Bool)
-
-    k_term = zero_sensitive_float(CanonicalParams, NumType)
-    k_term.v[] = k
-    if calculate_derivs
-        k_term.d[ids.k[d, i], 1] = 1
-    end
-    return k_term
-end
-
-
-"""
 Subtract the KL divergence from the prior for c
 """
 function subtract_kl_c!{NumType <: Number}(
-    vs::Vector{NumType}, kl_source::SensitiveFloat{CanonicalParams, NumType},
-    calculate_derivs::Bool)
+                vs::Vector{NumType},
+                kl_source::SensitiveFloat{NumType})
+    kl_term = SensitiveFloat(kl_source)
 
-    kl_term = zero_sensitive_float(CanonicalParams, NumType)
     for i in 1:Ia, d in 1:D
         clear!(kl_term)
         pp_kl_cid = gen_diagmvn_mvn_kl(
@@ -219,21 +197,30 @@ function subtract_kl_c!{NumType <: Number}(
         mean_ids = ids.c1[:, i]
         var_ids = ids.c2[:, i]
         kl, grad_mean, grad_var, hess_mean, hess_var =
-            pp_kl_cid(vs[mean_ids], vs[var_ids], calculate_derivs)
+            pp_kl_cid(vs[mean_ids], vs[var_ids])
         kl_term.v[] = kl
 
-        if calculate_derivs
+        if kl_source.has_gradient
             kl_term.d[mean_ids, 1] = grad_mean
             kl_term.d[var_ids, 1] = grad_var
+        end
+
+        if kl_source.has_hessian
             kl_term.h[mean_ids, mean_ids] = hess_mean
             kl_term.h[var_ids, var_ids] = hess_var
         end
 
-        a_term = get_a_term_sensitive_float(vs[ids.a[i, 1]], i, calculate_derivs)
-        k_term = get_k_term_sensitive_float(vs[ids.k[d, i]], i, d, calculate_derivs)
-        multiply_sfs!(kl_term, a_term, calculate_derivs)
-        multiply_sfs!(kl_term, k_term, calculate_derivs)
-        add_scaled_sfs!(kl_source, kl_term, -1.0, calculate_derivs)
+        a_term = get_a_term_sensitive_float(kl_source, vs[ids.a[i, 1]], i)
+
+        k_term = SensitiveFloat(kl_source)
+        k_term.v[] = vs[ids.k[d, i]]
+        if k_term.has_gradient
+            k_term.d[ids.k[d, i], 1] = 1
+        end
+
+        multiply_sfs!(kl_term, a_term)
+        multiply_sfs!(kl_term, k_term)
+        add_scaled_sfs!(kl_source, kl_term, -1.0)
     end
 end
 
@@ -247,24 +234,25 @@ Args:
           of the k parameters.
 """
 function subtract_kl_k!{NumType <: Number}(
-        vs::Vector{NumType},
-        kl_source::SensitiveFloat{CanonicalParams, NumType},
-        calculate_derivs::Bool)
+                    vs::Vector{NumType},
+                    kl_source::SensitiveFloat{NumType})
+    kl_term = SensitiveFloat(kl_source)
 
-    kl_term = zero_sensitive_float(CanonicalParams, NumType)
     for i in 1:Ia
         clear!(kl_term)
         k_ind = ids.k[:, i]
         pp_kl_ki = gen_categorical_kl(prior.k[:, i])
-        kl, grad, hess = pp_kl_ki(vs[k_ind], calculate_derivs)
+        kl, grad, hess = pp_kl_ki(vs[k_ind])
         kl_term.v[] = kl
-        if calculate_derivs
+        if kl_source.has_gradient
             kl_term.d[k_ind, 1] = grad
+        end
+        if kl_source.has_hessian
             kl_term.h[k_ind, k_ind] = hess
         end
-        a_term = get_a_term_sensitive_float(vs[ids.a[i, 1]], i, calculate_derivs)
-        multiply_sfs!(kl_term, a_term, calculate_derivs)
-        add_scaled_sfs!(kl_source, kl_term, -1.0, calculate_derivs)
+        a_term = get_a_term_sensitive_float(kl_source, vs[ids.a[i, 1]], i)
+        multiply_sfs!(kl_term, a_term)
+        add_scaled_sfs!(kl_source, kl_term, -1.0)
     end
 end
 
@@ -273,23 +261,25 @@ end
 Subtract the KL divergence from the prior for r for object type i.
 """
 function subtract_kl_r!{NumType <: Number}(
-        vs::Vector{NumType}, kl_source::SensitiveFloat{CanonicalParams, NumType},
-        calculate_derivs::Bool)
+                    vs::Vector{NumType},
+                    kl_source::SensitiveFloat{NumType})
+    kl_term = SensitiveFloat(kl_source)
 
-    kl_term = zero_sensitive_float(CanonicalParams, NumType)
     for i in 1:Ia
         clear!(kl_term)
         pp_kl_r = gen_normal_kl(prior.r_mean[i], prior.r_var[i])
-        kl, grad, hess = pp_kl_r(vs[ids.r1[i]], vs[ids.r2[i]], calculate_derivs)
+        kl, grad, hess = pp_kl_r(vs[ids.r1[i]], vs[ids.r2[i]])
         r_ind = Integer[ ids.r1[i], ids.r2[i] ]
         kl_term.v[] = kl
-        if calculate_derivs
+        if kl_term.has_gradient
             kl_term.d[r_ind, 1] = grad
+        end
+        if kl_term.has_hessian
             kl_term.h[r_ind, r_ind] = hess
         end
-        a_term = get_a_term_sensitive_float(vs[ids.a[i, 1]], i, calculate_derivs)
-        multiply_sfs!(kl_term, a_term, calculate_derivs)
-        add_scaled_sfs!(kl_source, kl_term, -1.0, calculate_derivs)
+        a_term = get_a_term_sensitive_float(kl_source, vs[ids.a[i, 1]], i)
+        multiply_sfs!(kl_term, a_term)
+        add_scaled_sfs!(kl_source, kl_term, -1.0)
     end
 end
 
@@ -298,15 +288,18 @@ end
 Subtract the KL divergence from the prior for a
 """
 function subtract_kl_a!{NumType <: Number}(
-        vs::Vector{NumType}, kl_source::SensitiveFloat{CanonicalParams, NumType},
-        calculate_derivs::Bool)
-
+                    vs::Vector{NumType},
+                    kl_source::SensitiveFloat{NumType})
     pp_kl_a = gen_categorical_kl(prior.a)
 
-    kl, grad, hess = pp_kl_a(vs[ids.a[:, 1]], calculate_derivs)
-    kl_source.v[] -= kl
-    if calculate_derivs
+    kl, grad, hess = pp_kl_a(vs[ids.a[:, 1]])
+    kl_source.v[]  -= kl
+
+    if kl_source.has_gradient
         kl_source.d[ids.a[:, 1], 1] -= grad
+    end
+
+    if kl_source.has_hessian
         kl_source.h[ids.a[:, 1], ids.a[:, 1]] -= hess
     end
 end
@@ -316,18 +309,17 @@ end
 Subtract the KL divergences for all sources.
 """
 function subtract_kl!{NumType <: Number}(
-        ea::ElboArgs{NumType}, accum::SensitiveFloat{CanonicalParams, NumType};
-        calculate_derivs::Bool=true)
-
+                    ea::ElboArgs{NumType},
+                    accum::SensitiveFloat{NumType})
     for sa in 1:length(ea.active_sources)
         s = ea.active_sources[sa]
-        kl_source = zero_sensitive_float(CanonicalParams, NumType)
-        subtract_kl_a!(ea.vp[s], kl_source, calculate_derivs)
-        subtract_kl_k!(ea.vp[s], kl_source, calculate_derivs)
-        subtract_kl_r!(ea.vp[s], kl_source, calculate_derivs)
-        subtract_kl_c!(ea.vp[s], kl_source, calculate_derivs)
+        kl_source = SensitiveFloat{NumType}(length(CanonicalParams), 1,
+                                            accum.has_gradient, accum.has_hessian)
+        subtract_kl_a!(ea.vp[s], kl_source)
+        subtract_kl_k!(ea.vp[s], kl_source)
+        subtract_kl_r!(ea.vp[s], kl_source)
+        subtract_kl_c!(ea.vp[s], kl_source)
 
-        add_sources_sf!(accum, kl_source, sa, calculate_derivs)
+        add_sources_sf!(accum, kl_source, sa)
     end
-
 end

--- a/src/deterministic_vi/elbo_objective.jl
+++ b/src/deterministic_vi/elbo_objective.jl
@@ -27,6 +27,11 @@ function calculate_source_pixel_brightness!{NumType <: Number}(
                     sb::SourceBrightness{NumType},
                     b::Int, s::Int,
                     is_active_source::Bool)
+    @assert E_G_s.local_P == var_G_s.local_P == length(CanonicalParams)
+    @assert E_G_s.local_S == var_G_s.local_S == 1
+    @assert fs0m.local_P == length(StarPosParams)
+    @assert fs1m.local_P == length(GalaxyPosParams)
+
     E_G2_s = elbo_vars.E_G2_s
 
     clear!(E_G_s)

--- a/src/deterministic_vi/elbo_objective.jl
+++ b/src/deterministic_vi/elbo_objective.jl
@@ -20,18 +20,17 @@ Returns:
 function calculate_source_pixel_brightness!{NumType <: Number}(
                     elbo_vars::ElboIntermediateVariables{NumType},
                     ea::ElboArgs{NumType},
-                    E_G_s::SensitiveFloat{CanonicalParams, NumType},
-                    var_G_s::SensitiveFloat{CanonicalParams, NumType},
-                    fs0m::SensitiveFloat{StarPosParams, NumType},
-                    fs1m::SensitiveFloat{GalaxyPosParams, NumType},
+                    E_G_s::SensitiveFloat{NumType},
+                    var_G_s::SensitiveFloat{NumType},
+                    fs0m::SensitiveFloat{NumType},
+                    fs1m::SensitiveFloat{NumType},
                     sb::SourceBrightness{NumType},
                     b::Int, s::Int,
                     is_active_source::Bool)
     E_G2_s = elbo_vars.E_G2_s
 
-    clear_hessian = elbo_vars.calculate_hessian && elbo_vars.calculate_derivs
-    clear!(E_G_s, clear_hessian)
-    clear!(E_G2_s, clear_hessian)
+    clear!(E_G_s)
+    clear!(E_G2_s)
 
     @inbounds for i in 1:Ia # Stars and galaxies
         fsm_i = (i == 1) ? fs0m : fs1m
@@ -59,7 +58,7 @@ function calculate_source_pixel_brightness!{NumType <: Number}(
         E_G2_s.v[] += a_i * llff
 
         # Only calculate derivatives for active sources.
-        if is_active_source && elbo_vars.calculate_derivs
+        if is_active_source && elbo_vars.elbo.has_gradient
             ######################
             # Gradients.
 
@@ -86,7 +85,7 @@ function calculate_source_pixel_brightness!{NumType <: Number}(
                     a_i * (fsm_i_v^2) * sb_E_ll_a_b_i_d[p0_bright_ind, 1]
             end
 
-            if elbo_vars.calculate_hessian
+            if elbo_vars.elbo.has_hessian
                 ######################
                 # Hessians.
 
@@ -178,7 +177,7 @@ function calculate_source_pixel_brightness!{NumType <: Number}(
         end # if calculate derivatives
     end # i loop
 
-    if elbo_vars.calculate_hessian
+    if elbo_vars.elbo.has_hessian
         # Accumulate the u Hessian. u is the only parameter that is shared between
         # different values of i.
 
@@ -221,20 +220,18 @@ Returns:
 """
 function calculate_var_G_s!{NumType <: Number}(
                     elbo_vars::ElboIntermediateVariables{NumType},
-                    E_G_s::SensitiveFloat{CanonicalParams, NumType},
-                    E_G2_s::SensitiveFloat{CanonicalParams, NumType},
-                    var_G_s::SensitiveFloat{CanonicalParams, NumType},
+                    E_G_s::SensitiveFloat{NumType},
+                    E_G2_s::SensitiveFloat{NumType},
+                    var_G_s::SensitiveFloat{NumType},
                     is_active_source::Bool)
-    clear!(var_G_s,
-           elbo_vars.calculate_hessian &&
-           elbo_vars.calculate_derivs && is_active_source)
+    clear!(var_G_s)
 
     E_G_s_v = E_G_s.v[]
     E_G2_s_v = E_G2_s.v[]
 
     var_G_s.v[] = E_G2_s_v - (E_G_s_v ^ 2)
 
-    if is_active_source && elbo_vars.calculate_derivs
+    if is_active_source && elbo_vars.elbo.has_gradient
         var_G_s_d = var_G_s.d
         E_G2_s_d = E_G2_s.d
         E_G_s_d = E_G_s.d
@@ -245,7 +242,7 @@ function calculate_var_G_s!{NumType <: Number}(
             var_G_s_d[ind1] = E_G2_s_d[ind1] - 2 * E_G_s_v * E_G_s_d[ind1]
         end
 
-        if elbo_vars.calculate_hessian
+        if elbo_vars.elbo.has_hessian
             var_G_s_h = var_G_s.h
             E_G2_s_h = E_G2_s.h
             E_G_s_h = E_G_s.h
@@ -269,17 +266,13 @@ sensitive floast E_G and var_G, which are updated in place.
 function accumulate_source_pixel_brightness!{NumType <: Number}(
                     elbo_vars::ElboIntermediateVariables{NumType},
                     ea::ElboArgs{NumType},
-                    E_G::SensitiveFloat{CanonicalParams, NumType},
-                    var_G::SensitiveFloat{CanonicalParams, NumType},
-                    fs0m::SensitiveFloat{StarPosParams, NumType},
-                    fs1m::SensitiveFloat{GalaxyPosParams, NumType},
+                    E_G::SensitiveFloat{NumType},
+                    var_G::SensitiveFloat{NumType},
+                    fs0m::SensitiveFloat{NumType},
+                    fs1m::SensitiveFloat{NumType},
                     sb::SourceBrightness{NumType},
                     b::Int, s::Int,
                     is_active_source::Bool)
-    calculate_hessian = elbo_vars.calculate_hessian &&
-                        elbo_vars.calculate_derivs &&
-                        is_active_source
-
     # This updates elbo_vars.E_G_s and elbo_vars.var_G_s
     calculate_source_pixel_brightness!(
         elbo_vars,
@@ -295,8 +288,8 @@ function accumulate_source_pixel_brightness!{NumType <: Number}(
 
     if is_active_source
         sa = findfirst(ea.active_sources, s)
-        add_sources_sf!(E_G, elbo_vars.E_G_s, sa, calculate_hessian)
-        add_sources_sf!(var_G, elbo_vars.var_G_s, sa, calculate_hessian)
+        add_sources_sf!(E_G, elbo_vars.E_G_s, sa)
+        add_sources_sf!(var_G, elbo_vars.var_G_s, sa)
     else
         # If the sources is inactive, simply accumulate the values.
         E_G.v[] += elbo_vars.E_G_s.v[]
@@ -319,10 +312,11 @@ Args:
 """
 function add_elbo_log_term!{NumType <: Number}(
                 elbo_vars::ElboIntermediateVariables{NumType},
-                E_G::SensitiveFloat{CanonicalParams, NumType},
-                var_G::SensitiveFloat{CanonicalParams, NumType},
-                elbo::SensitiveFloat{CanonicalParams, NumType},
-                x_nbm::AbstractFloat, iota::AbstractFloat)
+                E_G::SensitiveFloat{NumType},
+                var_G::SensitiveFloat{NumType},
+                elbo::SensitiveFloat{NumType},
+                x_nbm::AbstractFloat,
+                iota::AbstractFloat)
     # See notes for a derivation. The log term is
     # log E[G] - Var(G) / (2 * E[G] ^2 )
 
@@ -337,11 +331,11 @@ function add_elbo_log_term!{NumType <: Number}(
         # If not calculating derivatives, add the values directly.
         elbo.v[] += x_nbm * (log(iota) + log_term_value)
 
-        if elbo_vars.calculate_derivs
+        if elbo_vars.elbo.has_gradient
             elbo_vars.combine_grad[1] = -0.5 / (E_G_v ^ 2)
             elbo_vars.combine_grad[2] = 1 / E_G_v + var_G_v / (E_G_v ^ 3)
 
-            if elbo_vars.calculate_hessian
+            if elbo_vars.elbo.has_hessian
                 elbo_vars.combine_hess[1, 1] = 0.0
                 elbo_vars.combine_hess[1, 2] = elbo_vars.combine_hess[2, 1] = 1 / E_G_v^3
                 elbo_vars.combine_hess[2, 2] =
@@ -351,8 +345,7 @@ function add_elbo_log_term!{NumType <: Number}(
             # Calculate the log term.
             combine_sfs!(
                 var_G, E_G, elbo_vars.elbo_log_term,
-                log_term_value, elbo_vars.combine_grad, elbo_vars.combine_hess,
-                elbo_vars.calculate_hessian)
+                log_term_value, elbo_vars.combine_grad, elbo_vars.combine_hess)
 
             # Add to the ELBO.
             elbo_d = elbo.d
@@ -362,7 +355,7 @@ function add_elbo_log_term!{NumType <: Number}(
                 elbo_d[ind] += x_nbm * elbo_vars_elbo_log_term_d[ind]
             end
 
-            if elbo_vars.calculate_hessian
+            if elbo_vars.elbo.has_hessian
                 elbo_h = elbo.h
                 elbo_vars_elbo_log_term_h = elbo_vars.elbo_log_term.h
                 for ind in 1:length(elbo_h)
@@ -379,16 +372,12 @@ function add_pixel_term!{NumType <: Number}(
                     n::Int, h::Int, w::Int,
                     star_mcs::Array{BvnComponent{NumType}, 2},
                     gal_mcs::Array{GalaxyCacheComponent{NumType}, 4},
-                    sbs::Vector{SourceBrightness{NumType}};
-                    calculate_derivs=true,
-                    calculate_hessian=true)
+                    sbs::Vector{SourceBrightness{NumType}})
     # This combines the bvn components to get the light density for each
     # source separately.
     Model.populate_fsm_vecs!(ea.elbo_vars.bvn_derivs,
                              ea.elbo_vars.fs0m_vec,
                              ea.elbo_vars.fs1m_vec,
-                             ea.elbo_vars.calculate_derivs,
-                             ea.elbo_vars.calculate_hessian,
                              ea.patches,
                              ea.active_sources,
                              ea.num_allowed_sd,
@@ -398,10 +387,8 @@ function add_pixel_term!{NumType <: Number}(
     img = ea.images[n]
 
     # This combines the sources into a single brightness value for the pixel.
-    clear!(elbo_vars.E_G,
-        elbo_vars.calculate_hessian && elbo_vars.calculate_derivs)
-    clear!(elbo_vars.var_G,
-        elbo_vars.calculate_hessian && elbo_vars.calculate_derivs)
+    clear!(elbo_vars.E_G)
+    clear!(elbo_vars.var_G)
 
     for s in 1:size(ea.patches, 1)
         p = ea.patches[s,n]
@@ -432,8 +419,7 @@ function add_pixel_term!{NumType <: Number}(
                        img.iota_vec[h])
     add_scaled_sfs!(elbo_vars.elbo,
                     elbo_vars.E_G,
-                    -img.iota_vec[h],
-                    elbo_vars.calculate_hessian && elbo_vars.calculate_derivs)
+                    -img.iota_vec[h])
 
     # Subtract the log factorial term. This is not a function of the
     # parameters so the derivatives don't need to be updated. Note that
@@ -448,18 +434,11 @@ Return the expected log likelihood for all bands in a section
 of the sky.
 Returns: A sensitive float with the log likelihood.
 """
-function elbo_likelihood{NumType <: Number}(
-                    ea::ElboArgs{NumType};
-                    calculate_derivs=true,
-                    calculate_hessian=true)
+function elbo_likelihood{NumType <: Number}(ea::ElboArgs{NumType})
     clear!(ea.elbo_vars)
-    ea.elbo_vars.calculate_derivs = calculate_derivs
-    ea.elbo_vars.calculate_hessian = calculate_derivs && calculate_hessian
 
     # this call loops over light sources (but not images)
-    sbs = load_source_brightnesses(ea,
-                calculate_derivs=ea.elbo_vars.calculate_derivs,
-                calculate_hessian=ea.elbo_vars.calculate_hessian)
+    sbs = load_source_brightnesses(ea)
 
     for n in 1:ea.N
         img = ea.images[n]
@@ -471,8 +450,8 @@ function elbo_likelihood{NumType <: Number}(
         star_mcs, gal_mcs = Model.load_bvn_mixtures(ea.S, ea.patches,
                                     ea.vp, ea.active_sources,
                                     ea.psf_K, n,
-                                    calculate_derivs=calculate_derivs,
-                                    calculate_hessian=calculate_hessian)
+                                    calculate_gradient=ea.elbo_vars.elbo.has_gradient,
+                                    calculate_hessian=ea.elbo_vars.elbo.has_hessian)
 
         # if there's only one active source, we know each pixel we visit
         # hasn't been visited before, so no need to allocate memory.
@@ -512,9 +491,7 @@ function elbo_likelihood{NumType <: Number}(
                 end
 
                 # if we're here it's a unique active pixel
-                add_pixel_term!(ea, n, h, w, star_mcs, gal_mcs, sbs;
-                                calculate_derivs=ea.elbo_vars.calculate_derivs,
-                                calculate_hessian=ea.elbo_vars.calculate_hessian)
+                add_pixel_term!(ea, n, h, w, star_mcs, gal_mcs, sbs)
             end
         end
     end
@@ -529,13 +506,8 @@ Calculates and returns the ELBO and its derivatives for all the bands
 of an image.
 Returns: A sensitive float containing the ELBO for the image.
 """
-function elbo{NumType <: Number}(
-                    ea::ElboArgs{NumType};
-                    calculate_derivs=true,
-                    calculate_hessian=true)
-    elbo = elbo_likelihood(ea; calculate_derivs=calculate_derivs,
-                               calculate_hessian=calculate_hessian)
-    # TODO: subtract the kl with the hessian.
-    subtract_kl!(ea, elbo, calculate_derivs=calculate_derivs)
+function elbo{NumType <: Number}(ea::ElboArgs{NumType})
+    elbo = elbo_likelihood(ea)
+    subtract_kl!(ea, elbo)
     elbo
 end

--- a/src/deterministic_vi/source_brightness.jl
+++ b/src/deterministic_vi/source_brightness.jl
@@ -56,60 +56,60 @@ function SourceBrightness{NumType <: Number}(vs::Vector{NumType};
         E_l_a[1, i].v[] = exp(-c1[1, i] + .5 * c2[1, i])
 
         if calculate_gradient
-        # band 3 is the reference band, relative to which the colors are
-        # specified.
-        # It is denoted r_s and has a lognormal expectation.
-        E_l_a[3, i].d[bids.r1] = E_l_a[3, i].v[]
-        E_l_a[3, i].d[bids.r2] = E_l_a[3, i].v[] * .5
+            # band 3 is the reference band, relative to which the colors are
+            # specified.
+            # It is denoted r_s and has a lognormal expectation.
+            E_l_a[3, i].d[bids.r1] = E_l_a[3, i].v[]
+            E_l_a[3, i].d[bids.r2] = E_l_a[3, i].v[] * .5
 
-        if calculate_hessian
-            set_hess!(E_l_a[3, i], bids.r1, bids.r1, E_l_a[3, i].v[])
-            set_hess!(E_l_a[3, i], bids.r1, bids.r2, E_l_a[3, i].v[] * 0.5)
-            set_hess!(E_l_a[3, i], bids.r2, bids.r2, E_l_a[3, i].v[] * 0.25)
-        end
+            if calculate_hessian
+                set_hess!(E_l_a[3, i], bids.r1, bids.r1, E_l_a[3, i].v[])
+                set_hess!(E_l_a[3, i], bids.r1, bids.r2, E_l_a[3, i].v[] * 0.5)
+                set_hess!(E_l_a[3, i], bids.r2, bids.r2, E_l_a[3, i].v[] * 0.25)
+            end
 
-        # The remaining indices involve c_s and have lognormal
-        # expectations times E_c_3.
+            # The remaining indices involve c_s and have lognormal
+            # expectations times E_c_3.
 
-        # band 4 = band 3 * color 3.
-        E_l_a[4, i].d[bids.c1[3]] = E_l_a[4, i].v[]
-        E_l_a[4, i].d[bids.c2[3]] = E_l_a[4, i].v[] * .5
-        if calculate_hessian
-            set_hess!(E_l_a[4, i], bids.c1[3], bids.c1[3], E_l_a[4, i].v[])
-            set_hess!(E_l_a[4, i], bids.c1[3], bids.c2[3], E_l_a[4, i].v[] * 0.5)
-            set_hess!(E_l_a[4, i], bids.c2[3], bids.c2[3], E_l_a[4, i].v[] * 0.25)
-        end
-        multiply_sfs!(E_l_a[4, i], E_l_a[3, i])
+            # band 4 = band 3 * color 3.
+            E_l_a[4, i].d[bids.c1[3]] = E_l_a[4, i].v[]
+            E_l_a[4, i].d[bids.c2[3]] = E_l_a[4, i].v[] * .5
+            if calculate_hessian
+                set_hess!(E_l_a[4, i], bids.c1[3], bids.c1[3], E_l_a[4, i].v[])
+                set_hess!(E_l_a[4, i], bids.c1[3], bids.c2[3], E_l_a[4, i].v[] * 0.5)
+                set_hess!(E_l_a[4, i], bids.c2[3], bids.c2[3], E_l_a[4, i].v[] * 0.25)
+            end
+            multiply_sfs!(E_l_a[4, i], E_l_a[3, i])
 
-        # Band 5 = band 4 * color 4.
-        E_l_a[5, i].d[bids.c1[4]] = E_l_a[5, i].v[]
-        E_l_a[5, i].d[bids.c2[4]] = E_l_a[5, i].v[] * .5
-        if calculate_hessian
-            set_hess!(E_l_a[5, i], bids.c1[4], bids.c1[4], E_l_a[5, i].v[])
-            set_hess!(E_l_a[5, i], bids.c1[4], bids.c2[4], E_l_a[5, i].v[] * 0.5)
-            set_hess!(E_l_a[5, i], bids.c2[4], bids.c2[4], E_l_a[5, i].v[] * 0.25)
-        end
-        multiply_sfs!(E_l_a[5, i], E_l_a[4, i])
+            # Band 5 = band 4 * color 4.
+            E_l_a[5, i].d[bids.c1[4]] = E_l_a[5, i].v[]
+            E_l_a[5, i].d[bids.c2[4]] = E_l_a[5, i].v[] * .5
+            if calculate_hessian
+                set_hess!(E_l_a[5, i], bids.c1[4], bids.c1[4], E_l_a[5, i].v[])
+                set_hess!(E_l_a[5, i], bids.c1[4], bids.c2[4], E_l_a[5, i].v[] * 0.5)
+                set_hess!(E_l_a[5, i], bids.c2[4], bids.c2[4], E_l_a[5, i].v[] * 0.25)
+            end
+            multiply_sfs!(E_l_a[5, i], E_l_a[4, i])
 
-        # Band 2 = band 3 * color 2.
-        E_l_a[2, i].d[bids.c1[2]] = E_l_a[2, i].v[] * -1.
-        E_l_a[2, i].d[bids.c2[2]] = E_l_a[2, i].v[] * .5
-        if calculate_hessian
-            set_hess!(E_l_a[2, i], bids.c1[2], bids.c1[2], E_l_a[2, i].v[])
-            set_hess!(E_l_a[2, i], bids.c1[2], bids.c2[2], E_l_a[2, i].v[] * -0.5)
-            set_hess!(E_l_a[2, i], bids.c2[2], bids.c2[2], E_l_a[2, i].v[] * 0.25)
-        end
-        multiply_sfs!(E_l_a[2, i], E_l_a[3, i])
+            # Band 2 = band 3 * color 2.
+            E_l_a[2, i].d[bids.c1[2]] = E_l_a[2, i].v[] * -1.
+            E_l_a[2, i].d[bids.c2[2]] = E_l_a[2, i].v[] * .5
+            if calculate_hessian
+                set_hess!(E_l_a[2, i], bids.c1[2], bids.c1[2], E_l_a[2, i].v[])
+                set_hess!(E_l_a[2, i], bids.c1[2], bids.c2[2], E_l_a[2, i].v[] * -0.5)
+                set_hess!(E_l_a[2, i], bids.c2[2], bids.c2[2], E_l_a[2, i].v[] * 0.25)
+            end
+            multiply_sfs!(E_l_a[2, i], E_l_a[3, i])
 
-        # Band 1 = band 2 * color 1.
-        E_l_a[1, i].d[bids.c1[1]] = E_l_a[1, i].v[] * -1.
-        E_l_a[1, i].d[bids.c2[1]] = E_l_a[1, i].v[] * .5
-        if calculate_hessian
-            set_hess!(E_l_a[1, i], bids.c1[1], bids.c1[1], E_l_a[1, i].v[])
-            set_hess!(E_l_a[1, i], bids.c1[1], bids.c2[1], E_l_a[1, i].v[] * -0.5)
-            set_hess!(E_l_a[1, i], bids.c2[1], bids.c2[1], E_l_a[1, i].v[] * 0.25)
-        end
-        multiply_sfs!(E_l_a[1, i], E_l_a[2, i])
+            # Band 1 = band 2 * color 1.
+            E_l_a[1, i].d[bids.c1[1]] = E_l_a[1, i].v[] * -1.
+            E_l_a[1, i].d[bids.c2[1]] = E_l_a[1, i].v[] * .5
+            if calculate_hessian
+                set_hess!(E_l_a[1, i], bids.c1[1], bids.c1[1], E_l_a[1, i].v[])
+                set_hess!(E_l_a[1, i], bids.c1[1], bids.c2[1], E_l_a[1, i].v[] * -0.5)
+                set_hess!(E_l_a[1, i], bids.c2[1], bids.c2[1], E_l_a[1, i].v[] * 0.25)
+            end
+            multiply_sfs!(E_l_a[1, i], E_l_a[2, i])
         else
             # Simply update the values if not calculating derivatives.
             E_l_a[4, i].v[] *= E_l_a[3, i].v[]
@@ -133,66 +133,66 @@ function SourceBrightness{NumType <: Number}(vs::Vector{NumType};
         E_ll_a[1, i].v[] = exp(-2 * c1[1, i] + 2 * c2[1, i])
 
         if calculate_gradient
-        # Band 3, the reference band.
-        E_ll_a[3, i].d[bids.r1] = 2 * E_ll_a[3, i].v[]
-        E_ll_a[3, i].d[bids.r2] = 2 * E_ll_a[3, i].v[]
-        if calculate_hessian
-            for hess_ids in [(bids.r1, bids.r1),
-                             (bids.r1, bids.r2),
-                             (bids.r2, bids.r2)]
-                set_hess!(E_ll_a[3, i], hess_ids..., 4.0 * E_ll_a[3, i].v[])
+            # Band 3, the reference band.
+            E_ll_a[3, i].d[bids.r1] = 2 * E_ll_a[3, i].v[]
+            E_ll_a[3, i].d[bids.r2] = 2 * E_ll_a[3, i].v[]
+            if calculate_hessian
+                for hess_ids in [(bids.r1, bids.r1),
+                                 (bids.r1, bids.r2),
+                                 (bids.r2, bids.r2)]
+                    set_hess!(E_ll_a[3, i], hess_ids..., 4.0 * E_ll_a[3, i].v[])
+                end
             end
-        end
 
-        # Band 4 = band 3 * color 3.
-        E_ll_a[4, i].d[bids.c1[3]] = E_ll_a[4, i].v[] * 2.
-        E_ll_a[4, i].d[bids.c2[3]] = E_ll_a[4, i].v[] * 2.
-        if calculate_hessian
-            for hess_ids in [(bids.c1[3], bids.c1[3]),
-                             (bids.c1[3], bids.c2[3]),
-                             (bids.c2[3], bids.c2[3])]
-                set_hess!(E_ll_a[4, i], hess_ids..., E_ll_a[4, i].v[] * 4.0)
+            # Band 4 = band 3 * color 3.
+            E_ll_a[4, i].d[bids.c1[3]] = E_ll_a[4, i].v[] * 2.
+            E_ll_a[4, i].d[bids.c2[3]] = E_ll_a[4, i].v[] * 2.
+            if calculate_hessian
+                for hess_ids in [(bids.c1[3], bids.c1[3]),
+                                 (bids.c1[3], bids.c2[3]),
+                                 (bids.c2[3], bids.c2[3])]
+                    set_hess!(E_ll_a[4, i], hess_ids..., E_ll_a[4, i].v[] * 4.0)
+                end
             end
-        end
-        multiply_sfs!(E_ll_a[4, i], E_ll_a[3, i])
+            multiply_sfs!(E_ll_a[4, i], E_ll_a[3, i])
 
-        # Band 5 = band 4 * color 4.
-        tmp4 = exp(2 * c1[4, i] + 2 * c2[4, i])
-        E_ll_a[5, i].d[bids.c1[4]] = E_ll_a[5, i].v[] * 2.
-        E_ll_a[5, i].d[bids.c2[4]] = E_ll_a[5, i].v[] * 2.
-        if calculate_hessian
-            for hess_ids in [(bids.c1[4], bids.c1[4]),
-                             (bids.c1[4], bids.c2[4]),
-                             (bids.c2[4], bids.c2[4])]
-                set_hess!(E_ll_a[5, i], hess_ids..., E_ll_a[5, i].v[] * 4.0)
+            # Band 5 = band 4 * color 4.
+            tmp4 = exp(2 * c1[4, i] + 2 * c2[4, i])
+            E_ll_a[5, i].d[bids.c1[4]] = E_ll_a[5, i].v[] * 2.
+            E_ll_a[5, i].d[bids.c2[4]] = E_ll_a[5, i].v[] * 2.
+            if calculate_hessian
+                for hess_ids in [(bids.c1[4], bids.c1[4]),
+                                 (bids.c1[4], bids.c2[4]),
+                                 (bids.c2[4], bids.c2[4])]
+                    set_hess!(E_ll_a[5, i], hess_ids..., E_ll_a[5, i].v[] * 4.0)
+                end
             end
-        end
-        multiply_sfs!(E_ll_a[5, i], E_ll_a[4, i])
+            multiply_sfs!(E_ll_a[5, i], E_ll_a[4, i])
 
-        # Band 2 = band 3 * color 2
-        tmp2 = exp(-2 * c1[2, i] + 2 * c2[2, i])
-        E_ll_a[2, i].d[bids.c1[2]] = E_ll_a[2, i].v[] * -2.
-        E_ll_a[2, i].d[bids.c2[2]] = E_ll_a[2, i].v[] * 2.
-        if calculate_hessian
-            for hess_ids in [(bids.c1[2], bids.c1[2]),
-                             (bids.c2[2], bids.c2[2])]
-                set_hess!(E_ll_a[2, i], hess_ids..., E_ll_a[2, i].v[] * 4.0)
+            # Band 2 = band 3 * color 2
+            tmp2 = exp(-2 * c1[2, i] + 2 * c2[2, i])
+            E_ll_a[2, i].d[bids.c1[2]] = E_ll_a[2, i].v[] * -2.
+            E_ll_a[2, i].d[bids.c2[2]] = E_ll_a[2, i].v[] * 2.
+            if calculate_hessian
+                for hess_ids in [(bids.c1[2], bids.c1[2]),
+                                 (bids.c2[2], bids.c2[2])]
+                    set_hess!(E_ll_a[2, i], hess_ids..., E_ll_a[2, i].v[] * 4.0)
+                end
+                set_hess!(E_ll_a[2, i], bids.c1[2], bids.c2[2],
+                          E_ll_a[2, i].v[] * -4.0)
             end
-            set_hess!(E_ll_a[2, i], bids.c1[2], bids.c2[2],
-                      E_ll_a[2, i].v[] * -4.0)
-        end
-        multiply_sfs!(E_ll_a[2, i], E_ll_a[3, i])
+            multiply_sfs!(E_ll_a[2, i], E_ll_a[3, i])
 
-        # Band 1 = band 2 * color 1
-        E_ll_a[1, i].d[bids.c1[1]] = E_ll_a[1, i].v[] * -2.
-        E_ll_a[1, i].d[bids.c2[1]] = E_ll_a[1, i].v[] * 2.
-        if calculate_hessian
-            for hess_ids in [(bids.c1[1], bids.c1[1]),
-                             (bids.c2[1], bids.c2[1])]
-                set_hess!(E_ll_a[1, i], hess_ids..., E_ll_a[1, i].v[] * 4.0)
-            end
-            set_hess!(E_ll_a[1, i], bids.c1[1], bids.c2[1],
-                      E_ll_a[1, i].v[] * -4.0)
+            # Band 1 = band 2 * color 1
+            E_ll_a[1, i].d[bids.c1[1]] = E_ll_a[1, i].v[] * -2.
+            E_ll_a[1, i].d[bids.c2[1]] = E_ll_a[1, i].v[] * 2.
+            if calculate_hessian
+                for hess_ids in [(bids.c1[1], bids.c1[1]),
+                                 (bids.c2[1], bids.c2[1])]
+                    set_hess!(E_ll_a[1, i], hess_ids..., E_ll_a[1, i].v[] * 4.0)
+                end
+                set_hess!(E_ll_a[1, i], bids.c1[1], bids.c2[1],
+                          E_ll_a[1, i].v[] * -4.0)
             end
             multiply_sfs!(E_ll_a[1, i], E_ll_a[2, i])
         else

--- a/src/deterministic_vi/source_brightness.jl
+++ b/src/deterministic_vi/source_brightness.jl
@@ -17,44 +17,45 @@ and all other rows are lognormal offsets.
 """
 immutable SourceBrightness{NumType <: Number}
     # [E[l|a=0], E[l]|a=1]]
-    E_l_a::Matrix{SensitiveFloat{BrightnessParams, NumType}}
+    E_l_a::Matrix{SensitiveFloat{NumType}}
 
     # [E[l^2|a=0], E[l^2]|a=1]]
-    E_ll_a::Matrix{SensitiveFloat{BrightnessParams, NumType}}
+    E_ll_a::Matrix{SensitiveFloat{NumType}}
 end
 
 
-function SourceBrightness{NumType <: Number}(
-    vs::Vector{NumType};
-    calculate_derivs::Bool=true, calculate_hessian::Bool=true)
-  r1 = vs[ids.r1]
-  r2 = vs[ids.r2]
-  c1 = vs[ids.c1]
-  c2 = vs[ids.c2]
+function SourceBrightness{NumType <: Number}(vs::Vector{NumType};
+                                             calculate_gradient=true,
+                                             calculate_hessian=true)
+    r1 = vs[ids.r1]
+    r2 = vs[ids.r2]
+    c1 = vs[ids.c1]
+    c2 = vs[ids.c2]
 
-  # E_l_a has a row for each of the five colors and columns
-  # for star / galaxy.
-  E_l_a = Array(SensitiveFloat{BrightnessParams, NumType}, B, Ia)
-  E_ll_a = Array(SensitiveFloat{BrightnessParams, NumType}, B, Ia)
+    # E_l_a has a row for each of the five colors and columns
+    # for star / galaxy.
+    E_l_a = Array(SensitiveFloat{NumType}, B, Ia)
+    E_ll_a = Array(SensitiveFloat{NumType}, B, Ia)
 
-  for i = 1:Ia
-      ids_band_3 = Int[bids.r1, bids.r2]
-      ids_color_1 = Int[bids.c1[1], bids.c2[1]]
-      ids_color_2 = Int[bids.c1[2], bids.c2[2]]
-      ids_color_3 = Int[bids.c1[3], bids.c2[3]]
-      ids_color_4 = Int[bids.c1[4], bids.c2[4]]
+    for i = 1:Ia
+        ids_band_3 = Int[bids.r1, bids.r2]
+        ids_color_1 = Int[bids.c1[1], bids.c2[1]]
+        ids_color_2 = Int[bids.c1[2], bids.c2[2]]
+        ids_color_3 = Int[bids.c1[3], bids.c2[3]]
+        ids_color_4 = Int[bids.c1[4], bids.c2[4]]
 
-      for b = 1:B
-          E_l_a[b, i] = zero_sensitive_float(BrightnessParams, NumType)
-      end
+        for b = 1:B
+            E_l_a[b, i] = SensitiveFloat{NumType}(length(BrightnessParams), 1,
+                                       calculate_gradient, calculate_hessian)
+        end
 
-      E_l_a[3, i].v[] = exp(r1[i] + 0.5 * r2[i])
-      E_l_a[4, i].v[] = exp(c1[3, i] + .5 * c2[3, i])
-      E_l_a[5, i].v[] = exp(c1[4, i] + .5 * c2[4, i])
-      E_l_a[2, i].v[] = exp(-c1[2, i] + .5 * c2[2, i])
-      E_l_a[1, i].v[] = exp(-c1[1, i] + .5 * c2[1, i])
+        E_l_a[3, i].v[] = exp(r1[i] + 0.5 * r2[i])
+        E_l_a[4, i].v[] = exp(c1[3, i] + .5 * c2[3, i])
+        E_l_a[5, i].v[] = exp(c1[4, i] + .5 * c2[4, i])
+        E_l_a[2, i].v[] = exp(-c1[2, i] + .5 * c2[2, i])
+        E_l_a[1, i].v[] = exp(-c1[1, i] + .5 * c2[1, i])
 
-      if calculate_derivs
+        if calculate_gradient
         # band 3 is the reference band, relative to which the colors are
         # specified.
         # It is denoted r_s and has a lognormal expectation.
@@ -62,9 +63,9 @@ function SourceBrightness{NumType <: Number}(
         E_l_a[3, i].d[bids.r2] = E_l_a[3, i].v[] * .5
 
         if calculate_hessian
-          set_hess!(E_l_a[3, i], bids.r1, bids.r1, E_l_a[3, i].v[])
-          set_hess!(E_l_a[3, i], bids.r1, bids.r2, E_l_a[3, i].v[] * 0.5)
-          set_hess!(E_l_a[3, i], bids.r2, bids.r2, E_l_a[3, i].v[] * 0.25)
+            set_hess!(E_l_a[3, i], bids.r1, bids.r1, E_l_a[3, i].v[])
+            set_hess!(E_l_a[3, i], bids.r1, bids.r2, E_l_a[3, i].v[] * 0.5)
+            set_hess!(E_l_a[3, i], bids.r2, bids.r2, E_l_a[3, i].v[] * 0.25)
         end
 
         # The remaining indices involve c_s and have lognormal
@@ -74,135 +75,136 @@ function SourceBrightness{NumType <: Number}(
         E_l_a[4, i].d[bids.c1[3]] = E_l_a[4, i].v[]
         E_l_a[4, i].d[bids.c2[3]] = E_l_a[4, i].v[] * .5
         if calculate_hessian
-          set_hess!(E_l_a[4, i], bids.c1[3], bids.c1[3], E_l_a[4, i].v[])
-          set_hess!(E_l_a[4, i], bids.c1[3], bids.c2[3], E_l_a[4, i].v[] * 0.5)
-          set_hess!(E_l_a[4, i], bids.c2[3], bids.c2[3], E_l_a[4, i].v[] * 0.25)
+            set_hess!(E_l_a[4, i], bids.c1[3], bids.c1[3], E_l_a[4, i].v[])
+            set_hess!(E_l_a[4, i], bids.c1[3], bids.c2[3], E_l_a[4, i].v[] * 0.5)
+            set_hess!(E_l_a[4, i], bids.c2[3], bids.c2[3], E_l_a[4, i].v[] * 0.25)
         end
-        multiply_sfs!(E_l_a[4, i], E_l_a[3, i], calculate_hessian)
+        multiply_sfs!(E_l_a[4, i], E_l_a[3, i])
 
         # Band 5 = band 4 * color 4.
         E_l_a[5, i].d[bids.c1[4]] = E_l_a[5, i].v[]
         E_l_a[5, i].d[bids.c2[4]] = E_l_a[5, i].v[] * .5
         if calculate_hessian
-          set_hess!(E_l_a[5, i], bids.c1[4], bids.c1[4], E_l_a[5, i].v[])
-          set_hess!(E_l_a[5, i], bids.c1[4], bids.c2[4], E_l_a[5, i].v[] * 0.5)
-          set_hess!(E_l_a[5, i], bids.c2[4], bids.c2[4], E_l_a[5, i].v[] * 0.25)
+            set_hess!(E_l_a[5, i], bids.c1[4], bids.c1[4], E_l_a[5, i].v[])
+            set_hess!(E_l_a[5, i], bids.c1[4], bids.c2[4], E_l_a[5, i].v[] * 0.5)
+            set_hess!(E_l_a[5, i], bids.c2[4], bids.c2[4], E_l_a[5, i].v[] * 0.25)
         end
-        multiply_sfs!(E_l_a[5, i], E_l_a[4, i], calculate_hessian)
+        multiply_sfs!(E_l_a[5, i], E_l_a[4, i])
 
         # Band 2 = band 3 * color 2.
         E_l_a[2, i].d[bids.c1[2]] = E_l_a[2, i].v[] * -1.
         E_l_a[2, i].d[bids.c2[2]] = E_l_a[2, i].v[] * .5
         if calculate_hessian
-          set_hess!(E_l_a[2, i], bids.c1[2], bids.c1[2], E_l_a[2, i].v[])
-          set_hess!(E_l_a[2, i], bids.c1[2], bids.c2[2], E_l_a[2, i].v[] * -0.5)
-          set_hess!(E_l_a[2, i], bids.c2[2], bids.c2[2], E_l_a[2, i].v[] * 0.25)
+            set_hess!(E_l_a[2, i], bids.c1[2], bids.c1[2], E_l_a[2, i].v[])
+            set_hess!(E_l_a[2, i], bids.c1[2], bids.c2[2], E_l_a[2, i].v[] * -0.5)
+            set_hess!(E_l_a[2, i], bids.c2[2], bids.c2[2], E_l_a[2, i].v[] * 0.25)
         end
-        multiply_sfs!(E_l_a[2, i], E_l_a[3, i], calculate_hessian)
+        multiply_sfs!(E_l_a[2, i], E_l_a[3, i])
 
         # Band 1 = band 2 * color 1.
         E_l_a[1, i].d[bids.c1[1]] = E_l_a[1, i].v[] * -1.
         E_l_a[1, i].d[bids.c2[1]] = E_l_a[1, i].v[] * .5
         if calculate_hessian
-          set_hess!(E_l_a[1, i], bids.c1[1], bids.c1[1], E_l_a[1, i].v[])
-          set_hess!(E_l_a[1, i], bids.c1[1], bids.c2[1], E_l_a[1, i].v[] * -0.5)
-          set_hess!(E_l_a[1, i], bids.c2[1], bids.c2[1], E_l_a[1, i].v[] * 0.25)
+            set_hess!(E_l_a[1, i], bids.c1[1], bids.c1[1], E_l_a[1, i].v[])
+            set_hess!(E_l_a[1, i], bids.c1[1], bids.c2[1], E_l_a[1, i].v[] * -0.5)
+            set_hess!(E_l_a[1, i], bids.c2[1], bids.c2[1], E_l_a[1, i].v[] * 0.25)
         end
-        multiply_sfs!(E_l_a[1, i], E_l_a[2, i], calculate_hessian)
-      else
-        # Simply update the values if not calculating derivatives.
-        E_l_a[4, i].v[] *= E_l_a[3, i].v[]
-        E_l_a[5, i].v[] *= E_l_a[4, i].v[]
-        E_l_a[2, i].v[] *= E_l_a[3, i].v[]
-        E_l_a[1, i].v[] *= E_l_a[2, i].v[]
-      end # Derivs
+        multiply_sfs!(E_l_a[1, i], E_l_a[2, i])
+        else
+            # Simply update the values if not calculating derivatives.
+            E_l_a[4, i].v[] *= E_l_a[3, i].v[]
+            E_l_a[5, i].v[] *= E_l_a[4, i].v[]
+            E_l_a[2, i].v[] *= E_l_a[3, i].v[]
+            E_l_a[1, i].v[] *= E_l_a[2, i].v[]
+        end # Derivs
 
-      ################################
-      # Squared terms.
+        ################################
+        # Squared terms.
 
-      for b = 1:B
-          E_ll_a[b, i] = zero_sensitive_float(BrightnessParams, NumType)
-      end
+        for b = 1:B
+            E_ll_a[b, i] = SensitiveFloat{NumType}(length(BrightnessParams), 1,
+                                           calculate_gradient, calculate_hessian)
+        end
 
-      E_ll_a[3, i].v[] = exp(2 * r1[i] + 2 * r2[i])
-      E_ll_a[4, i].v[] = exp(2 * c1[3, i] + 2 * c2[3, i])
-      E_ll_a[5, i].v[] = exp(2 * c1[4, i] + 2 * c2[4, i])
-      E_ll_a[2, i].v[] = exp(-2 * c1[2, i] + 2 * c2[2, i])
-      E_ll_a[1, i].v[] = exp(-2 * c1[1, i] + 2 * c2[1, i])
+        E_ll_a[3, i].v[] = exp(2 * r1[i] + 2 * r2[i])
+        E_ll_a[4, i].v[] = exp(2 * c1[3, i] + 2 * c2[3, i])
+        E_ll_a[5, i].v[] = exp(2 * c1[4, i] + 2 * c2[4, i])
+        E_ll_a[2, i].v[] = exp(-2 * c1[2, i] + 2 * c2[2, i])
+        E_ll_a[1, i].v[] = exp(-2 * c1[1, i] + 2 * c2[1, i])
 
-      if calculate_derivs
+        if calculate_gradient
         # Band 3, the reference band.
         E_ll_a[3, i].d[bids.r1] = 2 * E_ll_a[3, i].v[]
         E_ll_a[3, i].d[bids.r2] = 2 * E_ll_a[3, i].v[]
         if calculate_hessian
-          for hess_ids in [(bids.r1, bids.r1),
-                           (bids.r1, bids.r2),
-                           (bids.r2, bids.r2)]
-            set_hess!(E_ll_a[3, i], hess_ids..., 4.0 * E_ll_a[3, i].v[])
-          end
+            for hess_ids in [(bids.r1, bids.r1),
+                             (bids.r1, bids.r2),
+                             (bids.r2, bids.r2)]
+                set_hess!(E_ll_a[3, i], hess_ids..., 4.0 * E_ll_a[3, i].v[])
+            end
         end
 
         # Band 4 = band 3 * color 3.
         E_ll_a[4, i].d[bids.c1[3]] = E_ll_a[4, i].v[] * 2.
         E_ll_a[4, i].d[bids.c2[3]] = E_ll_a[4, i].v[] * 2.
         if calculate_hessian
-          for hess_ids in [(bids.c1[3], bids.c1[3]),
-                           (bids.c1[3], bids.c2[3]),
-                           (bids.c2[3], bids.c2[3])]
-            set_hess!(E_ll_a[4, i], hess_ids..., E_ll_a[4, i].v[] * 4.0)
-          end
+            for hess_ids in [(bids.c1[3], bids.c1[3]),
+                             (bids.c1[3], bids.c2[3]),
+                             (bids.c2[3], bids.c2[3])]
+                set_hess!(E_ll_a[4, i], hess_ids..., E_ll_a[4, i].v[] * 4.0)
+            end
         end
-        multiply_sfs!(E_ll_a[4, i], E_ll_a[3, i], calculate_hessian)
+        multiply_sfs!(E_ll_a[4, i], E_ll_a[3, i])
 
         # Band 5 = band 4 * color 4.
         tmp4 = exp(2 * c1[4, i] + 2 * c2[4, i])
         E_ll_a[5, i].d[bids.c1[4]] = E_ll_a[5, i].v[] * 2.
         E_ll_a[5, i].d[bids.c2[4]] = E_ll_a[5, i].v[] * 2.
         if calculate_hessian
-          for hess_ids in [(bids.c1[4], bids.c1[4]),
-                           (bids.c1[4], bids.c2[4]),
-                           (bids.c2[4], bids.c2[4])]
-            set_hess!(E_ll_a[5, i], hess_ids..., E_ll_a[5, i].v[] * 4.0)
-          end
+            for hess_ids in [(bids.c1[4], bids.c1[4]),
+                             (bids.c1[4], bids.c2[4]),
+                             (bids.c2[4], bids.c2[4])]
+                set_hess!(E_ll_a[5, i], hess_ids..., E_ll_a[5, i].v[] * 4.0)
+            end
         end
-        multiply_sfs!(E_ll_a[5, i], E_ll_a[4, i], calculate_hessian)
+        multiply_sfs!(E_ll_a[5, i], E_ll_a[4, i])
 
         # Band 2 = band 3 * color 2
         tmp2 = exp(-2 * c1[2, i] + 2 * c2[2, i])
         E_ll_a[2, i].d[bids.c1[2]] = E_ll_a[2, i].v[] * -2.
         E_ll_a[2, i].d[bids.c2[2]] = E_ll_a[2, i].v[] * 2.
         if calculate_hessian
-          for hess_ids in [(bids.c1[2], bids.c1[2]),
-                           (bids.c2[2], bids.c2[2])]
-            set_hess!(E_ll_a[2, i], hess_ids..., E_ll_a[2, i].v[] * 4.0)
-          end
-          set_hess!(E_ll_a[2, i], bids.c1[2], bids.c2[2],
-                    E_ll_a[2, i].v[] * -4.0)
+            for hess_ids in [(bids.c1[2], bids.c1[2]),
+                             (bids.c2[2], bids.c2[2])]
+                set_hess!(E_ll_a[2, i], hess_ids..., E_ll_a[2, i].v[] * 4.0)
+            end
+            set_hess!(E_ll_a[2, i], bids.c1[2], bids.c2[2],
+                      E_ll_a[2, i].v[] * -4.0)
         end
-        multiply_sfs!(E_ll_a[2, i], E_ll_a[3, i], calculate_hessian)
+        multiply_sfs!(E_ll_a[2, i], E_ll_a[3, i])
 
         # Band 1 = band 2 * color 1
         E_ll_a[1, i].d[bids.c1[1]] = E_ll_a[1, i].v[] * -2.
         E_ll_a[1, i].d[bids.c2[1]] = E_ll_a[1, i].v[] * 2.
         if calculate_hessian
-          for hess_ids in [(bids.c1[1], bids.c1[1]),
-                           (bids.c2[1], bids.c2[1])]
-            set_hess!(E_ll_a[1, i], hess_ids..., E_ll_a[1, i].v[] * 4.0)
-          end
-          set_hess!(E_ll_a[1, i], bids.c1[1], bids.c2[1],
-                    E_ll_a[1, i].v[] * -4.0)
-        end
-        multiply_sfs!(E_ll_a[1, i], E_ll_a[2, i], calculate_hessian)
-      else
-        # Simply update the values if not calculating derivatives.
-        E_ll_a[4, i].v[] *= E_ll_a[3, i].v[]
-        E_ll_a[5, i].v[] *= E_ll_a[4, i].v[]
-        E_ll_a[2, i].v[] *= E_ll_a[3, i].v[]
-        E_ll_a[1, i].v[] *= E_ll_a[2, i].v[]
-      end # calculate_derivs
-  end
+            for hess_ids in [(bids.c1[1], bids.c1[1]),
+                             (bids.c2[1], bids.c2[1])]
+                set_hess!(E_ll_a[1, i], hess_ids..., E_ll_a[1, i].v[] * 4.0)
+            end
+            set_hess!(E_ll_a[1, i], bids.c1[1], bids.c2[1],
+                      E_ll_a[1, i].v[] * -4.0)
+            end
+            multiply_sfs!(E_ll_a[1, i], E_ll_a[2, i])
+        else
+            # Simply update the values if not calculating derivatives.
+            E_ll_a[4, i].v[] *= E_ll_a[3, i].v[]
+            E_ll_a[5, i].v[] *= E_ll_a[4, i].v[]
+            E_ll_a[2, i].v[] *= E_ll_a[3, i].v[]
+            E_ll_a[1, i].v[] *= E_ll_a[2, i].v[]
+        end # calculate_gradient
+    end
 
-  SourceBrightness(E_l_a, E_ll_a)
+    SourceBrightness(E_l_a, E_ll_a)
 end
 
 
@@ -237,14 +239,16 @@ Returns:
 """
 function load_source_brightnesses{NumType <: Number}(
                     ea::ElboArgs{NumType};
-                    calculate_derivs::Bool=true,
+                    calculate_gradient::Bool=true,
                     calculate_hessian::Bool=true)
     sbs = Array(SourceBrightness{NumType}, ea.S)
 
     for s in 1:ea.S
-        calculate_this_deriv = (s in ea.active_sources) && calculate_derivs
-        sbs[s] = SourceBrightness(ea.vp[s],
-        calculate_derivs=calculate_this_deriv, calculate_hessian=calculate_hessian)
+        this_deriv = (s in ea.active_sources) && calculate_gradient
+        this_hess = (s in ea.active_sources) && calculate_hessian
+        sbs[s] = SourceBrightness(ea.vp[s];
+                                  calculate_gradient=this_deriv,
+                                  calculate_hessian=this_hess)
     end
 
     sbs

--- a/src/deterministic_vi_image_psf/fsm_matrices.jl
+++ b/src/deterministic_vi_image_psf/fsm_matrices.jl
@@ -1,7 +1,7 @@
 
-typealias GMatrix Matrix{SensitiveFloat{CanonicalParams, Float64}}
-typealias fs0mMatrix Matrix{SensitiveFloat{StarPosParams, Float64}}
-typealias fs1mMatrix Matrix{SensitiveFloat{GalaxyPosParams, Float64}}
+typealias GMatrix Matrix{SensitiveFloat{Float64}}
+typealias fs0mMatrix Matrix{SensitiveFloat{Float64}}
+typealias fs1mMatrix Matrix{SensitiveFloat{Float64}}
 
 
 type FSMSensitiveFloatMatrices
@@ -62,12 +62,12 @@ function initialize_fsm_sf_matrices_band!(
 
     # An fsm value is only sensitive to one source's parameters.
     fsms.fs1m_image = zero_sensitive_float_array(
-        GalaxyPosParams, Float64, 1, h_width, w_width);
+        Float64, length(GalaxyPosParams), 1, h_width, w_width);
     fsms.fs1m_conv = zero_sensitive_float_array(
-        GalaxyPosParams, Float64, 1, h_width, w_width);
+        Float64, length(GalaxyPosParams), 1, h_width, w_width);
 
     fsms.fs0m_conv = zero_sensitive_float_array(
-        StarPosParams, Float64, 1, h_width, w_width);
+        Float64, length(StarPosParams), 1, h_width, w_width);
 
     # The amount of padding introduced by the convolution
     (fft_size1, fft_size2) =
@@ -79,15 +79,15 @@ function initialize_fsm_sf_matrices_band!(
     fsms.pad_pix_w = Integer((psf_size[2] - 1) / 2)
 
     fsms.fs1m_image_padded = zero_sensitive_float_array(
-        GalaxyPosParams, Float64, 1, fft_size1, fft_size2);
+        Float64, length(GalaxyPosParams), 1, fft_size1, fft_size2);
     fsms.fs1m_conv_padded = zero_sensitive_float_array(
-        GalaxyPosParams, Float64, 1, fft_size1, fft_size2);
+        Float64, length(GalaxyPosParams), 1, fft_size1, fft_size2);
 
     # Brightness images
     fsms.E_G = zero_sensitive_float_array(
-        CanonicalParams, Float64, num_active_sources, h_width, w_width);
+        Float64, length(CanonicalParams), num_active_sources, h_width, w_width);
     fsms.var_G = zero_sensitive_float_array(
-        CanonicalParams, Float64, num_active_sources, h_width, w_width);
+        Float64, length(CanonicalParams), num_active_sources, h_width, w_width);
 
     # Store the psf image and its FFT.
     S = size(psf_image_mat, 1)
@@ -151,14 +151,14 @@ function debug_populate_fsm_vec!(
     lanczos_width::Int)
 
     sbs = load_source_brightnesses(ea,
-        calculate_derivs=ea.elbo_vars.calculate_derivs,
+        calculate_gradient=ea.elbo_vars.calculate_gradient,
         calculate_hessian=ea.elbo_vars.calculate_hessian);
 
     gal_mcs_vec = Array(Array{GalaxyCacheComponent{Float64}, 4}, ea.N);
     for b=1:ea.N
         gal_mcs_vec[b] = load_gal_bvn_mixtures(
                 ea.S, ea.patches, ea.vp, ea.active_sources, b,
-                calculate_derivs=ea.elbo_vars.calculate_derivs,
+                calculate_gradient=ea.elbo_vars.calculate_gradient,
                 calculate_hessian=ea.elbo_vars.calculate_hessian);
     end
 

--- a/src/deterministic_vi_image_psf/lanczos.jl
+++ b/src/deterministic_vi_image_psf/lanczos.jl
@@ -44,7 +44,6 @@ function lanczos_interpolate!{NumType <: Number}(
         wcs_jacobian::Matrix{Float64},
         calculate_gradient::Bool,
         calculate_hessian::Bool)
-    @show image[1].local_P
     @assert image[1].local_P == length(StarPosParams)
 
     a = Float64(lanczos_width)

--- a/src/deterministic_vi_image_psf/lanczos.jl
+++ b/src/deterministic_vi_image_psf/lanczos.jl
@@ -36,27 +36,31 @@ end
 
 
 # Interpolate the PSF to the pixel values.
-function lanczos_interpolate!{NumType <: Number, ParamType <: ParamSet}(
-        image::Matrix{SensitiveFloat{ParamType, NumType}},
+function lanczos_interpolate!{NumType <: Number}(
+        image::Matrix{SensitiveFloat{NumType}},
         psf_image::Matrix{Float64},
         object_loc::Vector{NumType},
         lanczos_width::Int,
         wcs_jacobian::Matrix{Float64},
-        calculate_derivs::Bool,
+        calculate_gradient::Bool,
         calculate_hessian::Bool)
+    @show image[1].local_P
+    @assert image[1].local_P == length(StarPosParams)
 
     a = Float64(lanczos_width)
     h_psf_width = (size(psf_image, 1) + 1) / 2.0
     w_psf_width = (size(psf_image, 2) + 1) / 2.0
 
-    param_ids = getids(ParamType)
+    param_ids = getids(StarPosParams)
 
     # These are sensitive floats representing derviatives of the Lanczos kernel.
-    kernel = zero_sensitive_float(ParamType, NumType, 1)
-    kernel_h = zero_sensitive_float(ParamType, NumType, 1)
+    kernel = SensitiveFloat{NumType}(length(StarPosParams), 1,
+                                     calculate_gradient, calculate_hessian)
+    kernel_h = SensitiveFloat{NumType}(length(StarPosParams), 1,
+                                       calculate_gradient, calculate_hessian)
 
     # Pre-compute terms for transforming derivatives to world coordinates.
-    if calculate_derivs
+    if calculate_gradient
         k_h_grad = wcs_jacobian' * Float64[1, 0]
         k_w_grad = wcs_jacobian' * Float64[0, 1]
 
@@ -84,7 +88,7 @@ function lanczos_interpolate!{NumType <: Number, ParamType <: ParamSet}(
                 clear!(kernel_h)
                 kernel_h.v[] = lh_v
 
-                if calculate_derivs
+                if calculate_gradient
                     # This is -1 * wcs_jacobian' * [lh_d, 0]
                     # and -1 * wcs_jacobian' * [lh_h 0; 0 0] * wcs_jacobian
                     kernel_h.d[param_ids.u] = -1 * k_h_grad * lh_d
@@ -102,15 +106,14 @@ function lanczos_interpolate!{NumType <: Number, ParamType <: ParamSet}(
                         kernel.v[] = lw_v
                         # This is -1 * wcs_jacobian' * [0, lw_d]
                         # and -1 * wcs_jacobian' * [0 0; 0 lw_h] * wcs_jacobian
-                        if calculate_derivs
+                        if calculate_gradient
                             kernel.d[param_ids.u] = -1 * k_w_grad * lw_d;
                             if calculate_hessian
                                 kernel.h[param_ids.u, param_ids.u] = k_w_hess * lw_h;
                             end
-                            multiply_sfs!(kernel, kernel_h, calculate_hessian)
+                            multiply_sfs!(kernel, kernel_h)
                             add_scaled_sfs!(
-                                image[h, w], kernel, psf_image[h_ind, w_ind],
-                                calculate_hessian)
+                                image[h, w], kernel, psf_image[h_ind, w_ind])
                         else
                             image[h, w].v[] +=
                                 kernel.v[] * kernel_h.v[] * psf_image[h_ind, w_ind]

--- a/src/deterministic_vi_image_psf/sensitive_float_fft.jl
+++ b/src/deterministic_vi_image_psf/sensitive_float_fft.jl
@@ -6,10 +6,10 @@ Args:
   - conv_fft: Pre-allocated memory the same size as sf_matrix
   - sf_matrix_out: The FFT of the signal you want to convolve, same size as sf_matrix
 """
-function convolve_sensitive_float_matrix!{ParamType <: ParamSet}(
-    sf_matrix::Matrix{SensitiveFloat{ParamType, Float64}},
-    conv_fft::Matrix{Complex{Float64}},
-    sf_matrix_out::Matrix{SensitiveFloat{ParamType, Float64}})
+function convolve_sensitive_float_matrix!(
+            sf_matrix::Matrix{SensitiveFloat{Float64}},
+            conv_fft::Matrix{Complex{Float64}},
+            sf_matrix_out::Matrix{SensitiveFloat{Float64}})
 
     @assert size(sf_matrix) == size(conv_fft)
 
@@ -30,7 +30,7 @@ function convolve_sensitive_float_matrix!{ParamType <: ParamSet}(
         sf_matrix_out[h, w].v[] = real(fft_matrix[h, w]);
     end
 
-    for sa_d in 1:n_active_sources, ind in 1:length(ParamType)
+    for sa_d in 1:n_active_sources, ind in 1:sf_matrix[1,1].local_P
         for h in h_range, w in w_range
           fft_matrix[h, w] = sf_matrix[h, w].d[ind, sa_d]
         end

--- a/src/model/log_prob.jl
+++ b/src/model/log_prob.jl
@@ -1,7 +1,7 @@
 # Functions to compute the log probability of star parameters and galaxy
 # parameters given pixel data
 using Distributions
-import ..SensitiveFloats: SensitiveFloat, zero_sensitive_float, clear!
+import ..SensitiveFloats: SensitiveFloat, clear!
 
 const eps_prob_a = 1e-6
 
@@ -149,10 +149,11 @@ function state_log_likelihood(is_star::Bool,                # source is star
 
     # create objects needed to compute the mean poisson value per pixel
     # (similar to ElboDeriv.process_active_pixels!)
-    model_vars =
-      ModelIntermediateVariables(Float64, S, length(active_sources))
-    model_vars.calculate_derivs = false
-    model_vars.calculate_hessian= false
+    model_vars = ModelIntermediateVariables(Float64,
+                                            S,
+                                            length(active_sources);
+                                            calculate_gradient=false,
+                                            calculate_hessian=false)
 
     # load star/gal mixture components (make sure these reflect
     gdev, gaxis, gangle, gscale = gal_shape
@@ -172,8 +173,8 @@ function state_log_likelihood(is_star::Bool,                # source is star
 
         star_mcs, gal_mcs = load_bvn_mixtures(S, patches,
                               source_params, active_sources, psf_K, n,
-                              calculate_derivs=model_vars.calculate_derivs,
-                              calculate_hessian=model_vars.calculate_hessian)
+                              calculate_gradient=false,
+                              calculate_hessian=false)
 
         p = patches[active_sources[1], n]
         H2, W2 = size(p.active_pixel_bitmap)
@@ -190,8 +191,6 @@ function state_log_likelihood(is_star::Bool,                # source is star
             populate_fsm_vecs!(model_vars.bvn_derivs,
                                model_vars.fs0m_vec,
                                model_vars.fs1m_vec,
-                               model_vars.calculate_derivs,
-                               model_vars.calculate_hessian,
                                patches, active_sources, num_allowed_sd,
                                n, h, w, gal_mcs, star_mcs)
 

--- a/src/model/param_set.jl
+++ b/src/model/param_set.jl
@@ -17,8 +17,7 @@
 #           (formerly chi)
 # k       = {D|D-1}xIa matrix of color prior component indicators.
 #           (formerly kappa)
-
-import ..SensitiveFloats: ParamSet
+abstract ParamSet
 
 type StarPosParams <: ParamSet
     u::Vector{Int}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,7 +35,8 @@ test_files = setdiff(ARGS, [ long_running_flag ])
 if length(test_files) > 0
     testfiles = ["test_$(arg).jl" for arg in test_files]
 else
-    testfiles = ["test_log_prob.jl",
+    testfiles = [
+                 "test_log_prob.jl",
                  "test_elbo.jl",
                  "test_score.jl",
                  "test_derivatives.jl",
@@ -52,9 +53,7 @@ else
 end
 
 
-if test_long_running
-    warn("Testing ELBO derivatives, which may be slow.")
-else
+if !test_long_running
     warn("Skipping long running tests.  ",
          "To test everything, run tests with the flag ", long_running_flag)
 end

--- a/test/test_fft.jl
+++ b/test/test_fft.jl
@@ -1,12 +1,13 @@
 using Celeste.DeterministicVIImagePSF
 
 using Celeste.DeterministicVI.CanonicalParams
-using Celeste.SensitiveFloats.zero_sensitive_float
 using Celeste.SensitiveFloats.zero_sensitive_float_array
 using Celeste.SensitiveFloats.SensitiveFloat
 using Celeste.SensitiveFloats.clear!
 
 using ForwardDiff
+using Base.Test
+
 
 # Overload some base functions for testing with ForwardDiff
 import Base.floor
@@ -43,7 +44,7 @@ function test_convolve_sensitive_float_matrix()
     DeterministicVIImagePSF.initialize_fsm_sf_matrices_band!(
         fsms, 1, 1, 1, 1, 3, 3, psf_image_mat)
 
-    sf = zero_sensitive_float(GalaxyPosParams, Float64)
+    sf = SensitiveFloat{Float64}(length(GalaxyPosParams), 1, true, true)
     sf.v[] = 3;
     sf.d[:, 1] = rand(size(sf.d, 1))
     h = rand(size(sf.h))
@@ -131,13 +132,14 @@ function test_lanczos_interpolate()
 
     image_size = (11, 11)
     function lanczos_interpolate_loc{T <: Number}(
-        world_loc::Vector{T}, calculate_derivs::Bool)
-        local image = zero_sensitive_float_array(StarPosParams, T, 1, image_size...);
+        world_loc::Vector{T}, calculate_gradient::Bool)
+        local image = zero_sensitive_float_array(T, length(StarPosParams), 1,
+                                                            image_size...)
         local pixel_loc = Celeste.Model.linear_world_to_pix(
             wcs_jacobian, Float64[0., 0.], Float64[1.0, 0.5], world_loc)
         DeterministicVIImagePSF.lanczos_interpolate!(
             image, psf_image, pixel_loc, lanczos_width, wcs_jacobian,
-            calculate_derivs, calculate_derivs)
+            calculate_gradient, calculate_gradient)
         return image
     end
 

--- a/test/test_joint_infer.jl
+++ b/test/test_joint_infer.jl
@@ -27,8 +27,9 @@ function compute_obj_value(results,
     # active_sources = target_sources
     active_sources = collect(1:length(target_sources))
 
-    ea = ElboArgs(images, vp, patches, active_sources)
-    DeterministicVI.elbo(ea, calculate_derivs=false, calculate_hessian=false).v[]
+    ea = ElboArgs(images, vp, patches, active_sources,
+                  calculate_gradient=false, calculate_hessian=false)
+    DeterministicVI.elbo(ea).v[]
 end
 
 """

--- a/test/test_log_prob.jl
+++ b/test/test_log_prob.jl
@@ -13,7 +13,7 @@ test log_prob.jl and log_prob_util.jl
 function test_that_star_truth_is_most_likely_log_prob()
 
     # init ground truth star
-    images, ea, body = true_star_init();
+    images, ea, body = SampleData.true_star_init()
 
     # turn list of catalog entries a list of LatentStateParams
     source_states = [Model.catalog_entry_to_latent_state_params(body[s])

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -1,7 +1,5 @@
 using Base.Test
-
-import Celeste.SensitiveFloats.zero_sensitive_float_array
-
+import SensitiveFloats: zero_sensitive_float_array
 
 function test_sky_noise_estimates()
     images_vec = Array(Vector{Image}, 2)
@@ -20,7 +18,7 @@ end
 
 function test_zero_sensitive_float_array()
     S = 3
-    sf_vec = zero_sensitive_float_array(CanonicalParams, Float64, S, 3, 5)
+    sf_vec = zero_sensitive_float_array(Float64, length(ids), S, 3, 5)
     @test size(sf_vec) == (3, 5)
     for sf in sf_vec
         @test sf.v[] == 0

--- a/test/test_optimization.jl
+++ b/test/test_optimization.jl
@@ -114,7 +114,7 @@ function test_quadratic_optimization()
     centers[ids.k] = [ 0.3 0.3; 0.7 0.7 ]
 
     function quadratic_function{NumType <: Number}(ea::ElboArgs{NumType})
-        val = zero_sensitive_float(CanonicalParams, NumType)
+        val = SensitiveFloat{NumType}(length(ids), 1, true, true)
         val.v[] = -sum((ea.vp[1] - centers) .^ 2)
         val.d[:] = -2.0 * (ea.vp[1] - centers)
         val.h[:, :] = diagm(fill(-2.0, length(CanonicalParams)))

--- a/test/test_psf.jl
+++ b/test/test_psf.jl
@@ -24,22 +24,22 @@ Returns:
 """
 function evaluate_psf_fit{NumType <: Number}(
     psf_params::Vector{Vector{NumType}}, raw_psf::Matrix{Float64},
-    calculate_derivs::Bool)
+    calculate_gradient::Bool)
 
   K = length(psf_params)
-  x_mat = PSF.get_x_matrix_from_psf(raw_psf);
+  x_mat = PSF.get_x_matrix_from_psf(raw_psf)
 
   # TODO: allocate these outside?
-  bvn_derivs = BivariateNormalDerivatives{NumType}(NumType);
-  log_pdf = SensitiveFloats.zero_sensitive_float(PsfParams, NumType, 1);
-  pdf = SensitiveFloats.zero_sensitive_float(PsfParams, NumType, 1);
+  bvn_derivs = BivariateNormalDerivatives{NumType}(NumType)
+  log_pdf = SensitiveFloat{NumType}(length(PsfParams), 1, true, true)
+  pdf = SensitiveFloat{NumType}(length(PsfParams), 1, true, true)
 
-  pixel_value = SensitiveFloats.zero_sensitive_float(PsfParams, NumType, K);
-  squared_error = SensitiveFloats.zero_sensitive_float(PsfParams, NumType, K);
+  pixel_value = SensitiveFloat{NumType}(length(PsfParams), K, true, true)
+  squared_error = SensitiveFloat{NumType}(length(PsfParams), K, true, true)
 
   PSF.evaluate_psf_fit!(
       psf_params, raw_psf, x_mat, bvn_derivs,
-      log_pdf, pdf, pixel_value, squared_error, calculate_derivs)
+      log_pdf, pdf, pixel_value, squared_error, calculate_gradient)
 
   squared_error
 end
@@ -55,23 +55,23 @@ function load_raw_psf(; x::Float64=500., y::Float64=500.)
     @sprintf("%s/%s/%s/%s/psField-%06d-%d-%04d.fit",
         datadir, run_num, camcol_num, field_num,
                  run_num, camcol_num, field_num)
-  psf_fits = FITSIO.FITS(psf_filename);
-  raw_psf_comp = SDSSIO.read_psf(psf_fits, band_letters[b]);
+  psf_fits = FITSIO.FITS(psf_filename)
+  raw_psf_comp = SDSSIO.read_psf(psf_fits, band_letters[b])
   close(psf_fits)
 
-  eval_psf(raw_psf_comp, x, y);
+  eval_psf(raw_psf_comp, x, y)
 end
 
 
 function test_transform_psf_params()
   K = 2
-  psf_params = initialize_psf_params(K, for_test=true);
-  psf_params_original = deepcopy(psf_params);
-  psf_params_free = deepcopy(psf_params);
-  psf_transform = PSF.get_psf_transform(psf_params);
+  psf_params = initialize_psf_params(K, for_test=true)
+  psf_params_original = deepcopy(psf_params)
+  psf_params_free = deepcopy(psf_params)
+  psf_transform = PSF.get_psf_transform(psf_params)
 
-  transform_psf_params!(psf_params, psf_params_free, psf_transform, true);
-  transform_psf_params!(psf_params, psf_params_free, psf_transform, false);
+  transform_psf_params!(psf_params, psf_params_free, psf_transform, true)
+  transform_psf_params!(psf_params, psf_params_free, psf_transform, false)
 
   psf_params_free_2 = unconstrain_psf_params(psf_params, psf_transform)
   psf_params_2 = constrain_psf_params(psf_params_free, psf_transform)
@@ -85,7 +85,7 @@ end
 
 
 function test_psf_fit()
-  raw_psf = load_raw_psf();
+  raw_psf = load_raw_psf()
 
   # Initialize params
   K = 2
@@ -93,20 +93,20 @@ function test_psf_fit()
   psf_param_vec = wrap_psf_params(psf_params)
 
   function pixel_value_wrapper_sf{NumType <: Number}(
-      psf_param_vec::Vector{NumType}, calculate_derivs::Bool)
+      psf_param_vec::Vector{NumType}, calculate_gradient::Bool)
 
     local psf_params = unwrap_psf_params(psf_param_vec)
-    bvn_derivs = BivariateNormalDerivatives{NumType}(NumType);
-    log_pdf = zero_sensitive_float(PsfParams, NumType, 1);
-    pdf = zero_sensitive_float(PsfParams, NumType, 1);
+    bvn_derivs = BivariateNormalDerivatives{NumType}(NumType)
+    log_pdf = SensitiveFloat{NumType}(length(PsfParams), 1, true, true)
+    pdf = SensitiveFloat{NumType}(length(PsfParams), 1, true, true)
 
-    local pixel_value = zero_sensitive_float(PsfParams, NumType, K);
+    local pixel_value = SensitiveFloat{NumType}(length(PsfParams), K, true, true)
 
     local sigma_vec, sig_sf_vec, bvn_vec
-    sigma_vec, sig_sf_vec, bvn_vec = PSF.get_sigma_from_params(psf_params);
+    sigma_vec, sig_sf_vec, bvn_vec = PSF.get_sigma_from_params(psf_params)
 
-    # sigma_vec = Array(Matrix{NumType}, K);
-    # sig_sf_vec = Array(GalaxySigmaDerivs{NumType}, K);
+    # sigma_vec = Array(Matrix{NumType}, K)
+    # sig_sf_vec = Array(GalaxySigmaDerivs{NumType}, K)
     #
     # for k = 1:K
     #   sigma_vec[k] = PSF.get_bvn_cov(psf_params[k][psf_ids.e_axis],
@@ -115,14 +115,14 @@ function test_psf_fit()
     #   sig_sf_vec[k] = GalaxySigmaDerivs(
     #     psf_params[k][psf_ids.e_angle],
     #     psf_params[k][psf_ids.e_axis],
-    #     psf_params[k][psf_ids.e_scale], sigma_vec[k], calculate_derivs);
+    #     psf_params[k][psf_ids.e_scale], sigma_vec[k], calculate_gradient)
     #
     # end
 
     clear!(pixel_value)
     PSF.evaluate_psf_pixel_fit!(
         x, psf_params, sigma_vec, sig_sf_vec, bvn_vec,
-        bvn_derivs, log_pdf, pdf, pixel_value, calculate_derivs)
+        bvn_derivs, log_pdf, pdf, pixel_value, calculate_gradient)
 
     pixel_value
   end
@@ -133,7 +133,7 @@ function test_psf_fit()
 
   x = @SVector [1.0, 2.0]
 
-  sigma_vec = Array(Matrix{Float64}, K);
+  sigma_vec = Array(Matrix{Float64}, K)
   for k = 1:K
     sigma_vec[k] = PSF.get_bvn_cov(psf_params[k][psf_ids.e_axis],
                                     psf_params[k][psf_ids.e_angle],
@@ -143,15 +143,15 @@ function test_psf_fit()
   println("Testing single pixel value")
   psf_components = PsfComponent[
     PsfComponent(psf_params[k][psf_ids.weight], SVector{2,Float64}(psf_params[k][psf_ids.mu]), SMatrix{2,2,Float64,4}(sigma_vec[k]))
-                  for k = 1:K ];
+                  for k = 1:K ]
 
-  psf_rendered = get_psf_at_point(psf_components, rows=[ x[1] ], cols=[ x[2] ])[1];
+  psf_rendered = get_psf_at_point(psf_components, rows=[ x[1] ], cols=[ x[2] ])[1]
   @test_approx_eq psf_rendered pixel_value_wrapper_value(psf_param_vec)
 
-  pixel_value = deepcopy(pixel_value_wrapper_sf(psf_param_vec, true));
+  pixel_value = deepcopy(pixel_value_wrapper_sf(psf_param_vec, true))
 
-  ad_grad = ForwardDiff.gradient(pixel_value_wrapper_value, psf_param_vec);
-  ad_hess = ForwardDiff.hessian(pixel_value_wrapper_value, psf_param_vec);
+  ad_grad = ForwardDiff.gradient(pixel_value_wrapper_value, psf_param_vec)
+  ad_hess = ForwardDiff.hessian(pixel_value_wrapper_value, psf_param_vec)
 
   @test_approx_eq ad_grad pixel_value.d[:]
   @test_approx_eq ad_hess[:] pixel_value.h[:]
@@ -164,22 +164,22 @@ function test_psf_fit()
   keep_pixels = 20:30
 
   function evaluate_psf_fit_wrapper_sf{NumType <: Number}(
-        psf_param_vec::Vector{NumType}, calculate_derivs::Bool)
+        psf_param_vec::Vector{NumType}, calculate_gradient::Bool)
     local psf_params = unwrap_psf_params(psf_param_vec)
     local squared_error =
-      evaluate_psf_fit(psf_params, raw_psf[keep_pixels, keep_pixels], calculate_derivs)
+      evaluate_psf_fit(psf_params, raw_psf[keep_pixels, keep_pixels], calculate_gradient)
     squared_error
   end
 
   function evaluate_psf_fit_wrapper_value{NumType <: Number}(psf_param_vec::Vector{NumType})
-    local squared_error = evaluate_psf_fit_wrapper_sf(psf_param_vec, false);
+    local squared_error = evaluate_psf_fit_wrapper_sf(psf_param_vec, false)
     squared_error.v[]
   end
 
-  squared_error = deepcopy(evaluate_psf_fit_wrapper_sf(psf_param_vec, true));
+  squared_error = deepcopy(evaluate_psf_fit_wrapper_sf(psf_param_vec, true))
 
-  ad_grad = ForwardDiff.gradient(evaluate_psf_fit_wrapper_value, psf_param_vec);
-  ad_hess = ForwardDiff.hessian(evaluate_psf_fit_wrapper_value, psf_param_vec);
+  ad_grad = ForwardDiff.gradient(evaluate_psf_fit_wrapper_value, psf_param_vec)
+  ad_hess = ForwardDiff.hessian(evaluate_psf_fit_wrapper_value, psf_param_vec)
 
   @test_approx_eq ad_grad squared_error.d[:]
   @test_approx_eq ad_hess[:] squared_error.h[:]
@@ -187,13 +187,13 @@ end
 
 
 function test_transform_psf_sensitive_float()
-  raw_psf = load_raw_psf();
+  raw_psf = load_raw_psf()
 
   K = 2
-  psf_params = initialize_psf_params(K, for_test=true);
-  psf_transform = PSF.get_psf_transform(psf_params);
-  psf_params_free = unconstrain_psf_params(psf_params, psf_transform);
-  psf_params_free_vec = wrap_psf_params(psf_params_free)[:];
+  psf_params = initialize_psf_params(K, for_test=true)
+  psf_transform = PSF.get_psf_transform(psf_params)
+  psf_params_free = unconstrain_psf_params(psf_params, psf_transform)
+  psf_params_free_vec = wrap_psf_params(psf_params_free)[:]
 
 
   # Fewer pixels for quick testing.  Also, ForwardDiff.hessian runs into strange
@@ -201,15 +201,15 @@ function test_transform_psf_sensitive_float()
   keep_pixels = 20:30
 
   function psf_fit_for_optim{NumType <: Number}(
-      psf_params_free_vec::Vector{NumType}, calculate_derivs::Bool)
+      psf_params_free_vec::Vector{NumType}, calculate_gradient::Bool)
 
-    local sf_free = zero_sensitive_float(PsfParams, NumType, K);
+    local sf_free = SensitiveFloat{NumType}(length(PsfParams), K, true, true)
     local psf_params_free = unwrap_psf_params(psf_params_free_vec)
     local psf_params = constrain_psf_params(psf_params_free, psf_transform)
     local sf = evaluate_psf_fit(
-      psf_params, raw_psf[keep_pixels, keep_pixels], calculate_derivs);
+      psf_params, raw_psf[keep_pixels, keep_pixels], calculate_gradient)
     transform_psf_sensitive_float!(
-      psf_params, psf_transform, sf, sf_free, calculate_derivs)
+      psf_params, psf_transform, sf, sf_free, calculate_gradient)
 
     sf_free
   end
@@ -220,12 +220,12 @@ function test_transform_psf_sensitive_float()
     psf_fit_for_optim(psf_params_free_vec, false).v[]
   end
 
-  sf_free = deepcopy(psf_fit_for_optim(psf_params_free_vec, true));
+  sf_free = deepcopy(psf_fit_for_optim(psf_params_free_vec, true))
 
   expected_value =
-    evaluate_psf_fit(psf_params, raw_psf[keep_pixels, keep_pixels], false).v[];
-  ad_grad = ForwardDiff.gradient(psf_fit_for_optim_val, psf_params_free_vec);
-  ad_hess = ForwardDiff.hessian(psf_fit_for_optim_val, psf_params_free_vec);
+    evaluate_psf_fit(psf_params, raw_psf[keep_pixels, keep_pixels], false).v[]
+  ad_grad = ForwardDiff.gradient(psf_fit_for_optim_val, psf_params_free_vec)
+  ad_hess = ForwardDiff.hessian(psf_fit_for_optim_val, psf_params_free_vec)
 
   @test_approx_eq expected_value sf_free.v[]
   @test_approx_eq sf_free.d[:] ad_grad
@@ -234,12 +234,12 @@ end
 
 
 function test_psf_optimizer()
-  raw_psf = load_raw_psf();
+  raw_psf = load_raw_psf()
 
   K = 2
-  psf_params = initialize_psf_params(K, for_test=false);
-  psf_transform = get_psf_transform(psf_params);
-  psf_optimizer = PsfOptimizer(psf_transform, K);
+  psf_params = initialize_psf_params(K, for_test=false)
+  psf_transform = get_psf_transform(psf_params)
+  psf_optimizer = PsfOptimizer(psf_transform, K)
 
   nm_result = fit_psf(psf_optimizer, raw_psf, psf_params)
   psf_params_fit =
@@ -249,12 +249,12 @@ function test_psf_optimizer()
   @test 0.0 < Optim.minimum(nm_result) < 1e-3
 
   celeste_psf = fit_raw_psf_for_celeste(raw_psf, K)[1]
-  rendered_psf = get_psf_at_point(celeste_psf);
+  rendered_psf = get_psf_at_point(celeste_psf)
 
   @test_approx_eq Optim.minimum(nm_result) sum((raw_psf - rendered_psf) .^ 2)
 
   # Make sure that re-using the optimizer gets the same results.
-  raw_psf_10_10 = load_raw_psf(x=10., y=10.);
+  raw_psf_10_10 = load_raw_psf(x=10., y=10.)
   celeste_psf_10_10_v1, psf_params_10_10_v1 =
     fit_raw_psf_for_celeste(raw_psf_10_10, K)
   celeste_psf_10_10_v2, psf_params_10_10_v2 =


### PR DESCRIPTION
`SensitiveFloat` instances always allocate memory for gradients and Hessians, regardless of whether gradients and Hessians are being computed. This PR makes those allocations optional, and adds two new booleans to SensitiveFloat: `has_gradient` and `has_hessian`. 

Now that each `SensitiveFloat` records whether it is being used in a gradient or a hessian calculation, it isn't as necessary to pass those `calculate_derivs` and `calculate_hessian` flags around all over the place. For example, to set a every of field of a `SensitiveFloat` to `0`, you'd call `clear!(sf)`, not `clear!(sf, calculate_hessian)`. The new `clear!` method always zeros out the SensitiveFloat's value, the gradient (if it has one), and the Hessian (if it has one). There's no way to mess up and 1) forget to clear a field that is in use, 2) spend cycles clearing a field that isn't used. The latter was happening a lot. 

As a sanity check, with the PR, `benchmark_elbo.jl` shows a 30% drop in memory use, but a 40% drop in runtime. On master:
```
  0.389335 seconds (414.96 k allocations: 17.611 MB, 1.59% gc time)
```
And on this branch:
```
  0.238657 seconds (360.80 k allocations: 11.466 MB)
```

For a version of `benchmark_infer.jl` that doesn't measure the data loading parts, I see a 10% drop in runtime and 20% drop in memory use and memory allocations.
```
  2.140580 seconds (1.52 M allocations: 86.873 MB, 0.59% gc time)
```
vs
```
  1.864795 seconds (1.26 M allocations: 72.500 MB, 0.66% gc time)
```

A few other changes

- I'm using the term `gradient` everywhere now rather than `derivs` because there were places in the code where the latter was being used to refer to both the gradient and the Hessian, and then some places where `derivs` was used to refer only the gradient. The new terminology avoids this ambiguity.
- Newly initialized SensitiveFloats have a value of 0.
- SensitiveFloats no longer are parameterized by a `ParamType`. Doing so causes a new version of every method to be compiles for each `ParamType` it is called with. All a `SensitiveFloat` needs to know if the length of the ParamType, e.g. 32 for `CanonicalParams`. This change also makes `SensitiveFloat` clearer conceptually, because it isn't specific to Celeste's types of parameter vectors.
