### PR TITLE
restore elbo support for dual numbers as argument

### DIFF
--- a/src/SensitiveFloats.jl
+++ b/src/SensitiveFloats.jl
@@ -141,10 +141,16 @@ function combine_sfs!{T1 <: Number, T2 <: Number, T3 <: Number}(
     end
 
     if sf_result.has_gradient
+        for ind in eachindex(sf_result.d)
+            sf_result.d[ind] = g_d[1] * sf1.d[ind] + g_d[2] * sf2.d[ind]
+        end
+#=
         sf_result.d[:] = sf1.d
         n = length(sf_result.d)
+        @show (n, g_d[1], sf_result.d, 1)
         LinAlg.BLAS.scal!(n, g_d[1], sf_result.d, 1)
         LinAlg.BLAS.axpy!(g_d[2], sf2.d, sf_result.d)
+=#
     end
 
     sf_result.v[] = v

--- a/src/deterministic_vi/elbo_objective.jl
+++ b/src/deterministic_vi/elbo_objective.jl
@@ -207,7 +207,7 @@ function calculate_source_pixel_brightness!{NumType <: Number}(
             for u_ind1 = 1:2, u_ind2 = 1:2
                 E_G_s.h[ids.u[u_ind1], ids.u[u_ind2]] =
                     elbo_vars.E_G_s_hsub_vec[1].u_u[u_ind1, u_ind2]
-        
+
                 E_G2_s.h[ids.u[u_ind1], ids.u[u_ind2]] =
                     elbo_vars.E_G2_s_hsub_vec[1].u_u[u_ind1, u_ind2]
             end
@@ -533,11 +533,11 @@ Calculates and returns the ELBO and its derivatives for all the bands
 of an image.
 Returns: A sensitive float containing the ELBO for the image.
 """
-function elbo{T}(ea::ElboArgs{T};
+function elbo{T}(ea::ElboArgs{T},
                  kl_source = SensitiveFloat{T}(length(CanonicalParams), 1,
                                                ea.elbo_vars.elbo.has_gradient,
                                                ea.elbo_vars.elbo.has_hessian),
-                 kl_helper = KLDivergence.KL_HELPER_POOL[threadid()])
+                 kl_helper = KLDivergence.get_kl_helper(T))
     elbo = elbo_likelihood(ea)
     KLDivergence.subtract_kl_all_sources!(ea, elbo, kl_source, kl_helper)
     assert_all_finite(ea.elbo_vars.elbo)

--- a/src/deterministic_vi/elbo_objective.jl
+++ b/src/deterministic_vi/elbo_objective.jl
@@ -533,7 +533,7 @@ Calculates and returns the ELBO and its derivatives for all the bands
 of an image.
 Returns: A sensitive float containing the ELBO for the image.
 """
-function elbo{T}(ea::ElboArgs{T},
+function elbo{T}(ea::ElboArgs{T};
                  kl_source = SensitiveFloat{T}(length(CanonicalParams), 1,
                                                ea.elbo_vars.elbo.has_gradient,
                                                ea.elbo_vars.elbo.has_hessian),

--- a/src/deterministic_vi_image_psf/elbo_image_psf.jl
+++ b/src/deterministic_vi_image_psf/elbo_image_psf.jl
@@ -237,7 +237,7 @@ function accumulate_image_pixel_brightness!{NumType <: Number}(
     E_G::SensitiveFloat{NumType},
     var_G::SensitiveFloat{NumType},
     h::Int, w::Int, n::Int)
-    
+
     clear!(E_G)
     clear!(var_G)
 
@@ -278,7 +278,7 @@ function accumulate_band_in_elbo!(
 
     for s in 1:ea.S
         # Populate the fsm matrices.
-        
+
         # some sources don't appear in some images
         sum(ea.patches[s, n].active_pixel_bitmap) > 0 || continue
 
@@ -288,7 +288,7 @@ function accumulate_band_in_elbo!(
             ea, s, n, fsms.psf, fsms.fs0m_conv,
             fsms.h_lower, fsms.w_lower,
             fsms.kernel_fun, fsms.kernel_width)
-        
+
         is_active_source = s in ea.active_sources
         if !(is_active_source && ea.active_source_star_only)
             # Skip galaxies for active sources if ea.active_source_star_only
@@ -302,7 +302,7 @@ function accumulate_band_in_elbo!(
 
     H_min, W_min, H_max, W_max =
         get_active_pixel_range(ea.patches, ea.active_sources, n)
-        
+
     # Loop over pixels in the image and accumulate the ELBO.
     for h in H_min:H_max, w in W_min: W_max
         # Some pixels that are NaN in the original image may be active
@@ -315,7 +315,7 @@ function accumulate_band_in_elbo!(
 
         accumulate_image_pixel_brightness!(ea, fsm_mat, E_G, var_G, h, w, n)
         elbo = ea.elbo_vars.elbo;
-        
+
         # There are no derivatives with respect to epsilon, so can
         # afely add to the value.
         E_G.v[] += image.epsilon_mat[h, w]
@@ -424,7 +424,7 @@ function get_fft_elbo_function{T}(
         kl_source = SensitiveFloat{T}(length(CanonicalParams),
                                       1, elbo.has_gradient, elbo.has_hessian)
         elbo_likelihood_with_fft!(ea, fsm_mat)
-        kl_helper = KLDivergence.KL_HELPER_POOL[Base.Threads.threadid()]
+        kl_helper = KLDivergence.get_kl_helper(T)
         KLDivergence.subtract_kl_all_sources!(ea, elbo, kl_source, kl_helper)
         return deepcopy(elbo)
     end

--- a/test/test_elbo.jl
+++ b/test/test_elbo.jl
@@ -326,7 +326,9 @@ function test_elbo_supports_dual_numbers()
     # the hessian (it doesn't matter that the "perturbation" are all zero, it's just
     # for testing the speed and verifying that it works)
     P = length(ea0.vp[1])
-    T = ForwardDiff.Dual{P * ea0.S, Float64}
+    # `1` "perterbation" per dual number is enough for a hessian-vector mulitiply,
+    # I think
+    T = ForwardDiff.Dual{1, Float64}
     vp = Vector{T}[zeros(T, P) for s=1:ea0.S]
     for s=1:ea0.S
         vp[s][:] = ea0.vp[s][:]

--- a/test/test_elbo.jl
+++ b/test/test_elbo.jl
@@ -12,6 +12,10 @@ import DeterministicVI.KLDivergence.KLHelper
 import SampleData: gen_two_body_dataset, true_star_init
 
 
+chunksize = ForwardDiff.pickchunksize(length(Model.ids))
+kl_helper = KLHelper(Dual{chunksize, Dual{1, Float64}})
+
+
 function test_set_hess()
     sf = SensitiveFloat{Float64}(length(ids), 1, true, true)
     set_hess!(sf, 2, 3, 5.0)
@@ -339,9 +343,6 @@ function test_elbo_supports_dual_numbers()
 
     # evaluate the elbo for both argument types
     DeterministicVI.elbo(ea0)
-
-    chunksize = ForwardDiff.pickchunksize(length(Model.ids))
-    kl_helper = KLHelper(Dual{chunksize, Dual{1, Float64}})
     DeterministicVI.elbo(ea1; kl_helper=kl_helper)
 end
 

--- a/test/test_elbo.jl
+++ b/test/test_elbo.jl
@@ -4,6 +4,8 @@ using Base.Test
 using Distributions
 using DerivativeTestUtils
 using StaticArrays
+using ForwardDiff
+
 
 import SampleData: gen_two_body_dataset, true_star_init
 
@@ -314,6 +316,30 @@ function test_num_allowed_sd()
 end
 
 
+function test_elbo_supports_dual_numbers()
+    _, ea, _ = gen_two_body_dataset()
+
+    # create elbo arguments of type Float64 that compute the gradient but not the hessian
+    ea0 = ElboArgs(ea.images, ea.vp, ea.patches, ea.active_sources, calculate_hessian=false)
+
+    # create elbo arguments of the Dual number type, that compute the gradient but not
+    # the hessian (it doesn't matter that the "perturbation" are all zero, it's just
+    # for testing the speed and verifying that it works)
+    P = length(ea0.vp[1])
+    T = ForwardDiff.Dual{P * ea0.S, Float64}
+    vp = Vector{T}[zeros(T, P) for s=1:ea0.S]
+    for s=1:ea0.S
+        vp[s][:] = ea0.vp[s][:]
+    end
+    ea1 = ElboArgs(ea0.images, vp, ea0.patches, ea0.active_sources, calculate_hessian=false)
+
+    # evaluate the elbo for both argument types
+    @time DeterministicVI.elbo(ea0)
+    @time DeterministicVI.elbo(ea1)
+end
+
+
+test_elbo_supports_dual_numbers()
 test_active_sources()
 test_set_hess()
 test_bvn_cov()

--- a/test/test_elbo.jl
+++ b/test/test_elbo.jl
@@ -7,13 +7,8 @@ using StaticArrays
 
 using ForwardDiff
 import ForwardDiff.Dual
-import DeterministicVI.KLDivergence.KLHelper
 
 import SampleData: gen_two_body_dataset, true_star_init
-
-
-chunksize = ForwardDiff.pickchunksize(length(Model.ids))
-kl_helper = KLHelper(Dual{chunksize, Dual{1, Float64}})
 
 
 function test_set_hess()
@@ -343,7 +338,7 @@ function test_elbo_supports_dual_numbers()
 
     # evaluate the elbo for both argument types
     DeterministicVI.elbo(ea0)
-    DeterministicVI.elbo(ea1; kl_helper=kl_helper)
+    DeterministicVI.elbo(ea1)
 end
 
 

--- a/test/test_kl.jl
+++ b/test/test_kl.jl
@@ -68,7 +68,7 @@ function test_subtract_kl()
     sf = SensitiveFloat{Float64}(32, 1, true, true)
     vs = rand(MersenneTwister(1), 32)
     kl_result = DiffBase.DiffResult(0.0, sf.d)
-    kl_helper = KLDivergence.KL_HELPER_POOL[Base.Threads.threadid()]
+    kl_helper = KLDivergence.get_kl_helper(Float64)
     KLDivergence.subtract_kl_source!(sf, kl_result, vs, kl_helper)
     @test sf.v[] == DiffBase.value(kl_result)
     @test sf.d === DiffBase.gradient(kl_result)


### PR DESCRIPTION
@jrevels I was trying to compare the runtimes for dual numbers vs Float64, to a get a sense of the overhead, but I'm getting an error from the KL divergence code when I try calling it with ForwardDiff's dual numbers. Any idea what's happening? It's at elbo_kl.jl:187. The test I wrote to recreate this error is part of this branch but not master.

Thanks!

```
jeff@dean ~/git/Celeste/test $ ./runtests.jl elbo
make: Nothing to be done for 'all'.
make: Nothing to be done for 'all'.
make: Nothing to be done for 'fetch'.
WARNING: Skipping long running tests.  To test everything, run tests with the flag --long-running
Running test_elbo.jl
  2.129635 seconds (1.97 M allocations: 76.162 MB, 0.78% gc time)
	FAILED: test_elbo.jl
ERROR: LoadError: LoadError: MethodError: Cannot `convert` an object of type ForwardDiff.Dual{88,Float64} to an object of type Float64
This may have arisen from a call to the constructor Float64(...),
since type constructors fall back to convert methods.
 in copy!(::Base.LinearFast, ::Array{Float64,1}, ::Base.LinearFast, ::Array{ForwardDiff.Dual{88,Float64},1}) at ./abstractarray.jl:559
 in value! at /home/jeff/.julia/v0.5/ReverseDiff/src/tracked.jl:146 [inlined]
 in seeded_forward_pass! at /home/jeff/.julia/v0.5/ReverseDiff/src/api/tape.jl:35 [inlined]
 in gradient!(::DiffBase.DiffResult{1,ForwardDiff.Dual{88,Float64},Tuple{Array{ForwardDiff.Dual{88,Float64},2}}}, ::ReverseDiff.Compiled{ReverseDiff.GradientTape{Celeste.DeterministicVI.KLDivergence.#subtract_kl,ReverseDiff.TrackedArray{Float64,Float64,1,Array{Float64,1},Array{Float64,1}},ReverseDiff.TrackedReal{Float64,Float64,Void}},Celeste.DeterministicVI.KLDivergence.#subtract_kl,ReverseDiff.TrackedArray{Float64,Float64,1,Array{Float64,1},Array{Float64,1}},ReverseDiff.TrackedReal{Float64,Float64,Void},##1#2,##3#4}, ::Array{ForwardDiff.Dual{88,Float64},1}) at /home/jeff/.julia/v0.5/ReverseDiff/src/api/gradients.jl:79
 in subtract_kl_source!(::Celeste.SensitiveFloats.SensitiveFloat{ForwardDiff.Dual{88,Float64}}, ::DiffBase.DiffResult{1,ForwardDiff.Dual{88,Float64},Tuple{Array{ForwardDiff.Dual{88,Float64},2}}}, ::Array{ForwardDiff.Dual{88,Float64},1}, ::Celeste.DeterministicVI.KLDivergence.KLHelper{ReverseDiff.##301#302{ReverseDiff.Compiled{ReverseDiff.GradientTape{Celeste.DeterministicVI.KLDivergence.#subtract_kl,ReverseDiff.TrackedArray{Float64,Float64,1,Array{Float64,1},Array{Float64,1}},ReverseDiff.TrackedReal{Float64,Float64,Void}},Celeste.DeterministicVI.KLDivergence.#subtract_kl,ReverseDiff.TrackedArray{Float64,Float64,1,Array{Float64,1},Array{Float64,1}},ReverseDiff.TrackedReal{Float64,Float64,Void},##1#2,##3#4}},Celeste.DeterministicVI.KLDivergence.##4#6{ForwardDiff.JacobianConfig{9,Float64,Array{ForwardDiff.Dual{9,Float64},1}},Celeste.DeterministicVI.KLDivergence.##3#5{Array{ForwardDiff.Dual{9,Float64},1},ReverseDiff.##301#302{ReverseDiff.Compiled{ReverseDiff.GradientTape{Celeste.DeterministicVI.KLDivergence.#subtract_kl,ReverseDiff.TrackedArray{ForwardDiff.Dual{9,Float64},ForwardDiff.Dual{9,Float64},1,Array{ForwardDiff.Dual{9,Float64},1},Array{ForwardDiff.Dual{9,Float64},1}},ReverseDiff.TrackedReal{ForwardDiff.Dual{9,Float64},ForwardDiff.Dual{9,Float64},Void}},Celeste.DeterministicVI.KLDivergence.#subtract_kl,ReverseDiff.TrackedArray{ForwardDiff.Dual{9,Float64},ForwardDiff.Dual{9,Float64},1,Array{ForwardDiff.Dual{9,Float64},1},Array{ForwardDiff.Dual{9,Float64},1}},ReverseDiff.TrackedReal{ForwardDiff.Dual{9,Float64},ForwardDiff.Dual{9,Float64},Void},##5#6,##7#8}}}}}) at /home/jeff/.julia/v0.5/Celeste/src/deterministic_vi/elbo_kl.jl:187
```