### PR TITLE
Fix bug + support plots of posterior z-scores

### DIFF
--- a/benchmark/accuracy/qq_plot_errors.R
+++ b/benchmark/accuracy/qq_plot_errors.R
@@ -1,0 +1,34 @@
+require(argparse)
+require(dplyr)
+require(ggplot2)
+
+parser <- ArgumentParser()
+parser$add_argument('errors_csv')
+arguments <- parser$parse_args()
+
+data <- (
+    read.csv(arguments$errors_csv)
+    %>% mutate(z_score=error / posterior_std_err)
+)
+
+(ggplot(data, aes(sample=z_score))
+    + stat_qq(shape='O')
+    + geom_abline(slope=1, intercept=0, linetype='dashed')
+    + facet_wrap(~ name, scales='free_y')
+    + theme_bw()
+    + ggtitle('Q-Q plot of errors for all sources')
+)
+
+trimmed_data <- (
+    data
+    %>% group_by(name)
+    %>% filter(abs(z_score) < quantile(abs(z_score), 0.9))
+)
+
+(ggplot(trimmed_data, aes(sample=z_score))
+    + stat_qq(shape='O')
+    + geom_abline(slope=1, intercept=0, linetype='dashed')
+    + facet_wrap(~ name, scales='free_y')
+    + theme_bw()
+    + ggtitle('Q-Q plot of middle 90% of errors')
+)

--- a/benchmark/accuracy/score_uncertainty.jl
+++ b/benchmark/accuracy/score_uncertainty.jl
@@ -5,7 +5,12 @@ using DataFrames
 import Celeste.AccuracyBenchmark
 import Celeste.ArgumentParse
 
-parser = Celeste.ArgumentParse.ArgumentParser()
+parser = ArgumentParse.ArgumentParser()
+ArgumentParse.add_argument(
+    parser,
+    "--write-error-csv",
+    help="Write raw errors to the given CSV file",
+)
 ArgumentParse.add_argument(
     parser,
     "ground_truth_csv",
@@ -20,5 +25,10 @@ parsed_args = ArgumentParse.parse_args(parser, ARGS)
 
 truth = AccuracyBenchmark.read_catalog(parsed_args["ground_truth_csv"])
 predictions = AccuracyBenchmark.read_catalog(parsed_args["celeste_prediction_csv"])
-scores = AccuracyBenchmark.score_uncertainty(truth, predictions)
+uncertainty_df = AccuracyBenchmark.get_uncertainty_df(truth, predictions)
+scores = AccuracyBenchmark.score_uncertainty(uncertainty_df)
 println(repr(scores))
+
+if haskey(parsed_args, "write-error-csv")
+    writetable(parsed_args["write-error-csv"], uncertainty_df)
+end


### PR DESCRIPTION
As described in commit messages.

`get_uncertainty_df` and `get_error_df` could probably be merged but it's nontrivial so i'm putting it off for now.