### PR TITLE
Run Celeste on GalSim 500-source field

### DIFF
--- a/benchmark/galsim/Makefile
+++ b/benchmark/galsim/Makefile
@@ -1,21 +1,37 @@
 OUTPUT_DIR := output
 TEST_IMAGES_BASE_URL := http://portal.nersc.gov/project/dasrepo/celeste/galsim_fits
-LATEST_FITS_FILENAME := $(shell cat latest_filenames/latest_galsim_benchmarks.txt)
-LATEST_FITS_PATH := $(OUTPUT_DIR)/$(LATEST_FITS_FILENAME)
+BENCHMARK_FITS_FILENAME := $(shell cat latest_filenames/latest_galsim_benchmarks.txt)
+BENCHMARK_FITS_PATH := $(OUTPUT_DIR)/$(BENCHMARK_FITS_FILENAME)
+FIELD_FITS_FILENAME := $(shell cat latest_filenames/latest_galsim_benchmarks.txt)
+FIELD_FITS_PATH := $(OUTPUT_DIR)/$(FIELD_FITS_FILENAME)
 
 default: benchmark
 
-fetch: $(LATEST_FITS_PATH)
+fetch: $(BENCHMARK_FITS_PATH)
+fetch_field: $(FIELD_FITS_PATH)
 
-benchmark: GalsimBenchmark.jl run_galsim_benchmark.jl $(LATEST_FITS_PATH)
+benchmark: GalsimBenchmark.jl run_galsim_benchmark.jl $(BENCHMARK_FITS_PATH)
 	julia run_galsim_benchmark.jl
 
-$(LATEST_FITS_PATH):
-	echo "Fetching GalSim test images from $(TEST_IMAGES_BASE_URL)/$(LATEST_FITS_FILENAME)"
-	mkdir -p $(OUTPUT_DIR)
-	curl --fail -o $(LATEST_FITS_PATH) $(TEST_IMAGES_BASE_URL)/$(LATEST_FITS_FILENAME)
+field: GalsimBenchmark.jl run_galsim_field.jl $(FIELD_FITS_PATH)
+	julia run_galsim_field.jl
 
-generate_test_images: Vagrantfile bootstrap.sh generate_test_image.py test_case_definitions.py
+$(BENCHMARK_FITS_PATH):
+	echo "Fetching GalSim test images from $(TEST_IMAGES_BASE_URL)/$(BENCHMARK_FITS_FILENAME)"
+	mkdir -p $(OUTPUT_DIR)
+	curl --fail -o $(LATEST_FITS_PATH) $(TEST_IMAGES_BASE_URL)/$(BENCHMARK_FITS_FILENAME)
+
+$(FIELD_FITS_PATH):
+	echo "Fetching GalSim test images from $(TEST_IMAGES_BASE_URL)/$(FIELD_FITS_FILENAME)"
+	mkdir -p $(OUTPUT_DIR)
+	curl --fail -o $(LATEST_FITS_PATH) $(TEST_IMAGES_BASE_URL)/$(FIELD_FITS_FILENAME)
+
+generate_benchmark_fits: Vagrantfile bootstrap.sh generate_test_image.py galsim_benchmarks.py
 	vagrant up
-	vagrant ssh -c 'cd /vagrant && python generate_test_image.py'
+	vagrant ssh -c 'cd /vagrant && python galsim_benchmarks.py'
+	vagrant halt
+
+generate_field_fits: Vagrantfile bootstrap.sh generate_test_image.py galsim_field.py
+	vagrant up
+	vagrant ssh -c 'cd /vagrant && python galsim_field.py'
 	vagrant halt

--- a/benchmark/galsim/Makefile
+++ b/benchmark/galsim/Makefile
@@ -2,7 +2,7 @@ OUTPUT_DIR := output
 TEST_IMAGES_BASE_URL := http://portal.nersc.gov/project/dasrepo/celeste/galsim_fits
 BENCHMARK_FITS_FILENAME := $(shell cat latest_filenames/latest_galsim_benchmarks.txt)
 BENCHMARK_FITS_PATH := $(OUTPUT_DIR)/$(BENCHMARK_FITS_FILENAME)
-FIELD_FITS_FILENAME := $(shell cat latest_filenames/latest_galsim_benchmarks.txt)
+FIELD_FITS_FILENAME := $(shell cat latest_filenames/latest_galsim_field.txt)
 FIELD_FITS_PATH := $(OUTPUT_DIR)/$(FIELD_FITS_FILENAME)
 
 default: benchmark
