### PR TITLE
Remove Type argument from BivariateNormalDerivatives constructor

### DIFF
--- a/src/PSF.jl
+++ b/src/PSF.jl
@@ -53,7 +53,7 @@ type PsfOptimizer
                           grtol::Float64=1e-9)
         num_iters = 50
 
-        bvn_derivs = BivariateNormalDerivatives{Float64}(Float64)
+        bvn_derivs = BivariateNormalDerivatives{Float64}()
 
         log_pdf = SensitiveFloat{Float64}(length(PsfParams), 1, true, true)
         pdf = SensitiveFloat{Float64}(length(PsfParams), 1, true, true)

--- a/src/bivariate_normals.jl
+++ b/src/bivariate_normals.jl
@@ -62,31 +62,31 @@ type BivariateNormalDerivatives{NumType <: Number}
   bvn_ss_h::Array{NumType, 2}
   bvn_us_h::Array{NumType, 2}
 
-  function BivariateNormalDerivatives(ThisNumType::DataType)
-    py1 = zeros(ThisNumType, 1)
-    py2 = zeros(ThisNumType, 1)
-    f_pre = zeros(ThisNumType, 1)
+  function BivariateNormalDerivatives()
+    py1 = zeros(NumType, 1)
+    py2 = zeros(NumType, 1)
+    f_pre = zeros(NumType, 1)
 
-    bvn_x_d = zeros(ThisNumType, 2)
-    bvn_sig_d = zeros(ThisNumType, 3)
-    bvn_xx_h = zeros(ThisNumType, 2, 2)
-    bvn_xsig_h = zeros(ThisNumType, 2, 3)
-    bvn_sigsig_h = zeros(ThisNumType, 3, 3)
+    bvn_x_d = zeros(NumType, 2)
+    bvn_sig_d = zeros(NumType, 3)
+    bvn_xx_h = zeros(NumType, 2, 2)
+    bvn_xsig_h = zeros(NumType, 2, 3)
+    bvn_sigsig_h = zeros(NumType, 3, 3)
 
-    dpy1_dsig = zeros(ThisNumType, 3)
-    dpy2_dsig = zeros(ThisNumType, 3)
-    dsiginv_dsig = zeros(ThisNumType, 3, 3)
+    dpy1_dsig = zeros(NumType, 3)
+    dpy2_dsig = zeros(NumType, 3)
+    dsiginv_dsig = zeros(NumType, 3, 3)
 
     # Derivatives wrt u.
-    bvn_u_d = zeros(ThisNumType, 2)
-    bvn_uu_h = zeros(ThisNumType, 2, 2)
+    bvn_u_d = zeros(NumType, 2)
+    bvn_uu_h = zeros(NumType, 2, 2)
 
     # Shape deriviatives.  Here, s stands for "shape".
-    bvn_s_d = zeros(ThisNumType, length(gal_shape_ids))
+    bvn_s_d = zeros(NumType, length(gal_shape_ids))
 
     # The hessians.
-    bvn_ss_h = zeros(ThisNumType, length(gal_shape_ids), length(gal_shape_ids))
-    bvn_us_h = zeros(ThisNumType, 2, length(gal_shape_ids))
+    bvn_ss_h = zeros(NumType, length(gal_shape_ids), length(gal_shape_ids))
+    bvn_us_h = zeros(NumType, 2, length(gal_shape_ids))
 
     new(py1, py2, f_pre,
         bvn_x_d, bvn_sig_d, bvn_xx_h, bvn_xsig_h, bvn_sigsig_h,

--- a/src/deterministic_vi/elbo_args.jl
+++ b/src/deterministic_vi/elbo_args.jl
@@ -81,7 +81,7 @@ function ElboIntermediateVariables(NumType::DataType,
                                    calculate_hessian::Bool=true)
     @assert NumType <: Number
 
-    bvn_derivs = BivariateNormalDerivatives{NumType}(NumType)
+    bvn_derivs = BivariateNormalDerivatives{NumType}()
 
     # fs0m and fs1m accumulate contributions from all bvn components
     # for a given source.
@@ -124,7 +124,7 @@ end
 
 function clear!{NumType <: Number}(elbo_vars::ElboIntermediateVariables{NumType})
     #TODO: don't allocate memory here?
-    elbo_vars.bvn_derivs = BivariateNormalDerivatives{NumType}(NumType)
+    elbo_vars.bvn_derivs = BivariateNormalDerivatives{NumType}()
 
     for s = 1:length(elbo_vars.fs0m_vec)
         clear!(elbo_vars.fs0m_vec[s])

--- a/src/model/fsm_util.jl
+++ b/src/model/fsm_util.jl
@@ -116,7 +116,7 @@ function ModelIntermediateVariables(NumType::DataType,
                                     calculate_hessian::Bool=true)
     @assert NumType <: Number
 
-    bvn_derivs = BivariateNormalDerivatives{NumType}(NumType)
+    bvn_derivs = BivariateNormalDerivatives{NumType}()
 
     # fs0m and fs1m accumulate contributions from all bvn components
     # for a given source.

--- a/test/test_psf.jl
+++ b/test/test_psf.jl
@@ -30,7 +30,7 @@ function evaluate_psf_fit{NumType <: Number}(
   x_mat = PSF.get_x_matrix_from_psf(raw_psf)
 
   # TODO: allocate these outside?
-  bvn_derivs = BivariateNormalDerivatives{NumType}(NumType)
+  bvn_derivs = BivariateNormalDerivatives{NumType}()
   log_pdf = SensitiveFloat{NumType}(length(PsfParams), 1, true, true)
   pdf = SensitiveFloat{NumType}(length(PsfParams), 1, true, true)
 
@@ -96,7 +96,7 @@ function test_psf_fit()
       psf_param_vec::Vector{NumType}, calculate_gradient::Bool)
 
     local psf_params = unwrap_psf_params(psf_param_vec)
-    bvn_derivs = BivariateNormalDerivatives{NumType}(NumType)
+    bvn_derivs = BivariateNormalDerivatives{NumType}()
     log_pdf = SensitiveFloat{NumType}(length(PsfParams), 1, true, true)
     pdf = SensitiveFloat{NumType}(length(PsfParams), 1, true, true)
 


### PR DESCRIPTION
The constructor has access to the type parameters, so the argument is
redundant.

One possible definition could be:
```
BivariateNormalDerivatives{T}(::Type{T}) =
   BivariateNormalDerivatives{T}()
```
which would allow usage like
```
BivariateNormalDerivatives(Float64)
```
rather than
```
BivariateNormalDerivatives{Float64}()
```

However, that doesn't seem necessary in this case.