### PR TITLE
Multi-node joint infer with multiple runs

### DIFF
--- a/bin/infer-boxes.jl
+++ b/bin/infer-boxes.jl
@@ -1,44 +1,87 @@
 #!/usr/bin/env julia
 
 import Celeste.ParallelRun: BoundingBox, infer_boxes
+import Celeste.SDSSIO: RunCamcolField
 import Celeste.Log
 
-if length(ARGS) != 2
-    println("""
-        Usage:
-          infer-boxes.jl <boxes_file> <out_dir>
 
-        <boxes_file> format, one line per box:
-        <difficulty>	<#RCFs>	<#sources>	<ramin> <ramax> <decmin> <decmax>
-        """)
-else
-    all_boxes = BoundingBox[]
-    box_source_counts = Int64[]
-    boxes_file = ARGS[1]
-    f = open(boxes_file)
-    for ln in eachline(f)
-        lp = split(ln, '\t')
-        if length(lp) != 4
-            println("malformed line in box file, skipping remainder")
-            println("> $ln")
-            break
-        end
-        sc = parse(Int64, lp[3])
-        push!(box_source_counts, sc)
-        ss = split(lp[4], ' ')
-        ramin = parse(Float64, ss[1])
-        ramax = parse(Float64, ss[2])
-        decmin = parse(Float64, ss[3])
-        decmax = parse(Float64, ss[4])
-        bb = BoundingBox(ramin, ramax, decmin, decmax)
-        push!(all_boxes, bb)
-    end
-    close(f)
-    outdir = ARGS[2]
-    if length(all_boxes) < 1
-        println("box file is empty?")
+function run_infer_boxes(args::Vector{String})
+    if length(args) < 3
+        println("""
+Usage:
+  infer-boxes.jl <rcf_nsrcs_file> <boxes_file> [<boxes_file>...] <out_dir>
+
+<rcf_nsrcs_file> format, one line per RCF:
+  <run>	<camcol>	<field>	<num_primary_sources>
+
+<boxes_file> format, one line per box:
+  <difficulty>	<#RCFs>	<#sources>	<ramin> <ramax> <decmin> <decmax>	<rcf1idx>,<rcf2idx>...
+            """)
         exit(-1)
     end
-    infer_boxes(all_boxes, box_source_counts, ENV["CELESTE_STAGE_DIR"], outdir)
+    if !haskey(ENV, "CELESTE_STAGE_DIR")
+        Log.one_message("ERROR: set CELESTE_STAGE_DIR!")
+        exit(-2)
+    end
+
+    # load the RCFs #sources file
+    rcf_nsrcs_file = args[1]
+    all_rcfs = Vector{RunCamcolField}()
+    all_rcf_nsrcs = Vector{Int16}()
+    f = open(rcf_nsrcs_file)
+    for ln in eachline(f)
+        lp = split(ln, '\t')
+        run = parse(Int16, lp[1])
+        camcol = parse(UInt8, lp[2])
+        field = parse(Int16, lp[3])
+        nsrc = parse(Int16, lp[4])
+        push!(all_rcfs, RunCamcolField(run, camcol, field))
+        push!(all_rcf_nsrcs, nsrc)
+    end
+    close(f)
+
+    # parse the specified box file(s)
+    nboxfiles = length(args) - 2
+    all_boxes = Vector{Vector{BoundingBox}}()
+    all_boxes_rcf_idxs = Vector{Vector{Vector{Int32}}}()
+    for i = 1:nboxfiles
+        boxfile = args[i+1]
+        boxes = Vector{BoundingBox}()
+        boxes_rcf_idxs = Vector{Vector{Int32}}()
+        f = open(boxfile)
+        for ln in eachline(f)
+            lp = split(ln, '\t')
+            if length(lp) != 5
+                Log.one_message("ERROR: malformed line in box file:\n> $ln ")
+                continue
+            end
+
+            ss = split(lp[4], ' ')
+            ramin = parse(Float64, ss[1])
+            ramax = parse(Float64, ss[2])
+            decmin = parse(Float64, ss[3])
+            decmax = parse(Float64, ss[4])
+            bb = BoundingBox(ramin, ramax, decmin, decmax)
+            push!(boxes, bb)
+
+            ris = split(lp[5], ',')
+            rcf_idxs = [parse(Int32, ri) for ri in ris]
+            push!(boxes_rcf_idxs, rcf_idxs)
+        end
+        close(f)
+        if length(boxes) < 1
+            Log.one_message("$boxfile is empty?")
+        end
+        push!(all_boxes, boxes)
+        push!(all_boxes_rcf_idxs, boxes_rcf_idxs)
+    end
+    if length(all_boxes) < 1
+        Log.one_message("box file(s) empty?")
+        exit(-3)
+    end
+
+    infer_boxes(all_rcfs, all_rcf_nsrcs, all_boxes, all_boxes_rcf_idxs,
+                ENV["CELESTE_STAGE_DIR"], args[end])
 end
 
+run_infer_boxes(ARGS)

