### PR TITLE
score Celeste's half-life radius on stripe 82 correctly

### DIFF
--- a/benchmark/speed/benchmark_quarter_degree.jl
+++ b/benchmark/speed/benchmark_quarter_degree.jl
@@ -1,0 +1,53 @@
+#!/usr/bin/env julia
+
+import Celeste.ParallelRun: BoundingBox, infer_box
+import Celeste.SDSSIO: RunCamcolField
+
+
+const rcfs = [
+    RunCamcolField(4264,6,160),
+    RunCamcolField(4264,6,161),
+    RunCamcolField(4264,5,158),
+    RunCamcolField(4264,5,159),
+    RunCamcolField(4264,5,160),
+    RunCamcolField(4264,5,161),
+    RunCamcolField(4264,5,162),
+    RunCamcolField(4294,6,133),
+    RunCamcolField(4294,6,134),
+    RunCamcolField(4294,6,135),
+    RunCamcolField(4294,6,136),
+    RunCamcolField(4294,6,137),
+    RunCamcolField(4294,6,138),
+    RunCamcolField(4294,5,135)]
+
+const datadir = joinpath(Pkg.dir("Celeste"), "test", "data")
+wd = pwd()
+cd(datadir)
+for rcf in rcfs
+    run(`make RUN=$(rcf.run) CAMCOL=$(rcf.camcol) FIELD=$(rcf.field)`)
+end
+cd(wd)
+
+"""
+This benchmark optimizes all the light sources in a
+one-quarter-square-degree region of sky.
+"""
+function benchmark_quarter_degree()
+    box = BoundingBox(124.0, 124.5, 58.5, 59.0)
+
+    warmup_box = BoundingBox(124.2, 124.21, 58.7, 58.71)
+    infer_box(warmup_box, datadir, datadir)
+
+    # resets runtime profiler *and* count for --track-allocation
+    Profile.clear_malloc_data()
+
+    if isempty(ARGS)
+        @time infer_box(box, datadir, datadir)
+    elseif ARGS[1] == "--profile"
+        @profile infer_box(box, datadir, datadir)
+        Profile.print(format=:flat, sortedby=:count)
+    end
+end
+
+
+benchmark_quarter_degree()

--- a/src/DeterministicVI.jl
+++ b/src/DeterministicVI.jl
@@ -46,7 +46,7 @@ function infer_source(images::Vector{Image},
     # It's a bit inefficient to call the next 5 lines every time we optimize_f.
     # But, as long as runtime is dominated by the call to maximize_f, that
     # isn't a big deal.
-    cat_local = vcat(entry, neighbors)
+    cat_local = vcat([entry], neighbors)
     vp = Vector{Float64}[init_source(ce) for ce in cat_local]
     patches = Infer.get_sky_patches(images, cat_local)
     Infer.load_active_pixels!(images, patches)

--- a/src/Stripe82Score.jl
+++ b/src/Stripe82Score.jl
@@ -347,7 +347,7 @@ function get_err_df(truth::DataFrame, predicted::DataFrame)
                         :missed_gals, :mag_r],
                        color_cols,
                        abs_err_cols,
-                       :gal_angle)
+                       [:gal_angle])
 
     col_types = fill(Float64, length(col_Symbols))
     col_types[1] = String

--- a/src/Stripe82Score.jl
+++ b/src/Stripe82Score.jl
@@ -258,7 +258,7 @@ function load_ce!(i::Int, ce::CatalogEntry, df::DataFrame)
     df[i, :gal_fracdev] = ce.gal_frac_dev
     df[i, :gal_ab] = ce.gal_ab
     df[i, :gal_angle] = (180/pi)ce.gal_angle
-    df[i, :gal_scale] = ce.gal_scale
+    df[i, :gal_scale] = ce.gal_scale * sqrt(ce.gal_ab)
     df[i, :objid] = ce.objid
 end
 

