### PR TITLE
Make Celeste work with latest version of StaticArrays

### DIFF
--- a/src/Synthetic.jl
+++ b/src/Synthetic.jl
@@ -53,7 +53,7 @@ function write_star(img0::Image, ce::CatalogEntry, pixels::Matrix{Float64};
                     expectation=false)
     iota = median(img0.iota_vec)
     for k in 1:length(img0.psf)
-        the_mean = WCS.world_to_pix(img0.wcs, ce.pos) + img0.psf[k].xiBar
+        the_mean = SVector{2}(WCS.world_to_pix(img0.wcs, ce.pos)) + img0.psf[k].xiBar
         the_cov = img0.psf[k].tauBar
         intensity = ce.star_fluxes[img0.b] * iota * img0.psf[k].alphaBar
         write_gaussian(the_mean, the_cov, intensity, pixels,
@@ -71,7 +71,7 @@ function write_galaxy(img0::Image, ce::CatalogEntry, pixels::Matrix{Float64};
     for i in 1:2
         for gproto in galaxy_prototypes[i]
             for k in 1:length(img0.psf)
-                the_mean = WCS.world_to_pix(img0.wcs, ce.pos) +
+                the_mean = SVector{2}(WCS.world_to_pix(img0.wcs, ce.pos)) +
                            img0.psf[k].xiBar
                 the_cov = img0.psf[k].tauBar + gproto.nuBar * XiXi
                 intensity = ce.gal_fluxes[img0.b] * iota *


### PR DESCRIPTION
The promotion in `StaticArrays` has changes such that `SVector+Vector` now produces an `SVector`.