--- a/src/Log.jl
+++ b/src/Log.jl
@@ -15,17 +15,19 @@ grank() = 1
 end
 
 # thread-safe print function
-@inline ntputs(nid, tid, s...) = ccall(:puts, Cint, (Cstring,), string("[$nid]<$tid> ", s...))
+@inline puts(s...) = ccall(:puts, Cint, (Cstring,), string(s...))
+@inline rtputs(s...) = puts("[$(grank())]<$(threadid())> ", s...)
 
 
 # logging functions
-@inline message(msg...) = ntputs(grank(), threadid(), msg...) 
-@inline error(msg...) = ntputs(grank(), threadid(), "ERROR: ", msg...)
-@inline warn(msg...) = ntputs(grank(), threadid(), "WARN: ", msg...)
+@inline message(msg...) = rtputs(msg...)
+@inline one_message(msg...) = grank() == 1 && puts(msg...) 
+@inline error(msg...) = rtputs("ERROR: ", msg...)
+@inline warn(msg...) = rtputs("WARN: ", msg...)
 
 # In production mode, rather the development mode, don't log debug or info statements
-@inline info(msg...) = is_production_run || ntputs(grank(), threadid(), "INFO: ", msg...)
-@inline debug(msg...) = is_production_run || ntputs(grank(), threadid(), "DEBUG: ", msg...)
+@inline info(msg...) = is_production_run || rtputs("INFO: ", msg...)
+@inline debug(msg...) = is_production_run || rtputs("DEBUG: ", msg...)
 
 # Like `error()`, but include exception info and stack trace. Should only be called from a `catch`
 # block, e.g.,
@@ -39,17 +41,19 @@ function exception(exception::Exception, msg...)
         error(msg...)
     end
     error(exception)
-    error("Stack trace:")
-    stack_trace = catch_stacktrace()
-    if length(stack_trace) > 100
-        stack_trace = vcat(
-            [string(line) for line in stack_trace[1:50]],
-            @sprintf("...(removed %d frames)...", length(stack_trace) - 100),
-            [string(line) for line in stack_trace[(length(stack_trace) - 50):length(stack_trace)]],
-        )
-    end
-    for stack_line in stack_trace
-        error(@sprintf("  %s", stack_line))
+    if !is_production_run
+        error("Stack trace:")
+        stack_trace = catch_stacktrace()
+        if length(stack_trace) > 100
+            stack_trace = vcat(
+                [string(line) for line in stack_trace[1:50]],
+                @sprintf("...(removed %d frames)...", length(stack_trace) - 100),
+                [string(line) for line in stack_trace[(length(stack_trace) - 50):length(stack_trace)]],
+            )
+        end
+        for stack_line in stack_trace
+            error(@sprintf("  %s", stack_line))
+        end
     end
 end
 

--- a/src/SDSSIO.jl
+++ b/src/SDSSIO.jl
@@ -22,17 +22,17 @@ const BAND_CHAR_TO_NUM = Dict('u'=>1, 'g'=>2, 'r'=>3, 'i'=>4, 'z'=>5)
 
 
 immutable RunCamcolField
-    run::Int64
-    camcol::Int64
-    field::Int64
+    run::Int16
+    camcol::UInt8
+    field::Int16
 end
 
 
 function RunCamcolField(run::String, camcol::String, field::String)
     RunCamcolField(
-        parse(Int64, run),
-        parse(Int64, camcol),
-        parse(Int64, field))
+        parse(Int16, run),
+        parse(UInt8, camcol),
+        parse(Int16, field))
 end
 
 

--- a/src/joint_infer.jl
+++ b/src/joint_infer.jl
@@ -302,7 +302,7 @@ function partition_box(npartitions::Int, target_sources::Vector{Int},
         #return partition_cyclades(npartitions, target_sources,
         #                          cyclades_neighbor_map,
         #                          batch_size=batch_size)
-    return partition_cyclades_dynamic(target_sources,
+        return partition_cyclades_dynamic(target_sources,
                                           cyclades_neighbor_map,
                                           batch_size=batch_size)
     else
@@ -374,6 +374,7 @@ function one_node_joint_infer(config::Configs.Config, catalog, target_sources, n
                                                  neighbor_map;
                                                  cyclades_partition=cyclades_partition,
                                                  batch_size=batch_size)
+    #Log.info(batched_connected_components)
 
     Log.info("Done assigning sources to threads for processing")
 
@@ -635,6 +636,6 @@ function show_pixels_processed()
         elbo_vars.active_pixel_counter[] = 0
         elbo_vars.inactive_pixel_counter[] = 0
     end
-    Log.message("(active,inactive) pixels processed: \($n_active, $n_inactive\)")
+    Log.message("$(Time(now())): (active,inactive) pixels processed: \($n_active,$n_inactive\)")
 end
 


### PR DESCRIPTION
Removed multi-node single infer capability. Now, we need an RCF source counts file. Allows passing in multiple box files. Runs joint infer over sources in all boxes in one file, and uses the computed variational parameters for running inference over sources in all boxes in the next file, etc.

SC runs version.