### PR TITLE
Use seeding constructor of MersenneTwister instead of srand

### DIFF
--- a/src/multinode_run.jl
+++ b/src/multinode_run.jl
@@ -426,8 +426,7 @@ function joint_infer_boxes(config::Configs.Config,
     tid = threadid()
     all_threads_timing[tid] = InferTiming()
     thread_timing = all_threads_timing[tid]
-    rng = MersenneTwister()
-    srand(rng, 42)
+    rng = MersenneTwister(42)
 
     # Dtree parent ranks reserve one thread to drive the tree
     if mi.rundt && tid == nthreads()


### PR DESCRIPTION
This comes from https://github.com/JuliaLang/julia/pull/16984#issuecomment-290914407 (the zero-arg `MersenneTwister()` will be deprecated). Here the change is not necessary, but thought I could update the code as well.