### PR TITLE
unit tests and a bug fix

### DIFF
--- a/src/DeterministicVI.jl
+++ b/src/DeterministicVI.jl
@@ -17,6 +17,8 @@ using ..Transform
 import DataFrames
 import Optim
 using StaticArrays
+import ForwardDiff.Dual
+import Base.convert
 
 export ElboArgs, generic_init_source, catalog_init_source, init_sources
 

--- a/src/deterministic_vi/elbo_args.jl
+++ b/src/deterministic_vi/elbo_args.jl
@@ -197,7 +197,7 @@ type ElboArgs{NumType <: Number}
     # If this is set to Inf, the bivariate normals will be evaluated at all
     # points irrespective of their distance from the mean.
     num_allowed_sd::Float64
-    
+
     # If true, only render star parameters for active sources.
     active_source_star_only::Bool
 
@@ -241,4 +241,30 @@ function ElboArgs{NumType <: Number}(
                                           calculate_hessian=calculate_hessian)
     ElboArgs(S, N, psf_K, images, vp, patches,
              active_sources, num_allowed_sd, false, elbo_vars)
+end
+
+
+function convert(::Type{ElboArgs{Dual{1, Float64}}}, ea::ElboArgs{Float64})
+    T = Dual{1, Float64}
+    P = length(CanonicalParams)
+    vp = Vector{T}[zeros(T, P) for s=1:ea.S]
+    for s in 1:ea.S
+        vp[s][:] = ea.vp[s]
+    end
+    ElboArgs(ea.images, vp, ea.patches, ea.active_sources,
+             psf_K=ea.psf_K,
+             num_allowed_sd=ea.num_allowed_sd,
+             calculate_gradient=ea.elbo_vars.elbo.has_gradient,
+             calculate_hessian=ea.elbo_vars.elbo.has_hessian)
+end
+
+
+function ElboArgs{NumType <: Number}(ea::ElboArgs{NumType};
+                                     calculate_gradient=true,
+                                     calculate_hessian=true)
+    ElboArgs(ea.images, ea.vp, ea.patches, ea.active_sources,
+             psf_K=ea.psf_K,
+             num_allowed_sd=ea.num_allowed_sd,
+             calculate_gradient=calculate_gradient,
+             calculate_hessian=calculate_hessian)
 end

--- a/src/model/fsm_util.jl
+++ b/src/model/fsm_util.jl
@@ -220,18 +220,14 @@ function accum_galaxy_pos!{NumType <: Number}(
     f = bvn_derivs.f_pre[1] * gcc.e_dev_i
     fs1m.v[] += f
 
-    if fs1m.has_hessian && is_active_source
-
+    if fs1m.has_gradient && is_active_source
         get_bvn_derivs!(bvn_derivs, gcc.bmc,
                         fs1m.has_gradient, fs1m.has_hessian)
         transform_bvn_derivs!(
             bvn_derivs, gcc.sig_sf, wcs_jacobian, fs1m.has_hessian)
 
         bvn_u_d = bvn_derivs.bvn_u_d
-        bvn_uu_h = bvn_derivs.bvn_uu_h
         bvn_s_d = bvn_derivs.bvn_s_d
-        bvn_ss_h = bvn_derivs.bvn_ss_h
-        bvn_us_h = bvn_derivs.bvn_us_h
 
         # Accumulate the derivatives.
         for u_id in 1:2
@@ -249,6 +245,9 @@ function accum_galaxy_pos!{NumType <: Number}(
 
         if fs1m.has_hessian
             # The Hessians:
+            bvn_uu_h = bvn_derivs.bvn_uu_h
+            bvn_ss_h = bvn_derivs.bvn_ss_h
+            bvn_us_h = bvn_derivs.bvn_us_h
 
             # Hessian terms involving only the shape parameters.
             for shape_id1 in 1:length(gal_shape_ids)


### PR DESCRIPTION
This PR

- restores a unit test (`test_e_g_s_functions`)
- improves a test set (`Tests elbo gradient, and that elbo supports dual numbers`)
- fixes a bug that was keeping the derivative one place from getting computed if the hessian wasn't also getting computed

These commits are cherry picked from my `jcr/cg` branch. I figured we should make sure these tests pass on the `jr/constraints` branch too before merge, though I don't believe they'll present any trouble.