### PR TITLE
fix Optim.Options type over-restriction and add termination_callback test

### DIFF
--- a/src/deterministic_vi/ElboMaximize.jl
+++ b/src/deterministic_vi/ElboMaximize.jl
@@ -31,7 +31,7 @@ immutable Config{N,T}
     bvn_bundle::Model.BvnBundle{T}
     constraints::ConstraintBatch
     derivs::TransformDerivatives{N,T}
-    optim_options::Options{Void}
+    optim_options::Options
     trust_region::NewtonTrustRegion{T}
 end
 

--- a/test/test_optimization.jl
+++ b/test/test_optimization.jl
@@ -5,7 +5,7 @@ using Celeste.DeterministicVI.ConstraintTransforms: ParameterConstraint,
                         ConstraintBatch, BoxConstraint, SimplexConstraint
 using Celeste.DeterministicVI: ElboArgs
 using Celeste.DeterministicVI.ElboMaximize: Config, maximize!, elbo_optim_options
-
+using Optim
 
 function verify_sample_star(vs, pos)
     @test vs[ids.a[2]] <= 0.01
@@ -98,7 +98,18 @@ function test_full_elbo_optimization()
 end
 
 
+function test_termination_callback()
+    ea, vp, catalog = gen_sample_galaxy_dataset(; include_kl = false);
+    terminated = false
+    callback = x -> (terminated = x.iteration >= 3; return terminated)
+    cfg = Config(ea, vp; termination_callback = callback)
+    _, _, _, result = maximize!(ea, vp, cfg)
+    return terminated && Optim.iterations(result) == 3
+end
+
+
 test_star_optimization()
 test_single_source_optimization()
 test_full_elbo_optimization()
 test_galaxy_optimization()
+test_termination_callback()


### PR DESCRIPTION
The single type parameter of `Optim.Options` is actually the type of the callback, and we were always restricting it to `Void` before (since `callback = nothing` by default). I removed that restriction in `Config` to allow for actual callbacks to be passed.

This PR also adds a test to ensure that Optim is actually using/respecting the callback (which it seems to do appropriately).