### PR TITLE
Set `min_radius_pix` for GalSim unit tests

### DIFF
--- a/src/DeterministicVI.jl
+++ b/src/DeterministicVI.jl
@@ -111,7 +111,8 @@ Arguments:
 """
 function infer_source(images::Vector{Image},
                       neighbors::Vector{CatalogEntry},
-                      entry::CatalogEntry)
+                      entry::CatalogEntry;
+                      min_radius_pix=Nullable{Float64}())
     if length(neighbors) > 100
         Log.warn("Excessive number ($(length(neighbors))) of neighbors")
     end
@@ -122,7 +123,7 @@ function infer_source(images::Vector{Image},
     cat_local = vcat([entry], neighbors)
     vp = init_sources([1], cat_local)
     patches = Infer.get_sky_patches(images, cat_local)
-    Infer.load_active_pixels!(images, patches)
+    Infer.load_active_pixels!(images, patches, min_radius_pix=min_radius_pix)
 
     ea = ElboArgs(images, vp, patches, [1])
     f_evals, max_f, max_x, nm_result = maximize_f(elbo, ea)

--- a/src/DeterministicVIImagePSF.jl
+++ b/src/DeterministicVIImagePSF.jl
@@ -43,11 +43,12 @@ export elbo_likelihood_with_fft!, FSMSensitiveFloatMatrices,
 
 function infer_source_fft(images::Vector{Image},
                           neighbors::Vector{CatalogEntry},
-                          entry::CatalogEntry)
+                          entry::CatalogEntry;
+                          min_radius_pix=Nullable{Float64}())
    cat_local = vcat([entry], neighbors)
    vp = init_sources([1], cat_local)
    patches = get_sky_patches(images, cat_local)
-   load_active_pixels!(images, patches)
+   load_active_pixels!(images, patches, min_radius_pix=min_radius_pix)
 
    ea_fft, fsm_mat = initialize_fft_elbo_parameters(
        images, vp, patches, [1], use_raw_psf=false)

--- a/src/Infer.jl
+++ b/src/Infer.jl
@@ -76,15 +76,9 @@ function find_neighbors(target_sources::Vector{Int64},
 end
 
 
-"""
-  noise_fraction: The proportion of the noise below which we will remove pixels.
-  min_radius_pix: A minimum pixel radius to be included.
-"""
 function get_sky_patches(images::Vector{Image},
                          catalog::Vector{CatalogEntry};
-                         radius_override_pix=NaN,
-                         noise_fraction=0.1,
-                         min_radius_pix=8.0)
+                         radius_override_pix=NaN)
     N = length(images)
     S = length(catalog)
     patches = Array(SkyPatch, S, N)
@@ -141,7 +135,8 @@ function load_active_pixels!(images::Vector{Image},
                              patches::Matrix{SkyPatch};
                              exclude_nan=true,
                              noise_fraction=0.5,
-                             min_radius_pix=8.0)
+                             min_radius_pix=Nullable{Float64}())
+    min_radius_pix = get(min_radius_pix, 8.0)
     S, N = size(patches)
 
     for n = 1:N, s=1:S

--- a/src/deterministic_vi_image_psf/elbo_image_psf.jl
+++ b/src/deterministic_vi_image_psf/elbo_image_psf.jl
@@ -365,10 +365,11 @@ function initialize_fft_elbo_parameters(
     active_sources::Vector{Int};
     use_raw_psf=true,
     use_trimmed_psf=true,
-    allocate_fsm_mat=true)
+    allocate_fsm_mat=true,
+    min_radius_pix=Nullable{Float64}())
 
     ea = ElboArgs(images, vp, patches, active_sources, psf_K=1)
-    load_active_pixels!(images, ea.patches; exclude_nan=false)
+    load_active_pixels!(images, ea.patches; exclude_nan=false, min_radius_pix=min_radius_pix)
 
     fsm_mat = nothing
     if allocate_fsm_mat

--- a/src/joint_infer.jl
+++ b/src/joint_infer.jl
@@ -227,7 +227,8 @@ function one_node_joint_infer(catalog, target_sources, neighbor_map, images;
                               batch_size=60,
                               within_batch_shuffling=true,
                               n_iters=3,
-                              use_default_optim_params=true)
+                              use_default_optim_params=true,
+                              min_radius_pix=Nullable{Float64}())
     # Seed random number generator to ensure the same results per run.
     srand(42)
 
@@ -279,7 +280,7 @@ function one_node_joint_infer(catalog, target_sources, neighbor_map, images;
                 ids_local = vcat([entry_id], neighbor_ids)
 
                 patches = Infer.get_sky_patches(images, cat_local)
-                Infer.load_active_pixels!(images, patches)
+                Infer.load_active_pixels!(images, patches, min_radius_pix=min_radius_pix)
 
                 # Load vp with shared target source params, and also vp
                 # that doesn't share target source params

--- a/test/test_galsim_benchmarks.jl
+++ b/test/test_galsim_benchmarks.jl
@@ -3,11 +3,11 @@ using Base.Test
 import Celeste: GalsimBenchmark
 
 GALSIM_CASES_EXERCISED = [
-    #"simple_star", "probability of galaxy" is wrong (#482)
-    #"star_with_noise",
+    "simple_star",
+    "star_with_noise",
     "angle_and_axis_ratio_1",
     "galaxy_with_all",
-    #"galaxy_with_noise", half-light radius and brightness are wrong (#482)
+    "galaxy_with_noise",
 ]
 
 function assert_estimates_are_close(benchmark_results)

--- a/test/test_infer.jl
+++ b/test/test_infer.jl
@@ -65,7 +65,7 @@ function test_load_active_pixels()
     # the star is bright but it doesn't cover the whole image.
     # it's hard to say exactly how many pixels should be active,
     # but not all of them, and not none of them.
-    Infer.load_active_pixels!(ea.images, ea.patches; min_radius_pix=0.0)
+    Infer.load_active_pixels!(ea.images, ea.patches; min_radius_pix=Nullable(0.0))
 
     # most star light (>90%) should be recorded by the active pixels
     num_active_photons = 0.0
@@ -102,7 +102,7 @@ function test_load_active_pixels()
 
     # only 2 pixels per image are within 0.6 pixels of the
     # source's center (10.9, 11.5)
-    Infer.load_active_pixels!(ea.images, ea.patches; min_radius_pix=0.6)
+    Infer.load_active_pixels!(ea.images, ea.patches; min_radius_pix=Nullable(0.6))
 
     for n in 1:ea.N
 #  FIXME: is load active pixels off by (0.5, 0.5)?


### PR DESCRIPTION
This gets the GalSim unit tests passing again, per #537.

This is the simplest implementation but I think adding all these keyword args is ugly and not sustainable. First, it's just ugly to have a web of kw args spreading through the code. Second, because you want to make it optional, but don't want to duplicate the default value so many times, you end up doing all this Nullable business, which isn't particularly pretty in Julia. (You could alternatively make a global const holding the default value but I find that ugly too for all the global references.)

I don't know of a good clean alternative (setting global flags is a bad idea in my opinion) other than trying to solve the problem more holistically. There's just no easy way to pass options deep down into the call tree from the top level, that I know of. One possibility would be to make a big Configuration type, which holds options like this for the entire Celeste engine. I think it'd be best structured as a nested set of types, with a structure roughly mirroring the high-level modules of the Celeste code. (I'm using "modules" informally, not implying it has to match the Julia module structure of Celeste exactly.)

For example, maybe three modules of the Celeste code are 1) image preparation (choosing patches, active pixels, etc), 2) multiple source handling (single/joint inference & threading), 3) the inference method (MOG, FFT). (This is probably not a good/accurate separation but bear with me for the sake of example.) You might have something like

```julia
type ImagePreparationConfig
  radius_override_px::Nullable{Float64}
  min_radius_px::Float64
  noise_fraction::Float64
end
ImagePreparationConfig() = ImagePreparationConfig(Nullable{Float64}(), 8.0, 0.5)

abstract InferenceConfig
type MixtureOfGaussiansConfig <: InferenceConfig ...(options)... end
type ImageFFTConfig <: InferenceConfig ...(options)... end

abstract MultipleSourceConfig
type SingleInferConfig <: MultipleSourceConfig
  inference_config::InferenceConfig
  ...
end
type JoinInferConfig <: MultipleSourceConfig
  inference_config::InferenceConfig
  ...
end

type CelesteConfig
  image_preparation_config::ImagePreparationConfig
  multiple_source_config::MultipleSourceConfig
end
CelesteConfig() = ...(defaults)...

function run_celeste(config::CelesteConfig, catalog, images, target_sources, ...etc...)
  patches = prepare_images(config.image_preparation_config, images, catalog)
  results = run_inference(config.multiple_source_config, patches, catalog, target_sources)
  ...etc...
end

function run_inference(config::SingleInferConfig, ...)
  ...
  results = infer_source(config.inference_config, ...)
  ...
end
function run_inference(config::JointInferConfig, ...)
  ...
  results = infer_source(config.inference_config, ...)
  ...
end

# in DeterministicVI.jl
function infer_source(config::MixtureOfGaussiansConfig, images, neighbors, entry) ...
# in DeterministicVIImagePSF
function infer_source(config::ImageFFTConfig, images, neighbors, entry) ...

# top-level caller
config = CelesteConfig()
config.image_preparation_config.min_radius_px = 40.0
config.inference_config = ImageFFTConfig()
run_celeste(config, catalog, ...)
```

Some notable things:
* Top-level caller code is clean, and only does as much work as it wants to to customize the defaults.
* Defaults are encoded in one place, the config constructor.
* Each submodule only receives the config relevant to its operation, which should make the code a bit easier to understand (than if a single giant config object were passed everywhere).
* Instead of having different entry points for different versions of a module (e.g., `infer_source()` and `infer_source_fft()`) and explicitly dispatching with conditionals or callback params (e.g., `infer_source_callback`), we dispatch a single entry point method call on the type of the config object, for each module.

This is benefits but it's not simple, which is why I coded the "simple" approach in this PR so you can see it. Of course we don't need a mass conversion, this could be implemented somewhat piecemeal.

I also admit this is inspired by how I'd structure such a thing in an OO paradigm, so I hope there's a simpler, equally beneficial and more idiomatic solution in the Julia paradigm which I'm not thinking of, if so let me know!