### PR TITLE
faint sources & pixel visit counts

### DIFF
--- a/benchmark/speed/benchmark_four_light_sources.jl
+++ b/benchmark/speed/benchmark_four_light_sources.jl
@@ -11,7 +11,10 @@ cd(datadir)
 run(`make`)
 cd(wd)
 
-
+"""
+This benchmark operates on a box of the sky that contains
+four light sources. 170,474 pixel-visits in total.
+"""
 function benchmark_four_light_sources()
     # very small patch of sky that turns out to have 4 sources.
     # We checked that this patch is in the given field.
@@ -24,7 +27,7 @@ function benchmark_four_light_sources()
     ctni = (catalog, target_sources, neighbor_map, images)
 
     # Warm up---this compiles the code
-    one_node_joint_infer(ctni...; use_fft=true)
+    #one_node_joint_infer(ctni...; use_fft=true)
 
     # clear allocations in case julia is running with --track-allocations=user
     Profile.clear_malloc_data()

--- a/benchmark/speed/benchmark_one_light_source.jl
+++ b/benchmark/speed/benchmark_one_light_source.jl
@@ -4,7 +4,7 @@ import Celeste.ParallelRun: one_node_joint_infer, infer_init, BoundingBox
 import Celeste.SDSSIO: RunCamcolField, load_field_images
 import Celeste.Infer: find_neighbors
 import Celeste.DeterministicVIImagePSF: infer_source_fft
-
+import Celeste.DeterministicVIImagePSF
 
 const datadir = joinpath(Pkg.dir("Celeste"), "test", "data")
 wd = pwd()
@@ -12,7 +12,12 @@ cd(datadir)
 run(`make RUN=7713 CAMCOL=3 FIELD=152`)
 cd(wd)
 
-
+"""
+This benchmark operates on a box of the sky that contains just
+one light source. It visits 1048 pixels per evaluation of the elbo,
+and the optimizer runs for 37 iterations, for 38,776 pixel-visits
+in total.
+"""
 function benchmark_one_light_source()
     box = BoundingBox(347.7444, 347.7446, 16.6202, 16.6204)
     rcfs = [RunCamcolField(7713, 3, 152)]

--- a/benchmark/speed/benchmark_sixteenth_degree.jl
+++ b/benchmark/speed/benchmark_sixteenth_degree.jl
@@ -7,6 +7,10 @@ import Celeste.DeterministicVIImagePSF: infer_source_fft
 import Celeste.DeterministicVI: infer_source
 
 const rcfs = [
+    RunCamcolField(4294,6,136),
+    RunCamcolField(4264,5,158),
+    RunCamcolField(4264,5,159),
+    RunCamcolField(4264,5,161),
     RunCamcolField(4264,6,160),
     RunCamcolField(4264,5,160),
     RunCamcolField(4294,6,135),
@@ -29,13 +33,14 @@ function benchmark_sixteenth_degree()
 
     wrap_joint(cnti...) = one_node_joint_infer(cnti...; use_fft=true)
 
+#=
     warmup_box = BoundingBox(124.25, 124.26, 58.7, 58.71)
     warmup_rcfs = get_overlapping_fields(warmup_box, datadir)
     one_node_infer(warmup_rcfs,
                    datadir;
                    infer_callback=wrap_joint,
                    box=warmup_box)
-
+=#
     rcfs = get_overlapping_fields(box, datadir)
 
     # resets runtime profiler *and* count for --track-allocation

--- a/benchmark/speed/benchmark_sixteenth_degree.jl
+++ b/benchmark/speed/benchmark_sixteenth_degree.jl
@@ -6,6 +6,7 @@ import Celeste.SDSSIO: RunCamcolField
 import Celeste.DeterministicVIImagePSF: infer_source_fft
 import Celeste.DeterministicVI: infer_source
 
+
 const rcfs = [
     RunCamcolField(4294,6,136),
     RunCamcolField(4264,5,158),
@@ -27,20 +28,20 @@ cd(wd)
 """
 This benchmark optimizes all the light sources in a
 one-sixteenth-square-degree region of sky.
+It has 34,278,282 pixel-visits.
 """
 function benchmark_sixteenth_degree()
     box = BoundingBox(124.25, 124.50, 58.5, 58.75)
 
     wrap_joint(cnti...) = one_node_joint_infer(cnti...; use_fft=true)
 
-#=
     warmup_box = BoundingBox(124.25, 124.26, 58.7, 58.71)
     warmup_rcfs = get_overlapping_fields(warmup_box, datadir)
     one_node_infer(warmup_rcfs,
                    datadir;
                    infer_callback=wrap_joint,
                    box=warmup_box)
-=#
+
     rcfs = get_overlapping_fields(box, datadir)
 
     # resets runtime profiler *and* count for --track-allocation

--- a/src/ParallelRun.jl
+++ b/src/ParallelRun.jl
@@ -291,10 +291,6 @@ function infer_init(rcfs::Vector{RunCamcolField},
                         duplicate_policy=duplicate_policy)
     Log.info("$(length(catalog)) primary sources")
 
-    # Filter out low-flux objects in the catalog.
-    catalog = filter(entry->(maximum(entry.star_fluxes) >= MIN_FLUX), catalog)
-    Log.info("$(length(catalog)) primary sources after MIN_FLUX cut")
-
     # Get indicies of entries in the RA/Dec range of interest.
     entry_in_range = entry->((box.ramin < entry.pos[1] < box.ramax) &&
                              (box.decmin < entry.pos[2] < box.decmax))

--- a/src/deterministic_vi_image_psf/elbo_image_psf.jl
+++ b/src/deterministic_vi_image_psf/elbo_image_psf.jl
@@ -227,6 +227,8 @@ function accumulate_source_image_brightness!(
 end
 
 
+pixel_counter = 0
+
 """
 Uses the values in fsms to add the contribution from this band to the ELBO.
 """
@@ -261,6 +263,7 @@ function accumulate_band_in_elbo!(
             if !p.active_pixel_bitmap[h_patch, w_patch]
                 continue
             end
+            global pixel_counter += 1
             h_image = h_patch + p.bitmap_offset[1]
             w_image = w_patch + p.bitmap_offset[2]
 

--- a/src/deterministic_vi_image_psf/elbo_image_psf.jl
+++ b/src/deterministic_vi_image_psf/elbo_image_psf.jl
@@ -227,8 +227,6 @@ function accumulate_source_image_brightness!(
 end
 
 
-pixel_counter = 0
-
 """
 Uses the values in fsms to add the contribution from this band to the ELBO.
 """
@@ -263,7 +261,6 @@ function accumulate_band_in_elbo!(
             if !p.active_pixel_bitmap[h_patch, w_patch]
                 continue
             end
-            global pixel_counter += 1
             h_image = h_patch + p.bitmap_offset[1]
             w_image = w_patch + p.bitmap_offset[2]
 


### PR DESCRIPTION
This PR removes the cut for faint light sources. Celeste performs especially well on faint light sources now!

This PR also adds comments to each of the 3 benchmarks scripts indicating how many pixels (non-unique) are visited during its execution. With these statistics, we should be able to extrapolate the number of floating point ops, from faster benchmarks to slower benchmarks.