### PR TITLE
Fixes and tweaks to make AccuracyBenchmark line up with Stripe82Score

### DIFF
--- a/benchmark/accuracy/run_celeste_on_field.jl
+++ b/benchmark/accuracy/run_celeste_on_field.jl
@@ -41,7 +41,7 @@ parsed_args = ArgumentParse.parse_args(parser, ARGS)
 
 srand(12345)
 
-if parsed_args["image-fits"] != nothing
+if haskey(parsed_args, "image-fits")
     extensions = AccuracyBenchmark.read_fits(parsed_args["image-fits"])
     images = AccuracyBenchmark.make_images(extensions)
 else
@@ -59,7 +59,7 @@ catalog_entries = AccuracyBenchmark.make_initialization_catalog(
 )
 @printf("Loaded %d sources...\n", length(catalog_entries))
 
-if parsed_args["limit-num-sources"] != nothing
+if haskey(parsed_args, "limit-num-sources")
     target_sources = collect(1:parsed_args["limit-num-sources"])
 else
     target_sources = collect(1:length(catalog_entries))
@@ -76,7 +76,7 @@ results = AccuracyBenchmark.run_celeste(
 )
 results_df = AccuracyBenchmark.celeste_to_df(results)
 
-if parsed_args["image-fits"] != nothing
+if haskey(parsed_args, "image-fits")
     catalog_label = splitext(basename(parsed_args["image-fits"]))[1]
 else
     rcf = AccuracyBenchmark.STRIPE82_RCF

--- a/benchmark/accuracy/score_predictions.jl
+++ b/benchmark/accuracy/score_predictions.jl
@@ -3,8 +3,6 @@
 using DataFrames
 
 import Celeste.AccuracyBenchmark
-import Celeste.Infer
-import Celeste.ParallelRun
 
 if !(2 <= length(ARGS) <= 3)
     println("Usage: score_predictions.jl <ground truth> <predictions> [predictions]")

--- a/benchmark/accuracy/sdss_rcf_to_csv.jl
+++ b/benchmark/accuracy/sdss_rcf_to_csv.jl
@@ -53,21 +53,16 @@ catalog_df[:objid] = fill("", size(catalog_df, 1))
 truth_df = AccuracyBenchmark.read_catalog(parsed_args["truth_catalog_csv"])
 used_truth_indices = Set()
 for source_index in 1:size(catalog_df, 1)
-    matching_truth_index = nothing
-    try
-        matching_truth_index = AccuracyBenchmark.match_position(
-            truth_df[:right_ascension_deg], truth_df[:declination_deg],
-            catalog_df[source_index, :right_ascension_deg],
-            catalog_df[source_index, :declination_deg],
-            1,
-        )
-    catch exc
-        if !isa(exc, AccuracyBenchmark.MatchException)
-            rethrow()
-        else
-            continue
-        end
+    matching_truth_indices = AccuracyBenchmark.match_position(
+        truth_df[:right_ascension_deg], truth_df[:declination_deg],
+        catalog_df[source_index, :right_ascension_deg],
+        catalog_df[source_index, :declination_deg],
+        1 / 0.396, # to match up with Stripe82Score
+    )
+    if isempty(matching_truth_indices)
+        continue
     end
+    matching_truth_index = matching_truth_indices[1]
 
     if in(matching_truth_index, used_truth_indices)
         continue

--- a/src/AccuracyBenchmark.jl
+++ b/src/AccuracyBenchmark.jl
@@ -105,7 +105,7 @@ function color_from_fluxes(flux1::AbstractFloat, flux2::AbstractFloat)
     end
 end
 function color_from_mags(mags1::AbstractFloat, mags2::AbstractFloat)
-    color_from_fluxes(mag_to_flux(mags1), mag_to_flux(mags1))
+    color_from_fluxes(mag_to_flux(mags1), mag_to_flux(mags2))
 end
 
 canonical_angle(angle_deg) = angle_deg - floor(angle_deg / 180) * 180
