### PR TITLE
Fixed position offset in accuracy benchmarks

### DIFF
--- a/src/AccuracyBenchmark.jl
+++ b/src/AccuracyBenchmark.jl
@@ -546,10 +546,9 @@ function make_initialization_catalog(catalog::DataFrame, use_full_initialzation:
         if use_full_initialzation
             make_catalog_entry(row)
         else
-            position_offset = rand(Uniform(-position_offset_width, position_offset_width), 2)
             make_catalog_entry(
-                row[:right_ascension_deg] + position_offset[1],
-                row[:declination_deg] + position_offset[2],
+                row[:right_ascension_deg] + position_offset_width,
+                row[:declination_deg] - 0.5 * position_offset_width,
                 row[:objid],
             )
         end

--- a/src/AccuracyBenchmark.jl
+++ b/src/AccuracyBenchmark.jl
@@ -548,8 +548,8 @@ function make_initialization_catalog(catalog::DataFrame, use_full_initialzation:
         else
             position_offset = rand(Uniform(-position_offset_width, position_offset_width), 2)
             make_catalog_entry(
-                row[:right_ascension_deg],
-                row[:declination_deg],
+                row[:right_ascension_deg] + position_offset[1],
+                row[:declination_deg] + position_offset[2],
                 row[:objid],
             )
         end


### PR DESCRIPTION
First, I fixed a bug where I simply forgot to add the position offset when constructing the initialization catalog. Then, I replaced the random offset with a fixed one, because that randomness really shouldn't have been there in a test, and Celeste happens to be sensitive to this in some cases (see commit logs).