@@ -19,12 +19,12 @@ field: GalsimBenchmark.jl run_galsim_field.jl $(FIELD_FITS_PATH)
 $(BENCHMARK_FITS_PATH):
 	echo "Fetching GalSim test images from $(TEST_IMAGES_BASE_URL)/$(BENCHMARK_FITS_FILENAME)"
 	mkdir -p $(OUTPUT_DIR)
-	curl --fail -o $(LATEST_FITS_PATH) $(TEST_IMAGES_BASE_URL)/$(BENCHMARK_FITS_FILENAME)
+	curl --fail -o $(BENCHMARK_FITS_PATH) $(TEST_IMAGES_BASE_URL)/$(BENCHMARK_FITS_FILENAME)
 
 $(FIELD_FITS_PATH):
 	echo "Fetching GalSim test images from $(TEST_IMAGES_BASE_URL)/$(FIELD_FITS_FILENAME)"
 	mkdir -p $(OUTPUT_DIR)
-	curl --fail -o $(LATEST_FITS_PATH) $(TEST_IMAGES_BASE_URL)/$(FIELD_FITS_FILENAME)
+	curl --fail -o $(FIELD_FITS_PATH) $(TEST_IMAGES_BASE_URL)/$(FIELD_FITS_FILENAME)
 
 generate_benchmark_fits: Vagrantfile bootstrap.sh generate_test_image.py galsim_benchmarks.py
 	vagrant up

--- a/benchmark/galsim/generate_test_image.py
+++ b/benchmark/galsim/generate_test_image.py
@@ -266,6 +266,7 @@ class GalSimTestCase(object):
             ('CLSIGMA', (self.psf_sigma_pixels, 'Gaussian PSF sigma (px)')),
             ('CLBAND', (band_index + 1, 'color band')),
             ('CLNSRC', (len(self._light_sources), 'number of sources')),
+            ('CLRES', (self.image_parameters.degrees_per_pixel(), 'resolution (degrees/px)')),
         ])
         for source_index, light_source in enumerate(self._light_sources):
             index_str = '{:03d}'.format(source_index + 1)

--- a/benchmark/galsim/latest_filenames/latest_galsim_benchmarks.txt
+++ b/benchmark/galsim/latest_filenames/latest_galsim_benchmarks.txt
@@ -1,1 +1,1 @@
-galsim_benchmarks_0b7bd50da4.fits
+galsim_benchmarks_7ec5149420.fits

--- a/benchmark/galsim/latest_filenames/latest_galsim_field.txt
+++ b/benchmark/galsim/latest_filenames/latest_galsim_field.txt
@@ -1,1 +1,1 @@
-galsim_field_d485f30ae6.fits
+galsim_field_e14652e058.fits

--- a/benchmark/galsim/run_galsim_benchmark.jl
+++ b/benchmark/galsim/run_galsim_benchmark.jl
@@ -21,6 +21,16 @@ for arg in ARGS
     end
 end
 
-GalsimBenchmark.main(
+results = GalsimBenchmark.run_benchmarks(
     test_case_names=test_case_names,
-    infer_source_callback=infer_source_callback)
+    joint_inference=false,
+    infer_source_callback=infer_source_callback,
+)
+joint_results = GalsimBenchmark.run_benchmarks(
+    test_case_names=test_case_names,
+    joint_inference=true,
+)
+
+results[:joint_estimate] = joint_results[:estimate]
+results[:joint_error_sds] = joint_results[:error_sds]
+println(repr(results))

--- a/benchmark/galsim/run_galsim_benchmark.jl
+++ b/benchmark/galsim/run_galsim_benchmark.jl
@@ -21,6 +21,8 @@ for arg in ARGS
     end
 end
 