@@ -268,6 +268,9 @@ function load_primary(rcf::SDSSIO.RunCamcolField, stagedir::String)
     # gal angle (degrees)
     raw_phi = dev_or_exp(:phi_dev, :phi_exp)
     result[:angle_deg] = canonical_angle.(raw_phi)
+
+    # primary is better at flagging oversaturated sources than coadd
+    result = result[flux_to_mag.(raw_df[:psfflux_r]) .>= 16, :]
 
     return result
 end
@@ -560,15 +563,12 @@ end
 # Score a set of predictions against a ground truth catalog
 ################################################################################
 
-ABSOLUTE_ERROR_COLUMNS = [
-    :de_vaucouleurs_mixture_weight,
-    :minor_major_axis_ratio,
-    :half_light_radius_px,
-    :color_log_ratio_ug,
-    :color_log_ratio_gr,
-    :color_log_ratio_ri,
-    :color_log_ratio_iz,
-]
+COLOR_COLUMNS = [:color_log_ratio_ug, :color_log_ratio_gr, :color_log_ratio_ri, :color_log_ratio_iz]
+
+ABSOLUTE_ERROR_COLUMNS = vcat(
+    [:de_vaucouleurs_mixture_weight, :minor_major_axis_ratio, :half_light_radius_px],
+    COLOR_COLUMNS,
+)
 
 function degrees_to_diff(a, b)
     angle_between = abs(a - b) % 180
@@ -587,7 +587,8 @@ function get_error_df(truth::DataFrame, predicted::DataFrame)
 
     predicted_galaxy = predicted[:is_star] .< .5
     true_galaxy = truth[:is_star] .< .5
-    errors[:misclassified] =  (predicted_galaxy .!= true_galaxy)
+    errors[:missed_stars] = !true_galaxy .& predicted_galaxy
+    errors[:missed_galaxies] = true_galaxy .& !predicted_galaxy
 
     errors[:position] = sky_distance_px.(
         truth[:right_ascension_deg],
@@ -595,32 +596,40 @@ function get_error_df(truth::DataFrame, predicted::DataFrame)
         predicted[:right_ascension_deg],
         predicted[:declination_deg],
     )
+
+    # compare flux in both mags and nMgy for now
     errors[:reference_band_flux_mag] = abs(
         flux_to_mag.(truth[:reference_band_flux_nmgy])
         .- flux_to_mag.(predicted[:reference_band_flux_nmgy])
+    )
+    errors[:reference_band_flux_nmgy] = abs(
+        truth[:reference_band_flux_nmgy] .- predicted[:reference_band_flux_nmgy]
     )
     errors[:angle_deg] = degrees_to_diff(truth[:angle_deg], predicted[:angle_deg])
 
     for column_symbol in ABSOLUTE_ERROR_COLUMNS
         errors[column_symbol] = abs(truth[column_symbol] - predicted[column_symbol])
     end
+    for color_column in COLOR_COLUMNS
+        # to match up with Stripe82Score, which used differences of mags
+        errors[color_column] *= 2.5 / log(10)
+    end
 
     errors
 end
 
-function filter_rows(truth::DataFrame, errors::DataFrame, column_name::Symbol, source_type::Symbol)
-    good_row = .!isna(errors[column_name])
-    if source_type == :star
-        good_row .&= (truth[:is_star] .> 0.5)
-    else
-        good_row .&= (truth[:is_star] .< 0.5)
-        if column_name in [:minor_major_axis_ratio, :half_light_radius_px, :angle_deg,
-                          :de_vaucouleurs_mixture_weight]
-            good_row .&= !(0.05 .< truth[:de_vaucouleurs_mixture_weight] .< 0.95)
-        end
-        if column_name == :angle_deg
-            good_row .&= truth[:minor_major_axis_ratio] .< .6
-        end
+function filter_rows(truth::DataFrame, errors::DataFrame, column_name::Symbol)
+    good_row = (.!isna(errors[column_name]) .& !isnan(errors[column_name]))
+    good_row .&= (isna(truth[:half_light_radius_px]) .| (truth[:half_light_radius_px] .<= 20))
+    if column_name in [:minor_major_axis_ratio, :half_light_radius_px, :angle_deg,
+                       :de_vaucouleurs_mixture_weight]
+        good_row .&= (
+            isna(truth[:de_vaucouleurs_mixture_weight])
+            .| !(0.05 .< truth[:de_vaucouleurs_mixture_weight] .< 0.95)
+        )
+    end
+    if column_name == :angle_deg
+        good_row .&= (isna(truth[:minor_major_axis_ratio]) .| (truth[:minor_major_axis_ratio] .< .6))
     end
     good_row
 end
