### PR TITLE
`cos` -> `cosd` + unit test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: julia
 os:
   - linux
-  - osx
 julia:
   - 0.5
   - nightly

--- a/src/Stripe82Score.jl
+++ b/src/Stripe82Score.jl
@@ -45,7 +45,7 @@ Return distance in pixels using small-distance approximation. Falls
 apart at poles and RA boundary.
 """
 dist(ra1, dec1, ra2, dec2) = (3600 / 0.396) * (sqrt((dec2 - dec1).^2 +
-                                  (cos(dec1) .* (ra2 - ra1)).^2))
+                                  (cosd(dec1) .* (ra2 - ra1)).^2))
 
 """
 match_position(ras, decs, ra, dec, dist)

--- a/test/test_score.jl
+++ b/test/test_score.jl
@@ -1,7 +1,34 @@
 import Celeste.Stripe82Score
+import FITSIO
+import WCS
 
 
-function test_score_field()
+@testset "test the distance calculation" begin
+    wd = pwd()
+    cd(datadir)
+    # this field is pretty near a pole--high declination means fewer pixels
+    # per arc second of right ascention
+    run(`make RUN=6075 CAMCOL=2 FIELD=29`)
+    high_fits = FITSIO.FITS("6075/2/29/frame-r-006075-2-0029.fits")
+    cd(wd)
+
+    # we're just loaded this image to use its wcs transform
+    high_wcs = WCS.from_header(FITSIO.read_header(high_fits[1], String))[1]
+    pt0_pix = [10; 10.]
+    pt0 = WCS.pix_to_world(high_wcs, pt0_pix)
+    # pt1 is 1 arc second to the right of pt0
+    pt1 = pt0 + [1. / 3600, 0]
+
+    exact_dist = norm(WCS.world_to_pix(high_wcs, pt1) - WCS.world_to_pix(high_wcs, pt0))
+    our_dist = Stripe82Score.dist(pt0..., pt1...)
+
+    # both distances are about 0.315 pixels -- an arc second shift to the right
+    # is less, in pixels, at higher elevations than at the equator, where it's
+    # 1/0.396 ≈ 2.525 pixels per arc second.
+    @test_approx_eq_eps exact_dist our_dist 1e-4
+end
+
+@testset "test scoring a whole field" begin
     results_filename = "celeste-004263-5-0119.jld"
 
     if !isfile(joinpath(datadir, results_filename))
@@ -15,6 +42,3 @@ function test_score_field()
         rcf, joinpath(datadir, results_filename), datadir, truthfile, datadir,
         "results_and_errors_test.jld")
 end
-
-
-test_score_field()


### PR DESCRIPTION
@gostevehoward @rcthomas 

So now I think that the distance formula with `cos` changed to `cosd` is correct. Pixel-scale must only refer to the scale of the pixels at declination 0. It isn't constant across declinations. I'd appreciate you two look over my unit test to confirm my latest thinking.