+srand(12345)
+
 results = GalsimBenchmark.run_benchmarks(
     test_case_names=test_case_names,
     joint_inference=false,

--- a/benchmark/galsim/run_galsim_field.jl
+++ b/benchmark/galsim/run_galsim_field.jl
@@ -1,0 +1,33 @@
+#!/usr/bin/env julia
+
+using DataFrames
+
+import Celeste.GalsimBenchmark
+import Celeste.DeterministicVI: infer_source
+import Celeste.DeterministicVIImagePSF: infer_source_fft
+
+srand(12345)
+
+results = GalsimBenchmark.run_field()
+writetable("galsim_field_results.csv", results)
+
+error_summaries = by(results, :field) do df
+    field = df[1, :field]
+    @assert all(isna(df[:error_sds])) || all(!isna(df[:error_sds]))
+    is_map_estimate = all(isna(df[:error_sds]))
+    if is_map_estimate
+        errors = abs(df[:estimate] .- df[:ground_truth])
+    else
+        errors = df[:error_sds]
+    end
+    DataFrame(
+        pct25=quantile(errors, 0.25),
+        pct50=quantile(errors, 0.5),
+        pct75=quantile(errors, 0.75),
+        max=maximum(errors),
+        mean=mean(errors),
+        frac_within_1=is_map_estimate ? NA : mean(errors .<= 1),
+        frac_within_2=is_map_estimate ? NA : mean(errors .<= 2),
+    )
+end
+println(repr(error_summaries))

--- a/src/GalsimBenchmark.jl
+++ b/src/GalsimBenchmark.jl
@@ -184,7 +184,9 @@ end
 
 function get_ground_truth_dataframe(header, source_index)
     source_field(label) = get_field(header, label, source_index)
-    ground_truth = @data(Any[
+    # this circuitous code seems necessary to construct a DataVector{Float64} with NAs
+    # using @data causes weird bugs -srh
+    ground_truth = DataVector{Any}(Any[
         source_field("CLX"),
         source_field("CLY"),
         source_field("CLRTO"),
@@ -201,7 +203,7 @@ function get_ground_truth_dataframe(header, source_index)
         label=fill(header["CLDESCR"], length(BENCHMARK_PARAMETER_LABELS)),
         source=fill(source_index, length(BENCHMARK_PARAMETER_LABELS)),
         field=BENCHMARK_PARAMETER_LABELS,
-        ground_truth=convert(DataVector{Float64}, ground_truth),
+        ground_truth=DataVector{Float64}(ground_truth)
     )
 end
 


### PR DESCRIPTION
Code to actually run Celeste on the new 500-source field image, along with some associated refactorings.

Here's the summary output:

```
│ Row │ field                        │ pct25      │ pct50      │ pct75       │ max         │ mean        │ frac_within_1 │ frac_within_2 │
├─────┼──────────────────────────────┼────────────┼────────────┼─────────────┼─────────────┼─────────────┼───────────────┼───────────────┤
│ 1   │ "Angle (degrees)"            │ 2.7108     │ 12.301     │ 49.5388     │ 179.044     │ 34.9881     │ NA            │ NA            │
│ 2   │ "Brightness (nMgy)"          │ 3.55416    │ 36.1541    │ 86.4531     │ 229.441     │ 48.8631     │ 0.114         │ 0.184         │
│ 3   │ "Color band 1-2 ratio"       │ 0.91544    │ 1.96917    │ 5.2204      │ 38.8232     │ 3.81343     │ 0.27          │ 0.508         │
│ 4   │ "Color band 2-3 ratio"       │ 1.1659     │ 3.03828    │ 6.11335     │ 25.5365     │ 4.26606     │ 0.212         │ 0.394         │
│ 5   │ "Color band 3-4 ratio"       │ 1.06422    │ 2.58081    │ 5.62078     │ 28.4668     │ 4.02687     │ 0.236         │ 0.422         │
│ 6   │ "Color band 4-5 ratio"       │ 0.693415   │ 1.65219    │ 3.7318      │ 27.9538     │ 2.86134     │ 0.356         │ 0.552         │
│ 7   │ "Half-light radius (pixels)" │ 2.92       │ 8.27315    │ 13.1355     │ 52.6417     │ 8.72262     │ NA            │ NA            │
│ 8   │ "Minor/major axis ratio"     │ 0.131155   │ 0.318093   │ 0.566737    │ 0.93024     │ 0.356196    │ NA            │ NA            │
│ 9   │ "Probability of galaxy"      │ 0.00500005 │ 0.00500061 │ 0.00742938  │ 0.995       │ 0.241918    │ NA            │ NA            │
│ 10  │ "X center (world coords)"    │ 3.84637e-6 │ 2.47892e-5 │ 0.000556245 │ 0.000980243 │ 0.000233997 │ NA            │ NA            │
│ 11  │ "Y center (world coords)"    │ 3.72948e-6 │ 2.25078e-5 │ 0.000459289 │ 0.000981193 │ 0.000228589 │ NA            │ NA            │
```

The columns show the quartiles, max and mean "error" for each field. "Error" is raw absolute error (in measurement units) for fields that use a MAP estimate, while for fields with a posterior distn, it's that divided by the posterior standard deviation. Last two columns report ratio of estimates within 1 and 2 posterior standard deviations.

Here's the full output: [galsim_field_results.csv.zip](https://github.com/jeff-regier/Celeste.jl/files/683845/galsim_field_results.csv.zip)

The errors obviously don't look very good and there is probably a bug in my benchmark driver, but I wanted to get this up for you to take a look before digging into it.
