### PR TITLE
CelesteEDA: iota after epsilon, not before

### DIFF
--- a/src/CelesteEDA.jl
+++ b/src/CelesteEDA.jl
@@ -93,11 +93,11 @@ function render_source(ea::ElboArgs, s::Int, n::Int;
         else
             error("Unknown field ", field)
         end
-        if include_iota
-            image[h2, w2] *= ea.images[n].iota_vec[h]
-        end
         if include_epsilon
             image[h2, w2] += ea.images[n].epsilon_mat[h, w]
+        end
+        if include_iota
+            image[h2, w2] *= ea.images[n].iota_vec[h]
         end
     end
 
@@ -144,13 +144,12 @@ function render_source_fft(
         w_fsm = w - fsms.w_lower + 1
 
         image[h2, w2] = getfield(fsms, field)[h_fsm, w_fsm].v[]
-        if include_iota
-            image[h2, w2] *= ea.images[n].iota_vec[h]
-        end
         if include_epsilon
             image[h2, w2] += ea.images[n].epsilon_mat[h, w]
         end
-
+        if include_iota
+            image[h2, w2] *= ea.images[n].iota_vec[h]
+        end
     end
 
     return deepcopy(image)


### PR DESCRIPTION
@rgiordan  I may have spotted a bug in `CelesteEDA`. Currently if both `include_iota` and `include_epsilon` are `true`, epsilon gets added to the synthetic image after the pixels are scaled by iota. But epsilon is in nanomaggies, not counts. So I think it epsilon should be added beforehand. Is that the case?