### PR TITLE
Joint infer improve

### DIFF
--- a/benchmark/stripe82/validate_on_stripe82.jl
+++ b/benchmark/stripe82/validate_on_stripe82.jl
@@ -81,7 +81,7 @@ else
     # alone would primarily be useful for debugging.
     if !("--score-only" in ARGS)
         wrap_joint(cnti...) = one_node_joint_infer(cnti...;
-                                                   termination_percent=.95)
+                                                   termination_percent=0.9)
         source_callback = "--fft" in ARGS ? infer_source_fft : infer_source
         wrap_single(cnti...) = one_node_single_infer(cnti...;
                                       infer_source_callback=source_callback)

--- a/benchmark/stripe82/validate_on_stripe82.jl
+++ b/benchmark/stripe82/validate_on_stripe82.jl
@@ -81,7 +81,8 @@ else
     # alone would primarily be useful for debugging.
     if !("--score-only" in ARGS)
         wrap_joint(cnti...) = one_node_joint_infer(cnti...;
-                                                   termination_percent=0.9)
+                                                   termination_percent=.95,
+                                                   n_iters=200)
         source_callback = "--fft" in ARGS ? infer_source_fft : infer_source
         wrap_single(cnti...) = one_node_single_infer(cnti...;
                                       infer_source_callback=source_callback)

--- a/benchmark/stripe82/validate_on_stripe82.jl
+++ b/benchmark/stripe82/validate_on_stripe82.jl
@@ -81,8 +81,7 @@ else
     # alone would primarily be useful for debugging.
     if !("--score-only" in ARGS)
         wrap_joint(cnti...) = one_node_joint_infer(cnti...;
-                                                   termination_percent=.95,
-                                                   n_iters=200)
+                                                   termination_percent=.95)
         source_callback = "--fft" in ARGS ? infer_source_fft : infer_source
         wrap_single(cnti...) = one_node_single_infer(cnti...;
                                       infer_source_callback=source_callback)

--- a/benchmark/stripe82/validate_on_stripe82.jl
+++ b/benchmark/stripe82/validate_on_stripe82.jl
@@ -81,7 +81,7 @@ else
     # alone would primarily be useful for debugging.
     if !("--score-only" in ARGS)
         wrap_joint(cnti...) = one_node_joint_infer(cnti...;
-                                                   termination_percent=0.9)
+                                                   termination_percent=0.95)
         source_callback = "--fft" in ARGS ? infer_source_fft : infer_source
         wrap_single(cnti...) = one_node_single_infer(cnti...;
                                       infer_source_callback=source_callback)

--- a/src/GalsimBenchmark.jl
+++ b/src/GalsimBenchmark.jl
@@ -249,6 +249,7 @@ function main(; test_case_names=String[], print_fn=println)
         println("Running test case '$this_test_case_name'")
         iota = header["CL_IOTA"]
         psf = make_psf(header["CL_SIGMA"])
