### PR TITLE
Add a logger that includes traceback, and wrap `Thread.@threads` loops

### DIFF
--- a/src/Log.jl
+++ b/src/Log.jl
@@ -26,5 +26,31 @@ end
 # In production mode, rather the development mode, don't log debug statements
 @inline debug(msg...) = is_production_run || ntputs(nodeid, threadid(), "DEBUG: ", msg...)
 
+# Like `error()`, but include exception info and stack trace. Should only be called from a `catch`
+# block, e.g.,
+# try
+#   ...
+# catch ex
+#   Log.exception(ex, catch_stacktrace(), "Something happened %s", some_var)
+# end
+function exception(exception::Exception, msg...)
+    if length(msg) > 0
+        error(msg...)
+    end
+    error(exception)
+    error("Stack trace:")
+    stack_trace = catch_stacktrace()
+    if length(stack_trace) > 100
+        stack_trace = vcat(
+            [string(line) for line in stack_trace[1:50]],
+            @sprintf("...(removed %d frames)...", length(stack_trace) - 100),
+            [string(line) for line in stack_trace[(length(stack_trace) - 50):length(stack_trace)]],
+        )
+    end
+    for stack_line in stack_trace
+        error(@sprintf("  %s", stack_line))
+    end
+end
+
 end
 

--- a/src/SDSSIO.jl
+++ b/src/SDSSIO.jl
@@ -338,7 +338,12 @@ function load_field_images(rcfs, stagedir)
     images = Vector{Image}(N)
 
     Threads.@threads for n in 1:N
-        images[n] = convert(Image, raw_images[n])
+        try
+            images[n] = convert(Image, raw_images[n])
+        catch exc
+            Log.exception(exc)
+            rethrow()
+        end
     end
 
     return images


### PR DESCRIPTION
* `Log.exception()` is like `Log.error()`, but includes exception information. Inspired by Python's
  `logging.exception()` and such.

* Since exceptions inside threads are silently swallowed right now
  (https://github.com/JuliaLang/julia/issues/17532), always wrap the body of a `Thread.@threads`
  call with a try-catch that manually logs the exception.