### PR TITLE
don't deepcopy elbo

### DIFF
--- a/src/deterministic_vi/elbo_objective.jl
+++ b/src/deterministic_vi/elbo_objective.jl
@@ -521,7 +521,7 @@ function elbo_likelihood{NumType <: Number}(
     end
 
     assert_all_finite(elbo_vars.elbo)
-    deepcopy(elbo_vars.elbo)
+    elbo_vars.elbo
 end
 
 

--- a/test/test_elbo.jl
+++ b/test/test_elbo.jl
@@ -224,7 +224,6 @@ end
     end
 
     @time elbo_dual = DeterministicVI.elbo(ea, vp_dual)
-    @show elbo_dual.d
 
     for s in 1:2, p in 1:length(ids)
         auto_hessian_column_sum = elbo_dual.d[p, s].partials[]


### PR DESCRIPTION
Don't copy `elbo`, as described in #603 .

On master
```
$ ./benchmark_elbo_likelihood.jl 
  0.065030 seconds (4.56 k allocations: 201.906 KiB)
```

On `jcr/no_elbo_copy`:
```
$ ./benchmark_elbo_likelihood.jl 
  0.062648 seconds (4.56 k allocations: 185.703 KiB)
```