### PR TITLE
Adjust e_scale to match "area-preserving" definition of half-light radius

### DIFF
--- a/benchmark/galsim/GalsimBenchmark.jl
+++ b/benchmark/galsim/GalsimBenchmark.jl
@@ -137,7 +137,7 @@ function actual_values(ids, star_galaxy_index, params)
         params[ids.u[2]],
         params[ids.e_axis],
         canonical_angle(params) * 180 / pi,
-        params[ids.e_scale],
+        params[ids.e_scale] * sqrt(params[ids.e_axis]),
         exp(params[ids.r1[star_galaxy_index]]),
         exp(params[ids.c1[1, star_galaxy_index]]),
         exp(params[ids.c1[2, star_galaxy_index]]),

--- a/benchmark/galsim/test_case_definitions.py
+++ b/benchmark/galsim/test_case_definitions.py
@@ -8,7 +8,6 @@ TEST_CASE_FNS = []
 ARCSEC_PER_DEGREE = 3600.
 ARCSEC_PER_PIXEL = 0.396 # the value used in SDSS (https://github.com/jeff-regier/Celeste.jl/pull/411)
 DEGREES_PER_PIXEL = ARCSEC_PER_PIXEL / ARCSEC_PER_DEGREE
-PSF_SIGMA_PIXELS = 4
 STAMP_SIZE_PX = 96
 COUNTS_PER_NMGY = 1000.0 # a.k.a. "iota" in Celeste
 


### PR DESCRIPTION
As discussed in #437 (this is "option 2").