### PR TITLE
Two fixes

### DIFF
--- a/benchmark/speed/benchmark_one_light_source.jl
+++ b/benchmark/speed/benchmark_one_light_source.jl
@@ -6,10 +6,11 @@ import Celeste.Infer: find_neighbors
 import Celeste.DeterministicVIImagePSF
 
 const datadir = joinpath(Pkg.dir("Celeste"), "test", "data")
-wd = pwd()
-cd(datadir)
-run(`make RUN=7713 CAMCOL=3 FIELD=152`)
-cd(wd)
+if ccall(:jl_generating_output, Cint, ()) == 0
+    cd(datadir) do
+        run(`make RUN=7713 CAMCOL=3 FIELD=152`)
+    end
+end
 
 """
 This benchmark operates on a box of the sky that contains just

--- a/src/PSF.jl
+++ b/src/PSF.jl
@@ -496,7 +496,7 @@ function get_sigma_from_params{NumType <: Number}(psf_params::Vector{Vector{NumT
         sig_sf_vec[k] = GalaxySigmaDerivs(
             psf_params[k][psf_ids.e_angle],
             psf_params[k][psf_ids.e_axis],
-            psf_params[k][psf_ids.e_scale], sigma_vec[k], one(NumType), true)
+            psf_params[k][psf_ids.e_scale], sigma_vec[k], 1.0, true)
 
         bvn_vec[k] =
             BvnComponent(SVector{2,NumType}(psf_params[k][psf_ids.mu]), sigma_vec[k], 1.0)

--- a/src/bivariate_normals.jl
+++ b/src/bivariate_normals.jl
@@ -326,7 +326,7 @@ Note that nubar is not included.
 """
 function GalaxySigmaDerivs{NumType <: Number}(
     e_angle::NumType, e_axis::NumType, e_scale::NumType,
-    XiXi::SMatrix{2,2,NumType,4}, nuBar::NumType = one(NumType), calculate_tensor::Bool=true)
+    XiXi::SMatrix{2,2,NumType,4}, nuBar::Float64=1.0, calculate_tensor::Bool=true)
 
   cos_sin = cos(e_angle)sin(e_angle)
   sin_sq  = sin(e_angle)^2
@@ -417,7 +417,8 @@ function GalaxyCacheComponent{NumType <: Number}(
   GalaxyCacheComponent(e_dev_dir, e_dev_i, bmc, sig_sf)
 end
 
-GalaxySigmaDerivs(NumType::Type) = GalaxySigmaDerivs(@SMatrix(zeros(NumType,3,gal_shape_ids_len)),
+GalaxySigmaDerivs{NumType}(::Type{NumType}) = GalaxySigmaDerivs(
+                                                     @SMatrix(zeros(NumType,3,gal_shape_ids_len)),
                                                      @SArray( zeros(NumType,3,gal_shape_ids_len,gal_shape_ids_len)))
 
 ###################################################


### PR DESCRIPTION
- Don't try to download image files when using the one source benchmark
  for precompilation.
- Fix an accidentally introduced memory allocation