### PR TITLE
Transform vec joint

### DIFF
--- a/src/Transform.jl
+++ b/src/Transform.jl
@@ -647,7 +647,7 @@ function get_mp_transform{NumType <: Number}(
                           vp::VariationalParams{NumType},
                           active_sources::Vector{Int};
                           loc_scale=1.0,
-                          loc_width=1.5e-3)
+                          loc_width=1e-4)
     bounds = Array(ParamBounds, length(active_sources))
 
     # Note that, for numerical reasons, the bounds must be on the scale

--- a/src/joint_infer.jl
+++ b/src/joint_infer.jl
@@ -306,8 +306,11 @@ function one_node_joint_infer(catalog, target_sources, neighbor_map, images;
                                                                    ea.active_sources)
             end
         catch ex
-            Log.error(string(ex))
-            exit(-1)
+            if is_production_run || nthreads() > 1
+                Log.error(string(ex))
+            else
+                rethrow(ex)
+            end
         end
     end
 
@@ -355,8 +358,6 @@ function one_node_joint_infer(catalog, target_sources, neighbor_map, images;
                     use_default_optim_params=use_default_optim_params)
             end
         catch ex
-            Log.error(stringe(ex))
-            exit(-1)
             if is_production_run || nthreads() > 1
                 Log.error(string(ex))
             else

--- a/test/test_joint_infer.jl
+++ b/test/test_joint_infer.jl
@@ -99,7 +99,7 @@ function compare_vp_params(r1, r2)
             return false
         end
     end
-
+    
     return length(r1) == length(r2)
 end
 


### PR DESCRIPTION
Fix for https://github.com/jeff-regier/Celeste.jl/issues/523
- Preallocate array of transform values, and persist them across maximize_f calls

stripe82 --joint
```c++
│ Row │ field        │ primary   │ celeste   │ diff        │ diff_sd    │ N   │
├─────┼──────────────┼───────────┼───────────┼─────────────┼────────────┼─────┤
│ 1   │ position     │ 0.243098  │ 0.235851  │ 0.00724705  │ 0.00713436 │ 417 │
│ 2   │ missed_stars │ 0.0263789 │ 0.100719  │ -0.0743405  │ 0.0139415  │ 417 │
│ 3   │ missed_gals  │ 0.0455635 │ 0.0263789 │ 0.0191847   │ 0.00996414 │ 417 │
│ 4   │ mag_r        │ 0.189753  │ 0.192812  │ -0.00305961 │ 0.0152683  │ 416 │
│ 5   │ color_ug     │ 1.25994   │ 0.733271  │ 0.526667    │ 0.0588452  │ 370 │
│ 6   │ color_gr     │ 0.30301   │ 0.183025  │ 0.119985    │ 0.0157226  │ 413 │
│ 7   │ color_ri     │ 0.18629   │ 0.120609  │ 0.0656811   │ 0.015259   │ 416 │
│ 8   │ color_iz     │ 0.285698  │ 0.139442  │ 0.146256    │ 0.0192315  │ 417 │
│ 9   │ gal_fracdev  │ 0.260406  │ 0.203652  │ 0.0567534   │ 0.0221176  │ 173 │
│ 10  │ gal_ab       │ 0.189946  │ 0.142031  │ 0.0479149   │ 0.0113366  │ 173 │
│ 11  │ gal_scale    │ 1.54675   │ 0.597384  │ 0.949368    │ 0.850287   │ 173 │
│ 12  │ gal_angle    │ 17.6112   │ 13.1947   │ 4.41658     │ 1.77449    │ 81  │
```

stripe82 --joint --fft
```c++
│ Row │ field        │ primary   │ celeste   │ diff       │ diff_sd    │ N   │
├─────┼──────────────┼───────────┼───────────┼────────────┼────────────┼─────┤
│ 1   │ position     │ 0.243098  │ 0.267466  │ -0.0243672 │ 0.00925981 │ 417 │
│ 2   │ missed_stars │ 0.0263789 │ 0.0551559 │ -0.028777  │ 0.00996414 │ 417 │
│ 3   │ missed_gals  │ 0.0455635 │ 0.0407674 │ 0.00479616 │ 0.0109604  │ 417 │
│ 4   │ mag_r        │ 0.189753  │ 0.287484  │ -0.097731  │ 0.0224436  │ 416 │
│ 5   │ color_ug     │ 1.25994   │ 0.752436  │ 0.507502   │ 0.060071   │ 370 │
│ 6   │ color_gr     │ 0.30301   │ 0.209093  │ 0.0939176  │ 0.0171674  │ 413 │
│ 7   │ color_ri     │ 0.18629   │ 0.151705  │ 0.0345847  │ 0.0154696  │ 416 │
│ 8   │ color_iz     │ 0.285698  │ 0.175232  │ 0.110466   │ 0.0205173  │ 417 │
│ 9   │ gal_fracdev  │ 0.260406  │ 0.218237  │ 0.0421684  │ 0.0236842  │ 173 │
│ 10  │ gal_ab       │ 0.189946  │ 0.146865  │ 0.043081   │ 0.0117984  │ 173 │
│ 11  │ gal_scale    │ 1.54675   │ 0.641874  │ 0.904878   │ 0.849957   │ 173 │
│ 12  │ gal_angle    │ 17.6112   │ 14.0432   │ 3.56804    │ 1.7484     │ 81  │
```