### PR TITLE
four -> seven in benchmark name

### DIFF
--- a/benchmark/speed/benchmark_seven_light_sources.jl
+++ b/benchmark/speed/benchmark_seven_light_sources.jl
@@ -13,9 +13,10 @@ cd(wd)
 
 """
 This benchmark operates on a box of the sky that contains
-four light sources. 170,474 pixel-visits in total.
+seven light sources. During the optimization, some pixel is visited
+254,771 times (``pixel visits'').
 """
-function benchmark_four_light_sources()
+function benchmark_seven_light_sources()
     # very small patch of sky that turns out to have 4 sources.
     # We checked that this patch is in the given field.
     box = BoundingBox(164.39, 164.41, 39.11, 39.13)
@@ -27,7 +28,8 @@ function benchmark_four_light_sources()
     ctni = (catalog, target_sources, neighbor_map, images)
 
     # Warm up---this compiles the code
-    #one_node_joint_infer(ctni...; use_fft=true)
+    ctni2 = (catalog, target_sources[1:1], neighbor_map[1:1], images[1:1])
+    one_node_joint_infer(ctni2...; use_fft=true)
 
     # clear allocations in case julia is running with --track-allocations=user
     Profile.clear_malloc_data()
@@ -42,4 +44,4 @@ function benchmark_four_light_sources()
 end
 
 
-benchmark_four_light_sources()
+benchmark_seven_light_sources()

--- a/benchmark/speed/benchmark_sixteenth_degree.jl
+++ b/benchmark/speed/benchmark_sixteenth_degree.jl
@@ -28,7 +28,8 @@ cd(wd)
 """
 This benchmark optimizes all the light sources in a
 one-sixteenth-square-degree region of sky.
-It has 34,278,282 pixel-visits.
+During the optimization, a pixel is visited
+35,937,971 times (``pixel visits'').
 """
 function benchmark_sixteenth_degree()
     box = BoundingBox(124.25, 124.50, 58.5, 58.75)

--- a/src/ParallelRun.jl
+++ b/src/ParallelRun.jl
@@ -279,8 +279,7 @@ function one_node_infer(rcfs::Vector{RunCamcolField},
                         infer_callback=one_node_single_infer,
                         objid="",
                         box=BoundingBox(-1000., 1000., -1000., 1000.),
-                        primary_initialization=true,
-                        timing=InferTiming())
+                        primary_initialization=true)
     catalog, target_sources, images, neighbor_map =
         infer_init(rcfs,
                    stagedir;
@@ -291,7 +290,7 @@ function one_node_infer(rcfs::Vector{RunCamcolField},
     Log.info("Running with $(nthreads()) threads")
 
     # NB: All I/O happens above. The methods below don't touch disk.
-    infer_callback(catalog, target_sources, neighbor_map, images; timing=timing)
+    infer_callback(catalog, target_sources, neighbor_map, images)
 end
 
 

--- a/test/test_joint_infer.jl
+++ b/test/test_joint_infer.jl
@@ -269,14 +269,14 @@ function test_different_result_with_different_iter(; use_fft=false)
     box = BoundingBox(154.39, 164.41, 39.11, 39.13)
     field_triplets = [RunCamcolField(3900, 6, 269),]
 
-    infer_few(ctni...; timing=InferTiming()) = one_node_joint_infer(ctni...;
+    infer_few(ctni...) = one_node_joint_infer(ctni...;
                                               n_iters=1,
                                               within_batch_shuffling=false,
                                               use_fft=use_fft)
     result_iter_1 = one_node_infer(field_triplets, datadir;
                                    infer_callback=infer_few, box=box)
 
-    infer_many(ctni...; timing=InferTiming()) = one_node_joint_infer(ctni...;
+    infer_many(ctni...) = one_node_joint_infer(ctni...;
                                                n_iters=5,
                                                within_batch_shuffling=false,
                                                use_fft=use_fft)
@@ -297,7 +297,7 @@ function test_same_result_with_diff_batch_sizes(;use_fft=false)
     field_triplets = [RunCamcolField(3900, 6, 269),]
 
     # With batch size = 7
-    infer_few(ctni...; timing=InferTiming()) = one_node_joint_infer(ctni...;
+    infer_few(ctni...) = one_node_joint_infer(ctni...;
                                 n_iters=3,
                                 batch_size=7,
                                 within_batch_shuffling=false,
@@ -307,7 +307,7 @@ function test_same_result_with_diff_batch_sizes(;use_fft=false)
                                  box=box)
 
     # With batch size = 39
-    infer_many(ctni...; timing=InferTiming()) = one_node_joint_infer(ctni...;
+    infer_many(ctni...) = one_node_joint_infer(ctni...;
                                 n_iters=3,
                                 batch_size=39,
                                 within_batch_shuffling=false,
@@ -349,7 +349,7 @@ function test_one_node_joint_infer_obj_overlapping(;use_fft=false)
 
     # 100 iterations
     tic()
-    infer_multi(ctni...; timing=InferTiming()) = one_node_joint_infer(ctni...;
+    infer_multi(ctni...) = one_node_joint_infer(ctni...;
                                                 n_iters=30,
                                                 within_batch_shuffling=true,
                                                 use_fft=use_fft)
@@ -361,7 +361,7 @@ function test_one_node_joint_infer_obj_overlapping(;use_fft=false)
 
     # 2 iterations
     tic()
-    infer_two(ctni...; timing=InferTiming()) = one_node_joint_infer(ctni...;
+    infer_two(ctni...) = one_node_joint_infer(ctni...;
                                               n_iters=2,
                                               within_batch_shuffling=true,
                                               use_fft=use_fft)


### PR DESCRIPTION
I removed a filter recently that excludes dim light sources. As a result, the number of light sources in the box tested by `benchmark_four_light_sources.jl` increased from 4 to 7. This PR changes the name of the benchmark from `four` to `seven`. It also updates some comments in the benchmark, to account for how many floating point operations we estimate each benchmark requires now that dimmer light sources are included.

Also, this PR fixes unit tests broken by the addition of the `timing` keyword to some functions.