+        n_sources = header["CL_NSRC"]
 
         band_pixels = [
             extensions[index].pixels for index in first_band_index:(first_band_index + 4)
@@ -260,13 +261,16 @@ function main(; test_case_names=String[], print_fn=println)
 
         # we're only scoring one object per image
         target_sources = [1,]
-
-        # everyone is a neighbor of the target source
         neighbor_map = Infer.find_neighbors(target_sources, catalog, images)
 
+        target_sources_joint = collect(1:n_sources)
+        neighbor_map_joint = Infer.find_neighbors(target_sources_joint, catalog, images)
+
         ctni = (catalog, target_sources, neighbor_map, images)
+        ctni_joint = (catalog, target_sources_joint, neighbor_map_joint, images)
+        
         single_results = one_node_single_infer(ctni...)
-        joint_results = one_node_joint_infer(ctni...)
+        joint_results = one_node_joint_infer(ctni_joint...)
 
         benchmark_data = benchmark_comparison_data(single_results[1].vs,
                                                    joint_results[1].vs,

--- a/src/joint_infer.jl
+++ b/src/joint_infer.jl
@@ -255,8 +255,8 @@ function one_node_joint_infer(catalog, target_sources, neighbor_map, images;
 
     # Pre-allocate dictionary of elboargs, call it ea_vec.
     ea_vec = Array{ElboArgs}(n_sources)
+    ea_first_pass_vec = Array{ElboArgs}(n_sources)
     function initialize_elboargs_sources(sources)
-#        nputs(dt_nodeid, "Thread $(Threads.threadid()) allocating mem for $(length(sources)) sources")
         for cur_source_index in sources
             entry_id = target_sources[cur_source_index]
             entry = catalog[target_sources[cur_source_index]]
@@ -264,18 +264,23 @@ function one_node_joint_infer(catalog, target_sources, neighbor_map, images;
             neighbors = catalog[neighbor_map[cur_source_index]]
 
             # TODO max: refactor this portion? It's reused in infer_source.
-#            nputs(dt_nodeid, "Thread $(Threads.threadid()) allocating mem for source $(target_sources[cur_source_index]): objid=$(entry.objid)")
             cat_local = vcat([entry], neighbors)
             ids_local = vcat([entry_id], neighbor_ids)
 
-            #vp = Vector{Float64}[init_source(ce) for ce in cat_local]
             vp = Vector{Float64}[haskey(target_source_variational_params, x) ?
                         target_source_variational_params[x] :
                         init_source(catalog[x]) for x in ids_local]
             patches = Infer.get_sky_patches(images, cat_local)
             ea = ElboArgs(images, vp, patches, [1])
             Infer.load_active_pixels!(ea.images, ea.patches)
+
+            # The ea_vec array contains elbo args for all target sources
             ea_vec[cur_source_index] = ea
+
+            vp_non_shared = vcat([target_source_variational_params[entry_id]],
+                                 [init_source(catalog[x]) for x in neighbor_ids])
+            ea_non_shared = ElboArgs(images, vp_non_shared, patches, [1])
+            ea_first_pass_vec[cur_source_index] = ea_non_shared
         end
     end
 
@@ -314,9 +319,6 @@ function one_node_joint_infer(catalog, target_sources, neighbor_map, images;
     function process_sources(source_assignment::Vector{Int64}, iter)
         try
 
-            # Use a constant number of newton steps
-            n_newton_steps = 5
-
             # Shuffle the source assignments within each batch of each process.
             # This is disabled by default because it ruins the deterministic outcome
             # required by the test cases.
@@ -328,12 +330,20 @@ function one_node_joint_infer(catalog, target_sources, neighbor_map, images;
                 # one of its neighbors has not converged
                 if should_optimize_source(cur_source_indx)
                     cur_entry = catalog[target_sources[cur_source_indx]]
-                    iter_count, obj_value, max_x, r = DeterministicVI.maximize_f(
-                        DeterministicVI.elbo,
-                        ea_vec[cur_source_indx],
-                        max_iters=n_newton_steps,
-                        use_default_optim_params=true)
-                    sources_converged[target_sources[cur_source_indx]] = Optim.converged(r)
+                    if iter == 1
+                        iter_count, obj_value, max_x, r = DeterministicVI.maximize_f(
+                            DeterministicVI.elbo,
+                            ea_first_pass_vec[cur_source_indx],
+                            max_iters=5,
+                            use_default_optim_params=true)                        
+                    else
+                        iter_count, obj_value, max_x, r = DeterministicVI.maximize_f(
+                            DeterministicVI.elbo,
+                            ea_vec[cur_source_indx],
+                            max_iters=2,
+                            use_default_optim_params=true)
+                        sources_converged[target_sources[cur_source_indx]] = Optim.converged(r)
+                    end
                 end
 
                 # Maintain count of sources that have converged


### PR DESCRIPTION
Fix joint infer in Galsim Benchmark to optimize all sources (not just the first one) since this is required for the joint infer to work.
