### PR TITLE
pixel counters + don't precompute sky

### DIFF
--- a/src/AccuracyBenchmark.jl
+++ b/src/AccuracyBenchmark.jl
@@ -455,6 +455,8 @@ function make_images(band_extensions::Vector{FitsImage})
     map(enumerate(band_extensions)) do pair
         band_index, extension = pair
         height, width = size(extension.pixels)
+        sky = Model.SkyIntensity(fill(extension.header["CLSKY"], height, width),
+                           collect(1:height), collect(1:width), ones(1:height))
         Model.Image(
             height,
             width,
@@ -465,7 +467,7 @@ function make_images(band_extensions::Vector{FitsImage})
             0, # SDSS run
             0, # SDSS camcol
             0, # SDSS field
-            fill(extension.header["CLSKY"], height, width),
+            sky,
             fill(extension.header["CLIOTA"], height),
             Model.RawPSF(Matrix{Float64}(0, 0), 0, 0, Array{Float64,3}(0, 0, 0)),
         )

--- a/src/Infer.jl
+++ b/src/Infer.jl
@@ -37,7 +37,7 @@ function find_neighbors(target_sources::Vector{Int64},
 
     epsilon_lb = fill(Inf, B)
     for img in images
-        epsilon = mean(img.epsilon_mat)  # use just the center if this is slow
+        epsilon = img.sky[div(img.H, 2), div(img.W, 2)]
         epsilon_lb[img.b] = min(epsilon_lb[img.b], epsilon)
     end
 
@@ -166,7 +166,7 @@ function load_active_pixels!(config::Configs.Config,
             # Note: This is risky because bright pixels are disproportionately likely
             # to get included, even if it's because of noise. Therefore it's important
             # to keep the noise fraction pretty low.
-            threshold = img.iota_vec[h] * img.epsilon_mat[h, w] * (1. + noise_fraction)
+            threshold = img.iota_vec[h] * img.sky[h, w] * (1. + noise_fraction)
             p.active_pixel_bitmap[h2, w2] = img.pixels[h, w] > threshold
         end
     end

--- a/src/Model.jl
+++ b/src/Model.jl
@@ -10,7 +10,7 @@ export Image, SkyPatch, PsfComponent,
        PriorParams, CanonicalParams, BrightnessParams, StarPosParams,
        GalaxyPosParams, GalaxyShapeParams,
        PsfParams, RawPSF, CatalogEntry,
-       ParamSet
+       ParamSet, SkyIntensity
 
 # functions
 export align

--- a/src/SDSSIO.jl
+++ b/src/SDSSIO.jl
@@ -7,7 +7,7 @@ import FITSIO
 import WCS
 
 import ..Log
-import ..Model: RawPSF, Image, CatalogEntry, eval_psf
+import ..Model: RawPSF, Image, CatalogEntry, eval_psf, SkyIntensity
 import ..PSF
 import Base.convert, Base.getindex
 
@@ -33,64 +33,6 @@ function RunCamcolField(run::String, camcol::String, field::String)
         parse(Int64, run),
         parse(Int64, camcol),
         parse(Int64, field))
-end
-
-
-immutable SkyIntensity
-    sky_small::Matrix{Float32}
-    sky_x::Vector{Float32}
-    sky_y::Vector{Float32}
-    calibration::Vector{Float64}
-end
-
-
-"""
-Interpolate the 2-d array `sky_small` at the grid of array coordinates spanned
-by the vectors `sky_x` and `sky_y` using bilinear interpolation.
-The output array will have size `(length(sky_x), length(sky_y))`.
-For example, if `x[1] = 3.3` and `y[2] = 4.7`, the element `out[1, 2]`
-will be a result of linear interpolation between the values
-`sky_small[3:4, 4:5]`.
-
-For coordinates that are out-of-bounds (e.g., `sky_x[i] < 1.0` or
-`sky_x[i] > size(sky_small,1)` where the interpolation would index sky_small values
-outside the array, the nearest values in the sky_small array are used. (This is
-constant extrapolation.)
-"""
-function interp_sky_kernel(sky::SkyIntensity, i::Int, j::Int)
-    nx, ny = size(sky.sky_small)
-
-    y0 = floor(Int, sky.sky_y[j])
-    y1 = y0 + 1
-    yw0 = sky.sky_y[j] - y0
-    yw1 = 1.0f0 - yw0
-
-    # modify out-of-bounds indicies to 1 or ny
-    y0 = min(max(y0, 1), ny)
-    y1 = min(max(y1, 1), ny)
-
-    x0 = floor(Int, sky.sky_x[i])
-    x1 = x0 + 1
-    xw0 = sky.sky_x[i] - x0
-    xw1 = 1.0f0 - xw0
-
-    # modify out-of-bounds indicies to 1 or nx
-    x0 = min(max(x0, 1), nx)
-    x1 = min(max(x1, 1), nx)
-
-    # bi-linear interpolation
-    skynmgy = (xw0 * yw0 * sky.sky_small[x0, y0]
-             + xw1 * yw0 * sky.sky_small[x1, y0]
-             + xw0 * yw1 * sky.sky_small[x0, y1]
-             + xw1 * yw1 * sky.sky_small[x1, y1])
-
-    # return sky intensity in counts
-    skynmgy * sky.calibration[i]
-end
-
-
-function getindex(sky::SkyIntensity, i::Int, j::Int)
-    interp_sky_kernel(sky, i, j)
 end
 
 
@@ -308,18 +250,16 @@ function convert(::Type{Image}, r::RawImage)
 
     # scale pixels to raw electron counts
     @assert size(r.pixels, 1) == length(r.calibration)
-    epsilon_mat = similar(r.pixels)
     @inbounds for j=1:size(r.pixels, 2), i=1:size(r.pixels, 1)
         sky_ij = r.sky[i, j]
         r.pixels[i, j] = (r.gain / r.calibration[i]) * (r.pixels[i, j] + sky_ij)
-        epsilon_mat[i, j] = sky_ij
     end
 
     iota_vec = r.gain ./ r.calibration
 
     Image(H, W, r.pixels, r.b, r.wcs, celeste_psf,
           r.rcf.run, r.rcf.camcol, r.rcf.field,
-          epsilon_mat, iota_vec, r.raw_psf_comp)
+          r.sky, iota_vec, r.raw_psf_comp)
 end
 
 

