### PR TITLE
Termination criteria

### DIFF
--- a/benchmark/stripe82/validate_on_stripe82.jl
+++ b/benchmark/stripe82/validate_on_stripe82.jl
@@ -76,7 +76,7 @@ else
     if length(ARGS) == 0 || ARGS[1] != "--score-only"
         # adding `; objid=...` to the call limits infer_field to that source.
         # Potentially useful for debugging.
-        @time infer_field(rcf, datadir, outdir)
+        @time infer_field(rcf, datadir, outdir, joint_infer=true)
     end
 
     # Calling `score_object_disk(rcf, objid, datadir, truthfile, datadir)`

--- a/src/ParallelRun.jl
+++ b/src/ParallelRun.jl
@@ -360,7 +360,7 @@ bounding box.
 function one_node_infer(rcfs::Vector{RunCamcolField},
                         stagedir::String;
                         joint_infer=false,
-                        joint_infer_n_iters=50,
+                        joint_infer_n_iters=1000,
                         joint_infer_batch_size=60,
                         joint_infer_shuffle=true,
                         objid="",

--- a/src/cyclades.jl
+++ b/src/cyclades.jl
@@ -222,8 +222,7 @@ function one_node_joint_infer(catalog, target_sources, neighbor_map, images;
                               cyclades_partition=true,
                               joint_infer_batch_size=60,
                               within_batch_shuffling=true,
-                              joint_inference_terminate=true,
-                              joint_inference_terminate_percentage=.95,
+                              joint_inference_terminate_percentage=1,
                               n_iters=10)
     # Seed random number generator to ensure the same results per run.
     srand(42)
@@ -369,11 +368,11 @@ function one_node_joint_infer(catalog, target_sources, neighbor_map, images;
             end
         end
 
-        if n_sources_converged >= joint_inference_terminate_percentage * n_sources &&
-            joint_inference_terminate
+        if n_sources_converged >= joint_inference_terminate_percentage * n_sources
             break
         end
     end
+    Log.info("$(n_sources_converged) / $(n_sources) converged")
     Log.info("Done fitting elboargs. Elapsed time: $(toq())")
 
     # Return add results to vector

--- a/src/cyclades.jl
+++ b/src/cyclades.jl
@@ -222,7 +222,7 @@ function one_node_joint_infer(catalog, target_sources, neighbor_map, images;
                               cyclades_partition=true,
                               joint_infer_batch_size=60,
                               within_batch_shuffling=true,
-                              joint_inference_terminate_percentage=1,
+                              joint_inference_terminate_percentage=.95,
                               n_iters=10)
     # Seed random number generator to ensure the same results per run.
     srand(42)
@@ -344,8 +344,6 @@ function one_node_joint_infer(catalog, target_sources, neighbor_map, images;
                 end
             end
         catch ex
-            Log.error(string(ex))
-            exit(-1)
             if is_production_run || nthreads() > 1
                 Log.error(string(ex))
             else

--- a/src/cyclades.jl
+++ b/src/cyclades.jl
@@ -1,5 +1,6 @@
 import FITSIO
 import JLD
+import Optim
 
 import ..Log
 using ..Model
@@ -207,6 +208,12 @@ catalog - the catalog of light sources
 target_sources - light sources to optimize
 neighbor_map - ligh_source index -> neighbor light_source id
 
+cyclades_partition - use the cyclades algorithm to partition into non conflicting batches for updates.
+joint_infer_batch_size - size of a single batch of sources for updates
+within_batch_shuffling - whether or not to process sources within a batch randomly
+joint_inference_terminate - whether to terminate once sources seem to be stable
+joint_inference_terminate_percentage - stop optimization once a certain percentage of sources have been optimized.
+
 Returns:
 
 - Vector of OptimizedSource results
@@ -215,6 +222,8 @@ function one_node_joint_infer(catalog, target_sources, neighbor_map, images;
                               cyclades_partition=true,
                               joint_infer_batch_size=60,
                               within_batch_shuffling=true,
+                              joint_inference_terminate=true,
+                              joint_inference_terminate_percentage=.95,
                               n_iters=10)
     # Seed random number generator to ensure the same results per run.
     srand(42)
@@ -283,6 +292,24 @@ function one_node_joint_infer(catalog, target_sources, neighbor_map, images;
 
     Log.info("Done preallocating array of elboargs. Elapsed time: $(toq())")
 
+    # Keep track of which sources have converged.
+    sources_converged = Dict{Int64, Bool}()
+    for source in target_sources
+        sources_converged[source] = false
+    end
+    n_sources_converged = 0
+
+    function should_optimize_source(src_indx)
+        src_has_converged = sources_converged[target_sources[src_indx]]
+        neighbors_have_converged = true
+        for neighbor in neighbor_map[src_indx]
+            if haskey(sources_converged, neighbor)
+                neighbors_have_converged = neighbors_have_converged && sources_converged[neighbor]
+            end
+        end 
+        return !src_has_converged || !neighbors_have_converged
+    end
+
     # Process partition of sources. Multiple threads call this function in parallel.
     function process_sources(source_assignment::Vector{Int64}, iter)
         try
@@ -297,14 +324,26 @@ function one_node_joint_infer(catalog, target_sources, neighbor_map, images;
                 shuffle!(source_assignment)
             end
             for cur_source_indx in source_assignment
-                cur_entry = catalog[target_sources[cur_source_indx]]
-                iter_count, obj_value, max_x, r = DeterministicVI.maximize_f(
-                    DeterministicVI.elbo,
-                    ea_vec[cur_source_indx],
-                    max_iters=n_newton_steps,
-                    use_default_optim_params=true)
+                # Optimize only if source has not converged or at least
+                # one of its neighbors has not converged
+                if should_optimize_source(cur_source_indx)
+                    cur_entry = catalog[target_sources[cur_source_indx]]
+                    iter_count, obj_value, max_x, r = DeterministicVI.maximize_f(
+                        DeterministicVI.elbo,
+                        ea_vec[cur_source_indx],
+                        max_iters=n_newton_steps,
+                        use_default_optim_params=true)
+                    sources_converged[target_sources[cur_source_indx]] = Optim.converged(r)
+                end
+
+                # Maintain count of sources that have converged
+                if sources_converged[target_sources[cur_source_indx]]
+                    n_sources_converged += 1
+                end
             end
         catch ex
+            Log.error(string(ex))
+            exit(-1)
             if is_production_run || nthreads() > 1
                 Log.error(string(ex))
             else
@@ -317,6 +356,9 @@ function one_node_joint_infer(catalog, target_sources, neighbor_map, images;
     tic()
     n_batches = length(thread_sources_assignment[1])
     for iter = 1:n_iters
+        # Reset number of sources converged
+        n_sources_converged = 0
+        
         # Process every batch of every iteration. We do the batches on the outside
         # Since there is an implicit barrier after the inner threaded for loop below.
         # We want this barrier because there may be conflict _between_ Cyclades batches.
@@ -325,6 +367,11 @@ function one_node_joint_infer(catalog, target_sources, neighbor_map, images;
             Threads.@threads for i = 1:nprocthreads
                 process_sources(thread_sources_assignment[i][batch], iter)
             end
+        end
+
+        if n_sources_converged >= joint_inference_terminate_percentage * n_sources &&
+            joint_inference_terminate
+            break
         end
     end
     Log.info("Done fitting elboargs. Elapsed time: $(toq())")

--- a/src/cyclades.jl
+++ b/src/cyclades.jl
@@ -297,6 +297,7 @@ function one_node_joint_infer(catalog, target_sources, neighbor_map, images;
         sources_converged[source] = false
     end
     n_sources_converged = 0
+    n_sources_converged_lock = SpinLock()
 
     function should_optimize_source(src_indx)
         src_has_converged = sources_converged[target_sources[src_indx]]
@@ -337,7 +338,9 @@ function one_node_joint_infer(catalog, target_sources, neighbor_map, images;
 
                 # Maintain count of sources that have converged
                 if sources_converged[target_sources[cur_source_indx]]
+                    lock(n_sources_converged_lock)
                     n_sources_converged += 1
+                    unlock(n_sources_converged_lock)
                 end
             end
         catch ex


### PR DESCRIPTION
Here are some benchmark results on stripe 82

single inference
```c++
│ Row │ field        │ primary   │ celeste   │ diff       │ diff_sd   │ N   │
├─────┼──────────────┼───────────┼───────────┼────────────┼───────────┼─────┤
│ 1   │ position     │ 0.325255  │ 0.238023  │ 0.0872314  │ 0.0499956 │ 423 │
│ 2   │ missed_stars │ 0.0236407 │ 0.0851064 │ -0.0614657 │ 0.0124957 │ 423 │
│ 3   │ missed_gals  │ 0.0543735 │ 0.0189125 │ 0.035461   │ 0.0105737 │ 423 │
│ 4   │ mag_r        │ 0.199846  │ 0.359353  │ -0.159506  │ 0.0210032 │ 422 │
│ 5   │ color_ug     │ 1.27414   │ 0.705869  │ 0.568269   │ 0.0572582 │ 376 │
│ 6   │ color_gr     │ 0.325773  │ 0.210347  │ 0.115427   │ 0.0169646 │ 419 │
│ 7   │ color_ri     │ 0.202225  │ 0.166646  │ 0.0355791  │ 0.0156357 │ 422 │
│ 8   │ color_iz     │ 0.307054  │ 0.156048  │ 0.151006   │ 0.0202112 │ 422 │
│ 9   │ gal_fracdev  │ 0.261586  │ 0.316576  │ -0.0549897 │ 0.0236274 │ 177 │
│ 10  │ gal_ab       │ 0.192684  │ 0.124943  │ 0.0677414  │ 0.0102626 │ 177 │
│ 11  │ gal_scale    │ 1.68904   │ 1.77017   │ -0.0811269 │ 0.619594  │ 177 │
│ 12  │ gal_angle    │ 17.8127   │ 12.8645   │ 4.94818    │ 1.74678   │ 81  │
```
130.499247 seconds (8 threads)

joint infer @ 1 (585/585 sources converged)

```c++
│ Row │ field        │ primary   │ celeste   │ diff       │ diff_sd   │ N   │
├─────┼──────────────┼───────────┼───────────┼────────────┼───────────┼─────┤
│ 1   │ position     │ 0.461921  │ 0.241025  │ 0.220896   │ 0.107057  │ 425 │
│ 2   │ missed_stars │ 0.0258824 │ 0.103529  │ -0.0776471 │ 0.0136913 │ 425 │
│ 3   │ missed_gals  │ 0.0541176 │ 0.0164706 │ 0.0376471  │ 0.0107595 │ 425 │
│ 4   │ mag_r        │ 0.221218  │ 0.357399  │ -0.136181  │ 0.023306  │ 424 │
│ 5   │ color_ug     │ 1.27552   │ 0.701567  │ 0.573957   │ 0.0571882 │ 377 │
│ 6   │ color_gr     │ 0.326605  │ 0.209495  │ 0.117109   │ 0.0166096 │ 421 │
│ 7   │ color_ri     │ 0.202844  │ 0.165295  │ 0.0375493  │ 0.0154332 │ 424 │
│ 8   │ color_iz     │ 0.311025  │ 0.153971  │ 0.157054   │ 0.0191256 │ 424 │
│ 9   │ gal_fracdev  │ 0.265734  │ 0.31627   │ -0.0505355 │ 0.023274  │ 178 │
│ 10  │ gal_ab       │ 0.193415  │ 0.136412  │ 0.0570025  │ 0.0110832 │ 178 │
│ 11  │ gal_scale    │ 1.74291   │ 1.79126   │ -0.0483564 │ 0.610063  │ 178 │
│ 12  │ gal_angle    │ 17.8127   │ 14.1866   │ 3.62609    │ 1.78741   │ 81  │
```
- 302 seconds (8 threads)

joint infer @ .95 (558/585 sources converged)
```c++
│ Row │ field        │ primary   │ celeste   │ diff       │ diff_sd   │ N   │
├─────┼──────────────┼───────────┼───────────┼────────────┼───────────┼─────┤
│ 1   │ position     │ 0.356997  │ 0.23773   │ 0.119267   │ 0.0780409 │ 423 │
│ 2   │ missed_stars │ 0.0260047 │ 0.104019  │ -0.0780142 │ 0.013753  │ 423 │
│ 3   │ missed_gals  │ 0.0543735 │ 0.0165485 │ 0.0378251  │ 0.010809  │ 423 │
│ 4   │ mag_r        │ 0.20834   │ 0.356602  │ -0.148262  │ 0.0197846 │ 422 │
│ 5   │ color_ug     │ 1.2566    │ 0.686033  │ 0.570571   │ 0.057121  │ 376 │
│ 6   │ color_gr     │ 0.32552   │ 0.20382   │ 0.1217     │ 0.0163246 │ 419 │
│ 7   │ color_ri     │ 0.198864  │ 0.16176   │ 0.0371035  │ 0.0154959 │ 422 │
│ 8   │ color_iz     │ 0.291458  │ 0.133137  │ 0.158321   │ 0.0192617 │ 422 │
│ 9   │ gal_fracdev  │ 0.262856  │ 0.305289  │ -0.0424325 │ 0.0232309 │ 176 │
│ 10  │ gal_ab       │ 0.191816  │ 0.134573  │ 0.0572424  │ 0.0111975 │ 176 │
│ 11  │ gal_scale    │ 1.5971    │ 1.74828   │ -0.151179  │ 0.61436   │ 176 │
│ 12  │ gal_angle    │ 17.3836   │ 13.6815   │ 3.7021     │ 1.80406   │ 80  │
```
- 222.487737 seconds (8 threads)

joint infer @ .9 (540 / 585 sources converged)

```c++
│ Row │ field        │ primary   │ celeste   │ diff       │ diff_sd   │ N   │
├─────┼──────────────┼───────────┼───────────┼────────────┼───────────┼─────┤
│ 1   │ position     │ 0.357356  │ 0.238364  │ 0.118992   │ 0.0773965 │ 422 │
│ 2   │ missed_stars │ 0.0260664 │ 0.104265  │ -0.0781991 │ 0.0137841 │ 422 │
│ 3   │ missed_gals  │ 0.0545024 │ 0.0165877 │ 0.0379147  │ 0.010834  │ 422 │
│ 4   │ mag_r        │ 0.20834   │ 0.356943  │ -0.148603  │ 0.0199333 │ 422 │
│ 5   │ color_ug     │ 1.23383   │ 0.680855  │ 0.552975   │ 0.0547526 │ 375 │
│ 6   │ color_gr     │ 0.32552   │ 0.204252  │ 0.121268   │ 0.0163517 │ 419 │
│ 7   │ color_ri     │ 0.198864  │ 0.16092   │ 0.0379441  │ 0.0154802 │ 422 │
│ 8   │ color_iz     │ 0.290429  │ 0.13021   │ 0.160219   │ 0.0194342 │ 421 │
│ 9   │ gal_fracdev  │ 0.264358  │ 0.309233  │ -0.0448748 │ 0.0233503 │ 175 │
│ 10  │ gal_ab       │ 0.191482  │ 0.13334   │ 0.0581419  │ 0.0112111 │ 175 │
│ 11  │ gal_scale    │ 1.58769   │ 1.74125   │ -0.153563  │ 0.618143  │ 175 │
│ 12  │ gal_angle    │ 16.5969   │ 13.2057   │ 3.39122    │ 1.81539   │ 79  │
```
- 221.194958 seconds (8 threads)