### PR TITLE
import ForwardDiff before StaticArrays

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.6
 Compat 0.18.0
 DataFrames
 DataStructures 0.5.2

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6-
 Compat 0.18.0
 DataFrames
 DataStructures 0.5.2

--- a/src/DeterministicVI.jl
+++ b/src/DeterministicVI.jl
@@ -16,8 +16,8 @@ import ..Log
 using ..Transform
 import DataFrames
 import Optim
-using StaticArrays
 import ForwardDiff.Dual
+using StaticArrays
 import Base.convert
 
 export ElboArgs, generic_init_source, catalog_init_source, init_sources

--- a/src/Model.jl
+++ b/src/Model.jl
@@ -1,6 +1,7 @@
 module Model
 
 using Compat
+import ForwardDiff
 using StaticArrays
 
 # parameter types
@@ -29,7 +30,6 @@ import Base.+
 import Distributions
 import FITSIO, WCS
 import WCS.WCSTransform
-import ForwardDiff
 import ..Log
 
 import Base.length

--- a/src/PSF.jl
+++ b/src/PSF.jl
@@ -16,8 +16,6 @@ import ..SensitiveFloats
 import Optim
 import WCS
 
-using StaticArrays
-
 include("bivariate_normals.jl")
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,14 @@
 #!/usr/bin/env julia
 
+if Pkg.installed("DataArrays") <= v"0.3.12"
+    Pkg.checkout("DataArrays")
+    Pkg.build("DataArrays")
+end
 
-Pkg.checkout("DataArrays")
-Pkg.build("DataArrays")
-Pkg.checkout("DataFrames", "anj/06")
-Pkg.build("DataFrames")
+if Pkg.installed("DataFrames") <= v"0.8.5"
+    Pkg.checkout("DataFrames", "anj/06")
+    Pkg.build("DataFrames")
+end
 
 using ForwardDiff
 using StaticArrays

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,8 @@ Pkg.build("DataArrays")
 Pkg.checkout("DataFrames", "anj/06")
 Pkg.build("DataFrames")
 
+using ForwardDiff
+using StaticArrays
 
 using Celeste: Model, DeterministicVI
 

--- a/test/test_derivatives.jl
+++ b/test/test_derivatives.jl
@@ -1,11 +1,8 @@
-import ForwardDiff
-
 using Celeste: Model, SensitiveFloats, DeterministicVI
 using Distributions
 import Celeste.DeterministicVI: BvnComponent, GalaxyCacheComponent
 import Celeste.DeterministicVI: eval_bvn_pdf!, get_bvn_derivs!, transform_bvn_derivs!
 using DerivativeTestUtils
-using StaticArrays
 
 
 """

--- a/test/test_elbo.jl
+++ b/test/test_elbo.jl
@@ -3,7 +3,6 @@ using Celeste: DeterministicVI, SensitiveFloats
 using Base.Test
 using Distributions
 using DerivativeTestUtils
-using StaticArrays
 
 import ForwardDiff.Dual
 

--- a/test/test_fft.jl
+++ b/test/test_fft.jl
@@ -5,7 +5,6 @@ using Celeste.SensitiveFloats.zero_sensitive_float_array
 using Celeste.SensitiveFloats.SensitiveFloat
 using Celeste.SensitiveFloats.clear!
 
-using ForwardDiff
 using Base.Test
 
 

--- a/test/test_score.jl
+++ b/test/test_score.jl
@@ -25,7 +25,7 @@ import WCS
     # both distances are about 0.315 pixels -- an arc second shift to the right
     # is less, in pixels, at higher elevations than at the equator, where it's
     # 1/0.396 ≈ 2.525 pixels per arc second.
-    @test_approx_eq_eps exact_dist our_dist 1e-4
+    @test exact_dist ≈ our_dist atol=1e-4
 end
 
 @testset "test scoring a whole field" begin


### PR DESCRIPTION
Reorder imports of forwarddiff and staticarrays so that forwarddiff comes first--this is a temporary workaround.