### PR TITLE
match primary results into coadd, not celeste results

### DIFF
--- a/benchmark/stripe82/validate_on_stripe82.jl
+++ b/benchmark/stripe82/validate_on_stripe82.jl
@@ -9,6 +9,7 @@ import Celeste.SDSSIO: RunCamcolField
 import Celeste.DeterministicVI: infer_source
 import Celeste.DeterministicVIImagePSF: infer_source_fft
 
+
 # I'd rather let the user specify a rcf on the command line, but picking
 # an arbitrary rcf isn't too useful without having ground truth for it,
 # from a co-add run. Getting ground truth isn't easy to automate because
@@ -16,7 +17,6 @@ import Celeste.DeterministicVIImagePSF: infer_source_fft
 # At least having these hard coded ensures that we don't compare scores
 # from different regions.
 const rcf = RunCamcolField(4263, 5, 119)
-
 
 # This data might already be there from the unit tests.
 # `make` won't fetch it again if it's already there.


### PR DESCRIPTION
@agnusmaximus @rgiordan  -- This should fix the issue with `N` varying across runs of `validate_on_stripe82.jl`.  Before we were matching Celeste results into Coadd (by location, not thing id), and then looking up Primary objects by `objid`. Now we're matching Primary results into Coadd (again, by location), and then looking up Celeste objects by `objid`. The second approach is better because Primary is constant across runs of `validate_on_stripe82.jl` whereas the Celeste results may vary slightly, causing 1 or 2 sources fewer to be matched on occasion.


`N=423` for single infer:
```
│ Row │ field        │ primary   │ celeste   │ diff       │ diff_sd   │ N   │
├─────┼──────────────┼───────────┼───────────┼────────────┼───────────┼─────┤
│ 1   │ position     │ 0.243422  │ 0.28916   │ -0.0457376 │ 0.0389249 │ 423 │
│ 2   │ missed_stars │ 0.0260047 │ 0.0874704 │ -0.0614657 │ 0.0124957 │ 423 │
│ 3   │ missed_gals  │ 0.0543735 │ 0.0189125 │ 0.035461   │ 0.0105737 │ 423 │
│ 4   │ mag_r        │ 0.202179  │ 0.370661  │ -0.168481  │ 0.0214247 │ 422 │
│ 5   │ color_ug     │ 1.26769   │ 0.705708  │ 0.561985   │ 0.0569545 │ 376 │
│ 6   │ color_gr     │ 0.327099  │ 0.216384  │ 0.110714   │ 0.016137  │ 419 │
│ 7   │ color_ri     │ 0.203595  │ 0.168319  │ 0.0352759  │ 0.0156782 │ 422 │
│ 8   │ color_iz     │ 0.291645  │ 0.139645  │ 0.152      │ 0.020086  │ 423 │
│ 9   │ gal_fracdev  │ 0.272315  │ 0.316787  │ -0.0444725 │ 0.0236397 │ 177 │
│ 10  │ gal_ab       │ 0.190473  │ 0.125808  │ 0.064664   │ 0.0101485 │ 177 │
│ 11  │ gal_scale    │ 1.9531    │ 2.12071   │ -0.167615  │ 0.612314  │ 177 │
│ 12  │ gal_angle    │ 18.182    │ 12.9137   │ 5.26832    │ 1.75487   │ 82  │
```

`N=423` for joint infer:
```
│ Row │ field        │ primary   │ celeste   │ diff       │ diff_sd   │ N   │
├─────┼──────────────┼───────────┼───────────┼────────────┼───────────┼─────┤
│ 1   │ position     │ 0.243422  │ 0.334909  │ -0.0914865 │ 0.0727628 │ 423 │
│ 2   │ missed_stars │ 0.0260047 │ 0.104019  │ -0.0780142 │ 0.013753  │ 423 │
│ 3   │ missed_gals  │ 0.0543735 │ 0.0165485 │ 0.0378251  │ 0.010809  │ 423 │
│ 4   │ mag_r        │ 0.202179  │ 0.370554  │ -0.168375  │ 0.0227576 │ 422 │
│ 5   │ color_ug     │ 1.26769   │ 0.708079  │ 0.559613   │ 0.0557899 │ 376 │
│ 6   │ color_gr     │ 0.327099  │ 0.212819  │ 0.114279   │ 0.0159302 │ 419 │
│ 7   │ color_ri     │ 0.203595  │ 0.16541   │ 0.0381847  │ 0.0155261 │ 422 │
│ 8   │ color_iz     │ 0.291645  │ 0.133696  │ 0.157949   │ 0.0193643 │ 423 │
│ 9   │ gal_fracdev  │ 0.272315  │ 0.316075  │ -0.0437598 │ 0.0231358 │ 177 │
│ 10  │ gal_ab       │ 0.190473  │ 0.135691  │ 0.0547816  │ 0.0109838 │ 177 │
│ 11  │ gal_scale    │ 1.9531    │ 2.12814   │ -0.17504   │ 0.60741   │ 177 │
│ 12  │ gal_angle    │ 18.182    │ 13.1781   │ 5.00395    │ 1.92922   │ 82  │
```