@@ -650,26 +659,25 @@ function get_scores_df(
         if column_name == :objid
             continue
         end
-        for source_type in [:star, :galaxy]
-            good_row = filter_rows(truth, first_errors, column_name, source_type)
-            if !isnull(second_errors)
-                good_row .&= filter_rows(truth, get(second_errors), column_name, source_type)
-            end
-            if sum(good_row) <= 1
-                continue
+
+        good_row = filter_rows(truth, first_errors, column_name)
+        if !isnull(second_errors)
+            good_row .&= filter_rows(truth, get(second_errors), column_name)
+        end
+        if sum(good_row) <= 1
+            continue
+        else
+            if isnull(second_errors)
+                row = score_column(first_errors[good_row, column_name])
             else
-                if isnull(second_errors)
-                    row = score_column(first_errors[good_row, column_name])
-                else
-                    row = score_column(
-                        first_errors[good_row, column_name],
-                        get(second_errors)[good_row, column_name],
-                    )
-                end
-                row[:field] = column_name
-                row[:source_type] = source_type
-                push!(score_rows, row)
+                row = score_column(
+                    first_errors[good_row, column_name],
+                    get(second_errors)[good_row, column_name],
+                )
             end
+
+            row[:field] = column_name
+            push!(score_rows, row)
         end
     end
     vcat(score_rows...)
@@ -733,12 +741,9 @@ position `ra`, `dec`. If none found, an exception is raised.
 """
 function match_position(ras, decs, ra, dec, maxdist_px)
     @assert length(ras) == length(decs)
-    for i in 1:length(ras)
-        if sky_distance_px(ra, dec, ras[i], decs[i]) < maxdist_px
-            return i
-        end
+    filter(eachindex(ras)) do index
+        sky_distance_px(ra, dec, ras[index], decs[index]) < maxdist_px
     end
-    throw(MatchException(@sprintf("No source found at %f  %f", ra, dec)))
 end
 
 # Run Celeste with any combination of single/joint inference and MOG/FFT model

--- a/src/ArgumentParse.jl
+++ b/src/ArgumentParse.jl
@@ -63,7 +63,7 @@ function add_argument(
         name = argument_string
     end
     if action == :store_true
-        @assert default == nothing || default == false
+        @assert default == NoDefault || default == false
         default = false
     end
     specification = ArgumentSpecification(

--- a/test/test_argument_parse.jl
+++ b/test/test_argument_parse.jl
@@ -51,6 +51,17 @@ end
     @test parsed_args["my-arg"] == "hi there"
 end
 
+@testset "keyword argument :store_true" begin
+    parser = ArgumentParse.ArgumentParser(propagate_errors=true)
+    ArgumentParse.add_argument(parser, "--my-arg", action=:store_true)
+
+    parsed_args = ArgumentParse.parse_args(parser, String[])
+    @test parsed_args["my-arg"] == false
+
+    parsed_args = ArgumentParse.parse_args(parser, String["--my-arg"])
+    @test parsed_args["my-arg"] == true
+end
+
 @testset "help message" begin
     parser = ArgumentParse.ArgumentParser(program_name="test.jl", propagate_errors=true)
     ArgumentParse.add_argument(parser, "--my-keyword", default="hello")


### PR DESCRIPTION
Here are a few genuine bugfixes and a few arbitrary changes (e.g., units of comparison) to make the
results of AccuracyBenchmark more closely match those from Stripe82Score.

They still don't match perfectly (I don't know why), but here's where we're at:

From Stripe82Score:
```
12×6 DataFrames.DataFrame
│ Row │ field        │ primary   │ celeste   │ diff       │ diff_sd    │ N   │
├─────┼──────────────┼───────────┼───────────┼────────────┼────────────┼─────┤
│ 1   │ position     │ 0.333928  │ 0.291017  │ 0.0429108  │ 0.00890511 │ 547 │
│ 2   │ missed_stars │ 0.023766  │ 0.0804388 │ -0.0566728 │ 0.0107474  │ 547 │
│ 3   │ missed_gals  │ 0.0493601 │ 0.0310786 │ 0.0182815  │ 0.00840828 │ 547 │
│ 4   │ flux_r       │ 1.7321    │ 2.09439   │ -0.362286  │ 0.343522   │ 547 │
│ 5   │ color_ug     │ 1.25811   │ 0.722694  │ 0.535415   │ 0.0484847  │ 486 │
│ 6   │ color_gr     │ 0.360966  │ 0.205052  │ 0.155914   │ 0.016428   │ 542 │
│ 7   │ color_ri     │ 0.262705  │ 0.164648  │ 0.0980569  │ 0.0137777  │ 546 │
│ 8   │ color_iz     │ 0.403609  │ 0.18437   │ 0.219238   │ 0.0221282  │ 544 │
│ 9   │ gal_fracdev  │ 0.311123  │ 0.189645  │ 0.121478   │ 0.0207522  │ 255 │
│ 10  │ gal_ab       │ 0.21808   │ 0.163677  │ 0.054403   │ 0.00957949 │ 255 │
│ 11  │ gal_scale    │ 2.0158    │ 0.667567  │ 1.34823    │ 0.638982   │ 255 │
│ 12  │ gal_angle    │ 19.6691   │ 14.953    │ 4.71609    │ 1.33851    │ 132 │
```

From AccuracyBenchmark:
```
│ Row │ N   │ first     │ second    │ diff       │ diff_sd    │ field                         │
├─────┼─────┼───────────┼───────────┼────────────┼────────────┼───────────────────────────────┤
│ 1   │ 547 │ 0.023766  │ 0.0804388 │ -0.0566728 │ 0.0107474  │ missed_stars                  │
│ 2   │ 547 │ 0.0493601 │ 0.0274223 │ 0.0219378  │ 0.00876542 │ missed_galaxies               │
│ 3   │ 547 │ 0.332059  │ 0.289964  │ 0.0420947  │ 0.00884916 │ position                      │
│ 4   │ 547 │ 1.74914   │ 1.96713   │ -0.217997  │ 0.342667   │ reference_band_flux_nmgy      │
│ 5   │ 132 │ 19.4795   │ 15.1436   │ 4.33595    │ 1.3764     │ angle_deg                     │
│ 6   │ 255 │ 0.311123  │ 0.190741  │ 0.120382   │ 0.0208254  │ de_vaucouleurs_mixture_weight │
│ 7   │ 255 │ 0.218483  │ 0.158259  │ 0.0602242  │ 0.00978837 │ minor_major_axis_ratio        │
│ 8   │ 255 │ 2.01317   │ 0.662868  │ 1.3503     │ 0.638938   │ half_light_radius_px          │
│ 9   │ 487 │ 1.25981   │ 0.721756  │ 0.538055   │ 0.0470949  │ color_log_ratio_ug            │
│ 10  │ 543 │ 0.377395  │ 0.203481  │ 0.173914   │ 0.0193789  │ color_log_ratio_gr            │
│ 11  │ 547 │ 0.266521  │ 0.162451  │ 0.104071   │ 0.0145886  │ color_log_ratio_ri            │
│ 12  │ 545 │ 0.404     │ 0.178985  │ 0.225015   │ 0.0199887  │ color_log_ratio_iz            │
```