### PR TITLE
Use dot notation for broadcast and sum(abs, x) instead of sum(abs(x))

### DIFF
--- a/src/GalsimBenchmark.jl
+++ b/src/GalsimBenchmark.jl
@@ -78,7 +78,7 @@ function typical_band_relative_intensities(is_star::Bool)
     # weight?
     dominant_component = indmax(prior_parameters.k[:, source_type_index])
     # What are the most typical log relative intensities for that component?
-    inter_band_ratios = exp(
+    inter_band_ratios = exp.(
         prior_parameters.c_mean[:, dominant_component, source_type_index]
         - diag(prior_parameters.c_cov[:, :, dominant_component, source_type_index])
     )

--- a/src/PSF.jl
+++ b/src/PSF.jl
@@ -691,11 +691,11 @@ function trim_psf(raw_psf::Array{Float64, 2}; trim_percent=0.999)
                 (w_mid - width):(w_mid + width)]
     end
 
-    psf_tot = sum(abs(raw_psf))
-    while sum(abs(get_trimmed_psf_image())) < trim_percent * psf_tot
+    psf_tot = sum(abs, raw_psf)
+    while sum(abs, get_trimmed_psf_image()) < trim_percent * psf_tot
         width += 1
     end
-    
+
     deepcopy(get_trimmed_psf_image())
 end
 

--- a/test/test_psf.jl
+++ b/test/test_psf.jl
@@ -272,7 +272,7 @@ function test_trim_psf()
     raw_psf = load_raw_psf()
     trim_percent = 0.95
     trimmed_psf = trim_psf(raw_psf; trim_percent=trim_percent)
-    @test sum(abs(trimmed_psf)) >= trim_percent * sum(abs(raw_psf)) 
+    @test sum(abs, trimmed_psf) >= trim_percent * sum(abs, raw_psf)
     @test size(trimmed_psf, 1) < size(raw_psf, 1)
     @test size(trimmed_psf, 2) < size(raw_psf, 2)
 end


### PR DESCRIPTION
to avoid deprecation warnings on 0.6