### PR TITLE
Joint auto batchsize 2

### DIFF
--- a/src/joint_infer.jl
+++ b/src/joint_infer.jl
@@ -237,7 +237,7 @@ function partition_cyclades_dynamic(target_sources, neighbor_map; batch_size=60)
         for (component_group_id, sources_of_component) in cur_batch_component
             push!(thread_sources_assignment[cur_batch], copy(sources_of_component))
         assigned_sources += length(sources_of_component)
-        end		
+        end
     end
 
     #Log.info("Cyclades - Assigned sources: $(assigned_sources) vs correct number of sources: $(n_sources)")
@@ -353,15 +353,9 @@ function partition_cyclades_dynamic_auto_batchsize(target_sources, neighbor_map,
         score = 0
         for batch in ccs
             # Find average load imbalance within the batch as a percentage
-            #times = [length(x) for x in batch]
 	    times = [sum([estimate_time(ea_vec[source_index].patches) for source_index in component]) for component in batch]
-            #println("Raw times $(times)")
             times = load_balance_across_threads(n_threads, times)
-            #println("Load balanced times $(times)")
             estimated_imbalance = mean(maximum(times) - times) 
-            #cur_load_imbalance = max(estimated_imbalance, cur_load_imbalance)
-            #score += length(times)
-	    #score = max(estimated_imbalance, score)
 	    score += estimated_imbalance
         end
         println("Score: $(score)")


### PR DESCRIPTION

Fixed
---------------
[1]<1> INFO: Batch 1 - [45.4487, 46.3055, 44.257, 54.4377, 228.014, 43.4422, 44.7916, 44.3096]
[1]<1> INFO: Batch 1 avg threads idle: 70% (159.13789280225 / 228.01363512)
[1]<1> INFO: Batch 1 - [0.112043, 1.50999, 0.148851, 0.194923, 0.117866, 0.0959366, 35.8763, 0.34163]
[1]<1> INFO: Batch 1 avg threads idle: 87% (31.076588655125 / 35.876278633)
[1]<1> INFO: Batch 1 - [0.120972, 0.184284, 0.333705, 19.0728, 0.132289, 0.0776484, 0.119532, 1.33049]
[1]<1> INFO: Batch 1 avg threads idle: 86% (16.401307544249995 / 19.07276834)
[1]<1> INFO: Total idle time: 1652.926312013

Auto
----------------------
[1]<1> Processing with dynamic connected components load balancing
[1]<1> INFO: Batch 1 - [4.66069, 9.02648, 56.0334, 5.62749, 1.83023, 8.56493, 2.85573, 3.90765]
[1]<1> INFO: Batch 1 avg threads idle: 79% (44.470064797250004 / 56.033389442)
[1]<1> INFO: Batch 2 - [9.54602, 5.14386, 4.87624, 2.96102, 10.8839, 5.94834, 8.71885, 1.97776]
[1]<1> INFO: Batch 2 avg threads idle: 43% (4.6269010475 / 10.883899854)
[1]<1> INFO: Batch 3 - [5.50868, 6.33543, 2.04802, 2.49867, 16.6963, 2.05799, 11.2987, 11.9882]
[1]<1> INFO: Batch 3 avg threads idle: 56% (9.392309876125 / 16.696307045)
[1]<1> INFO: Batch 1 - [0.573834, 4.92508, 0.426405, 0.787771, 3.80408, 0.873283, 0.0905221, 5.08893]
[1]<1> INFO: Batch 1 avg threads idle: 59% (3.017692408125 / 5.088930887)
[1]<1> INFO: Batch 2 - [4.91996, 2.70855, 0.706939, 1.84675, 0.128162, 0.125795, 2.23436, 1.1497]
[1]<1> INFO: Batch 2 avg threads idle: 65% (3.192437653 / 4.919964434)
[1]<1> INFO: Batch 3 - [2.07688, 4.62022, 2.37779, 0.116231, 0.153974, 5.29719, 0.709922, 0.467859]
[1]<1> INFO: Batch 3 avg threads idle: 63% (3.3196820347500005 / 5.297189123)
[1]<1> INFO: Batch 1 - [0.319126, 1.46545, 1.1803, 1.09311, 0.642828, 0.507094, 0.835996, 0.083363]
[1]<1> INFO: Batch 1 avg threads idle: 48% (0.6995402398749999 / 1.465447893)
[1]<1> INFO: Batch 2 - [1.00787, 0.532199, 0.12991, 0.815132, 0.695769, 0.270221, 0.589658, 0.573597]
[1]<1> INFO: Batch 2 avg threads idle: 43% (0.431079856375 / 1.007874876)
[1]<1> INFO: Batch 3 - [0.776568, 1.47652, 0.891136, 0.357014, 0.155678, 0.189897, 0.335379, 1.15842]
[1]<1> INFO: Batch 3 avg threads idle: 55% (0.8089421702499999 / 1.476518266)
[1]<1> INFO: Total idle time: 559.6692006660002