### PR TITLE
convert celeste's output from jld format to fits format

### DIFF
--- a/nersc/optimized_sources_to_fits.jl
+++ b/nersc/optimized_sources_to_fits.jl
@@ -1,0 +1,34 @@
+#!/usr/bin/env julia
+
+using FITSIO
+using Celeste
+using JLD
+using DataFrames
+
+
+function optimized_sources_to_fits(inpath, outdir)
+    optimized_sources = load(inpath)["results"]
+    sources_df = Celeste.Stripe82Score.celeste_to_df(optimized_sources)
+
+    # stores the optimized sources in an "attribute-major" format
+    # suitable for writing to a fits table
+    sources_dict = Dict{String, Vector}()
+    sources_dict["thingid"] = [os.thingid for os in optimized_sources]
+    for col_symbol in names(sources_df)
+        if !any(isna, sources_df[:, col_symbol]) && col_symbol != :objid
+            sources_dict[string(col_symbol)] = sources_df[col_symbol]
+        end
+    end
+
+    outpath = joinpath(outdir, "$(basename(inpath)[1:end-4]).fits")
+    outfits = FITS(outpath, "w")
+    write(outfits, sources_dict)
+    println("wrote $(length(optimized_sources)) to $outpath")
+end
+
+
+if length(ARGS) != 2 || ARGS[1][end-3:end] != ".jld"
+    println("usage: optimized_sources_to_fits.jl <celeste-*.jld> <outdir>")
+else
+    optimized_sources_to_fits(ARGS[1], ARGS[2])
+end

--- a/src/Celeste.jl
+++ b/src/Celeste.jl
@@ -25,4 +25,8 @@ include("Stripe82Score.jl")
 
 include("CelesteEDA.jl")
 
+import .ParallelRun: BoundingBox, OptimizedSource
+import .SDSSIO: RunCamcolField, CatalogEntry
+export BoundingBox, OptimizedSource, RunCamcolField, CatalogEntry
+
 end # module

--- a/src/Stripe82Score.jl
+++ b/src/Stripe82Score.jl
@@ -291,7 +291,7 @@ function celeste_to_df(results::Vector{OptimizedSource})
         i += 1
         vs = result.vs
 
-        function get_fluxes(i::Int)
+        function get_median_fluxes(i::Int)
             ret = Array(Float64, 5)
             ret[3] = exp(vs[ids.r1[i]] + 0.5 * vs[ids.r2[i]])
             ret[4] = ret[3] * exp(vs[ids.c1[3, i]])
@@ -304,8 +304,8 @@ function celeste_to_df(results::Vector{OptimizedSource})
         ce = CatalogEntry(
             vs[ids.u],
             vs[ids.a[1, 1]] > 0.5,
-            get_fluxes(1),
-            get_fluxes(2),
+            get_median_fluxes(1),
+            get_median_fluxes(2),
             vs[ids.e_dev],
             vs[ids.e_axis],
             vs[ids.e_angle],


### PR DESCRIPTION
I added a script (`nersc/optimized_sources_to_fits.jl`) that converts Celeste's output from the `.jld` format to `.fits` format, to close #381.

@rcthomas -- I thought you could use this script for #288. The `.jld` files from the full-SDSS run are stored in `/global/cscratch1/sd/jregier/celeste_sdds_catalog_jld`. With (hopefully) minor modification, this script should give output in a format suitable for loading onto legacysurvey.org with the fits-to-postgres utility.