--- a/src/deterministic_vi/elbo_args.jl
+++ b/src/deterministic_vi/elbo_args.jl
@@ -64,6 +64,9 @@ type ElboIntermediateVariables{NumType <: Number}
 
     star_mcs::Matrix{BvnComponent{NumType}}
     gal_mcs::Array{GalaxyCacheComponent{NumType}, 4}
+
+    active_pixel_counter::Int64
+    inactive_pixel_counter::Int64
 end
 
 
@@ -120,7 +123,7 @@ function ElboIntermediateVariables(NumType::DataType,
         bvn_derivs, fs0m, fs1m,
         E_G_s, E_G2_s, var_G_s, E_G_s_hsub_vec, E_G2_s_hsub_vec,
         E_G, var_G, combine_grad, combine_hess,
-        elbo_log_term, elbo, star_mcs, gal_mcs)
+        elbo_log_term, elbo, star_mcs, gal_mcs, 0, 0)
 end
 
 

--- a/src/deterministic_vi/elbo_objective.jl
+++ b/src/deterministic_vi/elbo_objective.jl
@@ -368,7 +368,7 @@ function add_pixel_term!{NumType <: Number}(
 
     # There are no derivatives with respect to epsilon, so can safely add
     # to the value.
-    elbo_vars.E_G.v[] += img.epsilon_mat[h, w]
+    elbo_vars.E_G.v[] += img.sky[h, w]
 
     # Add the terms to the elbo given the brightness.
     add_elbo_log_term!(elbo_vars,

--- a/src/deterministic_vi/elbo_objective.jl
+++ b/src/deterministic_vi/elbo_objective.jl
@@ -355,7 +355,12 @@ function add_pixel_term!{NumType <: Number}(
 
         H2, W2 = size(p.active_pixel_bitmap)
         if 1 <= h2 <= H2 && 1 <= w2 < W2 && p.active_pixel_bitmap[h2, w2]
-            is_active_source = s in ea.active_sources
+            if is_active_source
+                elbo_vars.active_pixel_counter += 1
+            else
+                elbo_vars.inactive_pixel_counter += 1
+            end
+
             accumulate_source_pixel_brightness!(ea, vp, elbo_vars,
                 sbs[s], ea.images[n].b, s, is_active_source)
         end

--- a/src/model/image_model.jl
+++ b/src/model/image_model.jl
@@ -1,6 +1,3 @@
-import Base.getindex
-
-
 immutable SkyIntensity
     sky_small::Matrix{Float32}
     sky_x::Vector{Float32}
@@ -49,10 +46,11 @@ function interp_sky_kernel(sky::SkyIntensity, i::Int, j::Int)
              + xw0 * yw1 * sky.sky_small[x0, y1]
              + xw1 * yw1 * sky.sky_small[x1, y1])
 
-    # return sky intensity in nmgy
+    # return sky intensity in counts
     skynmgy * sky.calibration[i]
 end
 
+import Base.getindex
 
 function getindex(sky::SkyIntensity, i::Int, j::Int)
     interp_sky_kernel(sky, i, j)

--- a/src/model/image_model.jl
+++ b/src/model/image_model.jl
@@ -1,3 +1,64 @@
+import Base.getindex
+
+
+immutable SkyIntensity
+    sky_small::Matrix{Float32}
+    sky_x::Vector{Float32}
+    sky_y::Vector{Float32}
+    calibration::Vector{Float64}
+end
+
+
+"""
+Interpolate the 2-d array `sky_small` at the grid of array coordinates spanned
+by the vectors `sky_x` and `sky_y` using bilinear interpolation.
+The output array will have size `(length(sky_x), length(sky_y))`.
+For example, if `x[1] = 3.3` and `y[2] = 4.7`, the element `out[1, 2]`
+will be a result of linear interpolation between the values
+`sky_small[3:4, 4:5]`.
+
+For coordinates that are out-of-bounds (e.g., `sky_x[i] < 1.0` or
+`sky_x[i] > size(sky_small,1)` where the interpolation would index sky_small values
+outside the array, the nearest values in the sky_small array are used. (This is
+constant extrapolation.)
+"""
+function interp_sky_kernel(sky::SkyIntensity, i::Int, j::Int)
+    nx, ny = size(sky.sky_small)
+
+    y0 = floor(Int, sky.sky_y[j])
+    y1 = y0 + 1
+    yw0 = sky.sky_y[j] - y0
+    yw1 = 1.0f0 - yw0
+
+    # modify out-of-bounds indicies to 1 or ny
+    y0 = min(max(y0, 1), ny)
+    y1 = min(max(y1, 1), ny)
+
+    x0 = floor(Int, sky.sky_x[i])
+    x1 = x0 + 1
+    xw0 = sky.sky_x[i] - x0
+    xw1 = 1.0f0 - xw0
+
+    # modify out-of-bounds indicies to 1 or nx
+    x0 = min(max(x0, 1), nx)
+    x1 = min(max(x1, 1), nx)
+
+    # bi-linear interpolation
+    skynmgy = (xw0 * yw0 * sky.sky_small[x0, y0]
+             + xw1 * yw0 * sky.sky_small[x1, y0]
+             + xw0 * yw1 * sky.sky_small[x0, y1]
+             + xw1 * yw1 * sky.sky_small[x1, y1])
+
+    # return sky intensity in nmgy
+    skynmgy * sky.calibration[i]
+end
+
+
+function getindex(sky::SkyIntensity, i::Int, j::Int)
+    interp_sky_kernel(sky, i, j)
+end
+
+
 """An image, taken though a particular filter band"""
 type Image
     # The image height.
@@ -25,7 +86,7 @@ type Image
     field_num::Int
 
     # The background noise in nanomaggies. (varies by position)
-    epsilon_mat::Array{Float32, 2}
+    sky::SkyIntensity
 
     # The expected number of photons contributed to this image
     # by a source 1 nanomaggie in brightness. (varies by row)
@@ -35,4 +96,3 @@ type Image
     # not a Celeste type
     raw_psf_comp::RawPSF
 end
-

--- a/src/model/imaged_sources.jl
+++ b/src/model/imaged_sources.jl
@@ -59,7 +59,7 @@ function choose_patch_radius(ce::CatalogEntry,
     # Choose enough pixels that the light is either 80% of the light
     # would be captured from a 1d gaussian or 5% of the sky noise,
     # whichever is a larger radius.
-    epsilon = img.epsilon_mat[div(img.H, 2), div(img.W, 2)]
+    epsilon = img.sky[div(img.H, 2), div(img.W, 2)]
     pdf_90 = exp(-0.5 * (1.64)^2) / (sqrt(2pi) * obj_width)
     pdf_target = min(pdf_90, epsilon / (20 * flux))
     rhs = log(pdf_target) + 0.5 * log(2pi) + log(obj_width)

--- a/src/model/log_prob.jl
+++ b/src/model/log_prob.jl
@@ -186,7 +186,7 @@ function state_log_likelihood(is_star::Bool,                # source is star
             hw = SVector{2,Float64}(h, w)
 
             # compute the background rate for this pixel
-            background_rate = img.epsilon_mat[h, w]
+            background_rate = img.sky[h, w]
             for s in 2:S  # excludes source #1
                 # determine if background source is star/gal; get fluxes
                 params_s  = source_params[s]

--- a/test/SampleData.jl
+++ b/test/SampleData.jl
@@ -94,13 +94,14 @@ function load_stamp_blob(stamp_dir, stamp_id)
         camcol_num = round(Int, hdr["CAMCOL"])
         field_num = round(Int, hdr["FIELD"])
 
-        epsilon_mat = fill(epsilon, H, W)
+        sky = SkyIntensity(fill(epsilon, H, W),
+                           collect(1:H), collect(1:W), ones(H))
         iota_vec = fill(iota, H)
         empty_psf_comp = RawPSF(Matrix{Float64}(0, 0), 0, 0,
                                  Array{Float64,3}(0, 0, 0))
 
         Image(H, W, nelec, b, wcs, psf,
-              run_num, camcol_num, field_num, epsilon_mat, iota_vec,
+              run_num, camcol_num, field_num, sky, iota_vec,
               empty_psf_comp)
     end
 
@@ -339,7 +340,9 @@ function gen_n_body_dataset(
     # Make non-constant background.
     for b=1:5
         images[b].iota_vec = fill(images[b].iota_vec[1], images[b].H)
-        images[b].epsilon_mat = fill(images[b].epsilon_mat[1], images[b].H, images[b].W)
+        images[b].sky = SkyIntensity(fill(images[b].sky[1,1], images[b].H, images[b].W),
+                                     collect(1:images[b].H), collect(1:images[b].W),
+                                     ones(images[b].H))
     end
 
     ea = make_elbo_args(

--- a/test/Synthetic.jl
+++ b/test/Synthetic.jl
@@ -84,7 +84,7 @@ function write_galaxy(img0::Image, ce::CatalogEntry, pixels::Matrix{Float64};
 end
 
 function gen_image(img0::Image, n_bodies::Vector{CatalogEntry}; expectation=false)
-    epsilon = img0.epsilon_mat[1]
+    epsilon = img0.sky[1, 1]
     iota = img0.iota_vec[1]
 
     if expectation
@@ -98,13 +98,15 @@ function gen_image(img0::Image, n_bodies::Vector{CatalogEntry}; expectation=fals
         body.is_star ? write_star(img0, body, pixels) : write_galaxy(img0, body, pixels)
     end
 
-    epsilon_mat = fill(epsilon, img0.H, img0.W)
+    sky = SkyIntensity(fill(epsilon, img0.H, img0.W),
+                       collect(1:img0.H), collect(1:img0.W),
+                       ones(img0.H))
     iota_vec = fill(iota, img0.H)
 
     return Image(img0.H, img0.W, pixels, img0.b, img0.wcs,
                  img0.psf,
                  img0.run_num, img0.camcol_num, img0.field_num,
-                 epsilon_mat, iota_vec,
+                 sky, iota_vec,
                  img0.raw_psf_comp)
 end
 

--- a/test/test_infer.jl
+++ b/test/test_infer.jl
@@ -75,7 +75,7 @@ function test_load_active_pixels()
             # (h2, w2) index the local patch, while (h, w) index the image
             h = p.bitmap_offset[1] + h2
             w = p.bitmap_offset[2] + w2
-            num_active_photons += img.pixels[h, w] - img.epsilon_mat[h, w]
+            num_active_photons += img.pixels[h, w] - img.sky[h, w]
             num_active_pixels += 1
         end
     end
@@ -84,7 +84,9 @@ function test_load_active_pixels()
 
     total_photons = 0.0
     for img in ea.images
-        total_photons += sum(img.pixels) - sum(img.epsilon_mat)
+        for w in 1:img.W, h in 1:img.H
+            total_photons += img.pixels[h, w] - img.sky[h, w]
+        end
     end
 
     @test num_active_photons <= total_photons  # sanity check
@@ -92,7 +94,9 @@ function test_load_active_pixels()
 
     # super dim images
     for img in ea.images
-        img.pixels[:,:] = img.epsilon_mat[:,:]
+        for w in 1:img.W, h in 1:img.H
+            img.pixels[h, w] = img.sky[h, w]
+        end
     end
 
     # only 2 pixels per image are within 0.6 pixels of the

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -1,7 +1,8 @@
 using Base.Test
 import SensitiveFloats: zero_sensitive_float_array
 
-function test_sky_noise_estimates()
+
+@testset "sky noise estimates" begin
     images_vec = Vector{Vector{Image}}(2)
     ea, vp, three_bodies = gen_three_body_dataset()  # synthetic
     images_vec[1] = ea.images
@@ -9,15 +10,17 @@ function test_sky_noise_estimates()
 
     for images in images_vec
         for b in 1:5
-            sdss_sky_estimate = median(images[b].epsilon_mat) * median(images[b].iota_vec)
-            crude_estimate = median(images[b].pixels)
+            img = images[b]
+            epsilon = img.sky[div(img.H, 2), div(img.W, 2)]
+            sdss_sky_estimate = epsilon * median(img.iota_vec)
+            crude_estimate = median(img.pixels)
             @test isapprox(sdss_sky_estimate / crude_estimate, 1.0, atol=0.3)
         end
     end
 end
 
 
-function test_zero_sensitive_float_array()
+@testset "zero sensitive float array" begin
     S = 3
     sf_vec = zero_sensitive_float_array(Float64, length(ids), S, 3, 5)
     @test size(sf_vec) == (3, 5)
@@ -40,9 +43,3 @@ function test_zero_sensitive_float_array()
         @test all(sf.h .== 0)
     end
 end
-
-
-####################################################
-
-test_sky_noise_estimates()
-test_zero_sensitive_float_array()

--- a/test/test_sdssio.jl
+++ b/test/test_sdssio.jl
@@ -1,12 +1,14 @@
 import Celeste.SDSSIO: SkyIntensity
 
-function test_interp_sky()
+
+@testset "sky interpolations" begin
     small_sky = [1.  2.  3.  4.;
-            5.  6.  7.  8.;
-            9. 10. 11. 12]
+                 5.  6.  7.  8.;
+                 9. 10. 11. 12]
     sky_x = [0.1, 2.5]
     sky_y = [0.5, 2.5, 4.]
-    sky = SkyIntensity(small_sky, sky_x, sky_y)
+    sky = SkyIntensity(small_sky, sky_x, sky_y, ones(2))
+
     @test sky[1, 1] ≈ 1.0
     @test sky[2, 1] ≈ 7.0
     @test sky[1, 2] ≈ 2.5
@@ -15,14 +17,13 @@ function test_interp_sky()
     @test sky[2, 3] ≈ 10.0
 end
 
-# test coordinates out of bounds
-function test_interp_sky_oob()
+@testset "test coordinates out of bounds" begin
     small_sky = [1.  2.  3.  4.;
             5.  6.  7.  8.;
             9. 10. 11. 12]
     sky_x = [-5.0, 4.0]
     sky_y = [-4.0, 5.0]
-    sky = SkyIntensity(small_sky, sky_x, sky_y)
+    sky = SkyIntensity(small_sky, sky_x, sky_y, ones(2))
 
     @test sky[1,1] == 1.0
     @test sky[1,2] == 4.0
@@ -30,9 +31,7 @@ function test_interp_sky_oob()
     @test sky[2,2] == 12.0
 end
 
-# test that read_photoobj handles missing table extensions.
-function test_read_photoobj_missing()
-
+@testset "read_photoobj handles missing table extensions" begin
     # get an example of a photoobj file with a missing table
     fname = joinpath(Pkg.dir("Celeste"), "test", "data",
                      "photoObj-006597-4-0025.fits")
@@ -42,8 +41,3 @@ function test_read_photoobj_missing()
 
     catalog = SDSSIO.read_photoobj(fname)
 end
-
-
-test_read_photoobj_missing()
-test_interp_sky()
-test_interp_sky_oob()

--- a/test/test_wcs.jl
+++ b/test/test_wcs.jl
@@ -6,15 +6,14 @@ import WCS
 const band_letters = ['u', 'g', 'r', 'i', 'z']
 
 
-"Test that the identity WCSTransform works as expected."
-function test_id_wcs()
+@testset "the identity WCSTransform works as expected" begin
     rand_coord = rand(2, 10)
     @test WCS.pix_to_world(SampleData.wcs_id, rand_coord) == rand_coord
     @test WCS.world_to_pix(SampleData.wcs_id, rand_coord) == rand_coord
 end
 
 
-function test_linear_world_to_pix()
+@testset "linear_world_to_pix works" begin
     rcf = SDSSIO.RunCamcolField(3900, 6, 269)
     image = SDSSIO.load_field_images(rcf, datadir)[1]
     wcs = image.wcs
@@ -40,7 +39,3 @@ function test_linear_world_to_pix()
 
     test_jacobian(wcs, pix_center, world_center)
 end
-
-
-test_id_wcs()
-test_linear_world_to_pix()


### PR DESCRIPTION
By not precomputing the sky background, the memory required to store the `Image` instances drops by nearly 50%. For `benchmark_quarter_degree.jl`, memory usage falls from 1.7 GB to 876 MB. Huzzah! 

On master:
```
Base.summarysize(ctni[4]) = 1714282080
```

On `jcr/sky2`
```
Base.summarysize(ctni[4]) = 876331960
```

Runtime doesn't change by more than a couple of percent.

I also added pixel counters in this PR but I'm not logging their values yet.

@kpamnany 