### PR TITLE
Avoid overflow in constrain_to_simplex and add missing assignment

### DIFF
--- a/src/Transform.jl
+++ b/src/Transform.jl
@@ -46,19 +46,20 @@ Convert an (n - 1)-vector of real numbers to an n-vector on the simplex, where
 the last entry implicitly has the untransformed value 1.
 """
 function constrain_to_simplex{NumType <: Number}(x::Vector{NumType})
-    if any(x .== Inf)
+    m = maximum(x)
+    if m == Inf
         # If more than 1 entry in x is Inf, it may be because the
         # the last entry in z is 0. Here we set all those entries to the
         # same value, though that may not be strictly correct.
-        z = NumType[ x_entry .== Inf ? one(NumType) : zero(NumType) for x_entry in x]
-        z ./ sum(z)
+        z   = NumType[ x_entry .== Inf ? one(NumType) : zero(NumType) for x_entry in x]
+        z ./= sum(z)
         push!(z, 0)
         return z
     else
-        z = exp.(x)
-        z_sum = sum(z) + 1
+        z = exp.(x .- m)
+        z_sum = sum(z) + exp(-m)
         z ./= z_sum
-        push!(z, 1 / z_sum)
+        push!(z, inv(z_sum)*exp(-m))
         return z
     end
 end

--- a/test/test_transforms.jl
+++ b/test/test_transforms.jl
@@ -191,6 +191,13 @@ function test_basic_transforms()
     @test Transform.unconstrain_simplex([1.0, 0.0]) ≈ [Inf]
 
     @test Transform.constrain_to_simplex([Inf, 5])  ≈ [1.0, 0.0, 0.0]
+
+    @test sum(Transform.constrain_to_simplex([Inf, Inf])) ≈ 1.0 # Make sure that it's a simplex when there is more than one Inf
+
+    @test sum(Transform.constrain_to_simplex([709.0, 709.0, 709.0])) ≈ 1.0 # sum overflows
+    @test sum(Transform.constrain_to_simplex([710.0, 710.0, 710.0])) ≈ 1.0 # each element overflows
+    @test sum(Transform.constrain_to_simplex([88.0f0, 88.0f0, 88.0f0])) ≈ 1.0f0 # sum overflows
+    @test sum(Transform.constrain_to_simplex([89.0f0, 89.0f0, 89.0f0])) ≈ 1.0f0 # each element overflows
 end
 
 


### PR DESCRIPTION
This uses the log-sum-exp trick to avoid that the simplex constraint gives `NaN`. There was also a missing assignment in the branch that handles cases with infinite values. Consequently, the sum of the simplex parameters wasn't one if two input values were `Inf`. This makes all the tests in `validate_on_stripe82.jl` pass on my machine.

There is a test failure in `test_Transforms.jl`, though. Basically, the test examines the case where all input values are `-Inf` (in this case a single value). Is that really a relevant test case? If so, what is a reasonable value of the simplex parameters if all inputs are `-Inf`?

Fixes #550