--- a/src/cyclades.jl
+++ b/src/cyclades.jl
@@ -252,8 +252,8 @@ function one_node_joint_infer(catalog, target_sources, neighbor_map, images;
 
             # TODO max: refactor this portion? It's reused in infer_source.
             nputs(dt_nodeid, "Thread $(Threads.threadid()) allocating mem for source $(target_sources[cur_source_index]): objid=$(entry.objid)")
-            cat_local = vcat(entry, neighbors)
-            ids_local = vcat(entry_id, neighbor_ids)
+            cat_local = vcat([entry], neighbors)
+            ids_local = vcat([entry_id], neighbor_ids)
 
             #vp = Vector{Float64}[init_source(ce) for ce in cat_local]
             vp = Vector{Float64}[haskey(target_source_variational_params, x) ?

--- a/src/deterministic_vi/elbo_kl.jl
+++ b/src/deterministic_vi/elbo_kl.jl
@@ -142,7 +142,7 @@ function gen_diagmvn_mvn_kl{NumType <: Number}(
 
       kl = sum(diag(precision2) .* vars1) - K
       kl += (diff' * precision2 * diff)[]
-      kl += -sum(log(vars1)) + logdet_cov2
+      kl += -sum(log.(vars1)) + logdet_cov2
       kl = 0.5 * kl
 
       grad_mean = zeros(NumType2, K)

--- a/test/test_derivatives.jl
+++ b/test/test_derivatives.jl
@@ -1282,7 +1282,7 @@ function test_real_image()
     sa = findfirst(objids, objid)
     neighbors = Infer.find_neighbors([sa], catalog, images)[1]
 
-    cat_local = vcat(catalog[sa], catalog[neighbors])
+    cat_local = vcat(catalog[sa:sa], catalog[neighbors])
     vp = Vector{Float64}[init_source(ce) for ce in cat_local]
     patches = Infer.get_sky_patches(images, cat_local)
     ea = ElboArgs(images, vp, patches, [1])


### PR DESCRIPTION
@gostevehoward identified a bug in how galaxy scales are compared while working with galsim data (issue #437). The same problem affects scoring on stripe 82. With the change, scores from `validate_on_stripe82.jl` look very good!

```
│ Row │ field        │ primary   │ celeste   │ diff       │ diff_sd   │ N   │
├─────┼──────────────┼───────────┼───────────┼────────────┼───────────┼─────┤
│ 1   │ position     │ 0.372055  │ 0.238824  │ 0.133232   │ 0.0658357 │ 421 │
│ 2   │ missed_stars │ 0.023753  │ 0.0902613 │ -0.0665083 │ 0.013295  │ 421 │
│ 3   │ missed_gals  │ 0.0570071 │ 0.0190024 │ 0.0380048  │ 0.010859  │ 421 │
│ 4   │ mag_r        │ 0.20105   │ 0.362753  │ -0.161702  │ 0.021012  │ 421 │
│ 5   │ color_ug     │ 1.25429   │ 0.697098  │ 0.557196   │ 0.0549773 │ 374 │
│ 6   │ color_gr     │ 0.3749    │ 0.214061  │ 0.160839   │ 0.0487459 │ 418 │
│ 7   │ color_ri     │ 0.253103  │ 0.169953  │ 0.0831497  │ 0.0493487 │ 421 │
│ 8   │ color_iz     │ 0.308664  │ 0.150345  │ 0.158319   │ 0.0197942 │ 420 │
│ 9   │ gal_fracdev  │ 0.258861  │ 0.314312  │ -0.0554506 │ 0.0237844 │ 175 │
│ 10  │ gal_ab       │ 0.190628  │ 0.126675  │ 0.0639529  │ 0.0105222 │ 175 │
│ 11  │ gal_scale    │ 1.63777   │ 1.75603   │ -0.118254  │ 0.622799  │ 175 │
│ 12  │ gal_angle    │ 17.0412   │ 12.6401   │ 4.40112    │ 1.79078   │ 80  │
```

Now Celeste is better than Photo/primary, or statistically tied (2 SDs), on every metric except `missed gals` and `mag_r` (brightness). The former problem may be patched up in issue #390. The latter problem is very likely due to inaccuracies in what we're treating as the ground truth, that systematically favor Photo.