### PR TITLE
excessive neighbors

### DIFF
--- a/src/DeterministicVI.jl
+++ b/src/DeterministicVI.jl
@@ -114,7 +114,9 @@ function infer_source(images::Vector{Image},
                       entry::CatalogEntry;
                       min_radius_pix=Nullable{Float64}())
     if length(neighbors) > 100
-        Log.warn("Excessive number ($(length(neighbors))) of neighbors")
+        msg = string("objid $(entry.objid) [ra: $(entry.pos)] has an excessive",
+                     "number ($(length(neighbors))) of neighbors")
+        Log.warn(msg)
     end
 
     # It's a bit inefficient to call the next 5 lines every time we optimize_f.

--- a/src/Infer.jl
+++ b/src/Infer.jl
@@ -50,9 +50,7 @@ function find_neighbors(target_sources::Vector{Int64},
         @assert radii_map[s] <= 25
     end
 
-    # compute distance in pixels using small-distance approximation
-    dist(ra1, dec1, ra2, dec2) = (3600 / 0.396) * (sqrt((dec2 - dec1)^2 +
-                                  (cos(dec1) * (ra2 - ra1))^2))
+    dist(ra1, dec1, ra2, dec2) = (3600 / 0.396) * max(abs(dec2 - dec1), abs(ra2 - ra1))
 
     neighbor_map = Vector{Int64}[Int64[] for s in target_sources]
 

--- a/src/model/imaged_sources.jl
+++ b/src/model/imaged_sources.jl
@@ -55,7 +55,7 @@ function choose_patch_radius(ce::CatalogEntry,
     flux = ce.is_star ? ce.star_fluxes[img.b] : ce.gal_fluxes[img.b]
     @assert flux > 0.
 
-    # Choose enough pixels that the light is either 90% of the light
+    # Choose enough pixels that the light is either 80% of the light
     # would be captured from a 1d gaussian or 5% of the sky noise,
     # whichever is a larger radius.
     epsilon = img.epsilon_mat[div(img.H, 2), div(img.W, 2)]

--- a/test/test_infer.jl
+++ b/test/test_infer.jl
@@ -144,6 +144,28 @@ function test_patch_pixel_selection()
     end
 end
 
+
+@testset "test that we don't select a patch that is way too big" begin
+    wd = pwd()
+    cd(datadir)
+    run(`make RUN=4114 CAMCOL=3 FIELD=127`)
+    run(`make RUN=4114 CAMCOL=4 FIELD=127`)
+    cd(wd)
+
+    rcfs= [RunCamcolField(4114, 3, 127), RunCamcolField(4114, 4, 127)]
+    images = SDSSIO.load_field_images(rcfs, datadir)
+    catalog = SDSSIO.read_photoobj_files(rcfs, datadir)
+    entry_id = findfirst((ce)->ce.objid == "1237663143711147274", catalog)
+    entry = catalog[entry_id]
+
+    neighbors = Infer.find_neighbors([entry_id,], catalog, images)[1]
+    @show neighbors
+
+    # there's a lot near this star, but not a lot that overlaps with it, see
+    # http://skyserver.sdss.org/dr10/en/tools/explore/summary.aspx?id=0x112d1012607f050a
+    @test length(neighbors) < 5
+end
+
 if test_long_running
     test_infer_rcf()
 end


### PR DESCRIPTION
We were finding an excessive number of neighbors because our distance calculation made no sense. First, it was computing taking the `cos` of degrees---but `cos` in Julia an argument in radians. Second, there's no reason to take that cosine anyway, as as I can tell. Pixel scale is 0.396 arc seconds everywhere in SDSS, regardless of the declination. (@rcthomas Is that correct? Is there any reason to scale the difference in RA by the cosine of the DEC?)

@gostevehoward  Heads up! I think this "distance" formula shows up in `Stripe82Score.jl` too--you were wondering about it, I seem to recall. It probably doesn't throw things off as much there because the stripe 82 declinations are all around 0, and `cos(0)` is about 1, but still, wow, that's a serious bug.

Fixes #562 .