### PR TITLE
Support for bigfiles

### DIFF
--- a/bin/binutil.jl
+++ b/bin/binutil.jl
@@ -1,0 +1,48 @@
+import Celeste.SDSSIO: RunCamcolField, PlainFITSStrategy, BigFileStrategy
+
+function decide_strategy(strategyarg, nsrcsarg)
+    if !haskey(ENV, "CELESTE_STAGE_DIR")
+        Log.one_message("ERROR: set CELESTE_STAGE_DIR!")
+        exit(-2)
+    end
+
+    # load the RCFs #sources file
+    rcf_nsrcs_file = nsrcsarg
+    all_rcfs = Vector{RunCamcolField}()
+    all_rcf_nsrcs = Vector{Int16}()
+    f = open(rcf_nsrcs_file)
+    for ln in eachline(f)
+        lp = split(ln, '\t')
+        run = parse(Int16, lp[1])
+        camcol = parse(UInt8, lp[2])
+        field = parse(Int16, lp[3])
+        nsrc = parse(Int16, lp[4])
+        push!(all_rcfs, RunCamcolField(run, camcol, field))
+        push!(all_rcf_nsrcs, nsrc)
+    end
+    close(f)
+
+    strategy = PlainFITSStrategy(ENV["CELESTE_STAGE_DIR"])
+    if !isempty(strategyarg)
+        which = strategyarg
+        if which ==  "mdtfits"
+            stagedir = strategy.stagedir
+            datadir(rcf) = joinpath(stagedir,"mdt$(rcf.run%5)","plan_b")
+            strategy = PlainFITSStrategy(stagedir, datadir, false)
+        elseif which == "mdtfitsslurp"
+            stagedir = strategy.stagedir
+            datadir(rcf) = joinpath(stagedir,"mdt$(rcf.run%5)","plan_b")
+            strategy = PlainFITSStrategy(stagedir, datadir, true)
+        elseif which == "bigfiles"
+            runs = unique(map(rcf->rcf.run, all_rcfs))
+            run_idx_map = Dict(r=>i for (i,r) in enumerate(runs))
+            rcf_idx_map = Dict(rcf=>i for (i,rcf) in enumerate(all_rcfs))
+            bfo = SDSSIO.init_bigfile_io(strategy.stagedir)
+            strategy = BigFileStrategy(strategy.stagedir, bfo, rcf_idx_map, run_idx_map)
+        else
+            Log.one_message("ERROR: Unknown IO strategy $(which)")
+            exit(-2)
+        end
+    end
+    strategy, all_rcfs, all_rcf_nsrcs
+end

--- a/src/Log.jl
+++ b/src/Log.jl
@@ -40,10 +40,14 @@ function exception(exception::Exception, msg...)
     if length(msg) > 0
         error(msg...)
     end
-    error(exception)
+    if !is_production_run
+        stack_trace = catch_stacktrace()
+    end
+    buf = IOBuffer()
+    Base.showerror(buf, exception)
+    error(takebuf_string(buf))
     if !is_production_run
         error("Stack trace:")
-        stack_trace = catch_stacktrace()
         if length(stack_trace) > 100
             stack_trace = vcat(
                 [string(line) for line in stack_trace[1:50]],

--- a/src/ParallelRun.jl
+++ b/src/ParallelRun.jl
@@ -372,12 +372,14 @@ Use multiple threads on one node to fit the Celeste model to sources in a given
 bounding box.
 """
 function one_node_infer(rcfs::Vector{RunCamcolField},
-                        strategy::SDSSIO.IOStrategy;
+                        stagedir::String;
                         infer_callback=one_node_single_infer,
                         objid="",
                         box=BoundingBox(-1000., 1000., -1000., 1000.),
                         primary_initialization=true,
                         timing=InferTiming())
+    strategy = PlainFITSStrategy(stagedir)
+
     catalog, target_sources, neighbor_map, images =
         infer_init(rcfs,
                    strategy;

--- a/src/SDSSIO.jl
+++ b/src/SDSSIO.jl
@@ -90,8 +90,8 @@ Read an SDSS \"frame\" FITS file and return a 4-tuple:
 - `sky`: 2-d sky that was subtracted.
 - `wcs`: WCSTransform constructed from image header.
 """
-function read_frame(fname, slurp::Bool = false)
-    f = FITSIO.FITS(slurp ? slurp_fits(fname) : fname)
+function read_frame(fname; data=nothing)
+    f = FITSIO.FITS(data != nothing ? data : fname)
     hdr = FITSIO.read_header(f[1], String)::String
     image = read(f[1])::Array{Float32, 2}  # sky-subtracted & calibrated data
     calibration = read(f[2])::Vector{Float32}
@@ -112,8 +112,8 @@ read_field_gains(fname, fieldnum)
 Return the image gains for field number `fieldnum` in an SDSS
 \"photoField\" file `fname`.
 """
-function read_field_gains(fname, fieldnum::Integer, slurp::Bool = false)
-    f = FITSIO.FITS(slurp ? slurp_fits(fname) : fname)
+function read_field_gains(fname, fieldnum::Integer; data=nothing)
+    f = FITSIO.FITS(data != nothing ? data : fname)
     fieldnums = read(f[2], "FIELD")::Vector{Int32}
     gains = read(f[2], "GAIN")::Array{Float32, 2}
     close(f)
@@ -137,8 +137,8 @@ Read a \"fpM\"-format SDSS file and return masked image ranges,
 based on `mask_planes`. Returns two `Vector{UnitRange{Int}}`,
 giving the range of x and y indicies to be masked.
 """
-function read_mask(fname, slurp::Bool=false, mask_planes=DEFAULT_MASK_PLANES)
-    f = FITSIO.FITS(slurp ? slurp_fits(fname) : fname)
+function read_mask(fname, mask_planes=DEFAULT_MASK_PLANES; data=nothing)
+    f = FITSIO.FITS(data != nothing ? data : fname)
 
     # The last (12th) HDU contains a key describing what each of the
     # other HDUs are. Use this to find the indicies of all the relevant
@@ -203,7 +203,8 @@ function load_raw_images(rcf::RunCamcolField, datadir, slurp::Bool = false, drop
 
     # read gain for each band
     photofield_name = "$subdir2/photoField-$(dec(rcf.run,6))-$(rcf.camcol).fits"
-    gains = read_field_gains(photofield_name, rcf.field, slurp)
+    gains = read_field_gains(photofield_name, rcf.field;
+                data=(slurp ? slurp_fits(photofield_name) : nothing))
 
     # open FITS file containing PSF for each band
     psf_name = "$(subdir3)/psField-$(dec(rcf.run,6))-$(rcf.camcol)-$(dec(rcf.field,4)).fit"
@@ -214,24 +215,8 @@ function load_raw_images(rcf::RunCamcolField, datadir, slurp::Bool = false, drop
     for (b, band) in enumerate(['u', 'g', 'r', 'i', 'z'])
         # load image data
         frame_name = "$(subdir3)/frame-$(band)-$(dec(rcf.run,6))-$(rcf.camcol)-$(dec(rcf.field,4)).fits"
-        pixels, calibration, sky, wcs = read_frame(frame_name, slurp)
-
-        # read mask
         mask_name = "$(subdir3)/fpM-$(dec(rcf.run,6))-$(band)$(rcf.camcol)-$(dec(rcf.field,4)).fit"
-        mask_xranges, mask_yranges = read_mask(mask_name, slurp)
-
-        # apply mask
-        for i=1:length(mask_xranges)
-            pixels[mask_xranges[i], mask_yranges[i]] = NaN
-        end
-
-        # read the psf
-        raw_psf_comp = read_psf(psffile, band)
-
-        # Set it to use a constant background but include the non-constant data.
-        r = RawImage(rcf, b,
-                            pixels, calibration, sky, wcs,
-                            gains[band], raw_psf_comp)
+        r = parse_image(rcf, b, frame_name, mask_name, psffile, band, gains)
         if !drop_quickly
             raw_images[b] = r
         end
@@ -239,6 +224,31 @@ function load_raw_images(rcf::RunCamcolField, datadir, slurp::Bool = false, drop
     close(psffile)
 
     return raw_images
+end
+
+function parse_image(rcf, b, frame_name, mask_name, psffile, band, gains; frame_data=nothing, mask_data=nothing)
+    @assert !isempty(frame_name) || frame_data != nothing
+    @assert !isempty(mask_name) || mask_data != nothing
+
+    # load image data
+    pixels, calibration, sky, wcs = read_frame(frame_name; data=frame_data)
+
+    # read mask
+    mask_xranges, mask_yranges = read_mask(mask_name; data=mask_data)
+
+    # apply mask
+    for i=1:length(mask_xranges)
+        pixels[mask_xranges[i], mask_yranges[i]] = NaN
+    end
+
+    # read the psf
+    raw_psf_comp = read_psf(psffile, band)
+
+    # Set it to use a constant background but include the non-constant data.
+    r = RawImage(rcf, b,
+                        pixels, calibration, sky, wcs,
+                        gains[band], raw_psf_comp)
+    r
 end
 
 
@@ -361,10 +371,10 @@ columns.
 The photoObj file format is documented here:
 https://data.sdss.org/datamodel/files/BOSS_PHOTOOBJ/RERUN/RUN/CAMCOL/photoObj.html
 """
-function read_photoobj(fname, band::Char='r', slurp::Bool=false)
+function read_photoobj(fname, band::Char='r'; data=nothing)
     b = BAND_CHAR_TO_NUM[band]
 
-    f = FITSIO.FITS(slurp ? slurp_fits(fname) : fname)
+    f = FITSIO.FITS(data != nothing ? data : fname)
 
     # sometimes the expected table extension is only an empty generic FITS
     # header, indicating no objects. We check explicitly for this case here
@@ -541,55 +551,8 @@ function convert(::Type{Vector{CatalogEntry}}, catalog::Dict{String, Any})
 end
 
 
-"""
-read_photoobj_files(fieldids, dirs) -> Vector{CatalogEntry}
-
-Combine photoobj catalogs for the given overlapping fields, returning a single
-joined catalog.
-
-The `duplicate_policy` argument controls how catalogs are joined.
-With `duplicate_policy = :primary`, only primary objects are included in the
-combined catalog.
-With `duplicate_policy = :first`, only the first detection is included in the
-combined catalog.
-"""
-function read_photoobj_files(fts::Vector{RunCamcolField},
-                             datadir;
-                             duplicate_policy=:primary,
-                             slurp::Bool = false,
-                             drop_quickly::Bool = false)
-    @assert duplicate_policy == :primary || duplicate_policy == :first
-    @assert duplicate_policy == :primary || length(fts) == 1
-
-    #Log.info("reading photoobj catalogs for $(length(fts)) fields")
-
-    # the code below assumes there is at least one field.
-    if length(fts) == 0
-        return CatalogEntry[]
-    end
-
-    # Read in all photoobj catalogs.
-    rawcatalogs = Vector{Dict}(length(fts))
-    for i in eachindex(fts)
-        ft = fts[i]
-        basedir = isa(datadir, String) ? datadir : datadir(ft)
-        dir = "$basedir/$(ft.run)/$(ft.camcol)/$(ft.field)"
-        fname = "$dir/photoObj-$(dec(ft.run,6))-$(dec(ft.camcol))-$(dec(ft.field,4)).fits"
-        #Log.info("field $(fts[i]): reading $fname")
-        po = read_photoobj(fname, 'r', slurp)
-        if !drop_quickly
-            rawcatalogs[i] = po
-        end
-    end
-
-    if drop_quickly
-        return CatalogEntry[]
-    end
-
-    #for i in eachindex(fts)
-    #    Log.info("field $(fts[i]): $(length(rawcatalogs[i]["objid"])) entries")
-    #end
-
+function assemble_catalog(rawcatalogs::Vector{Dict};
+                          duplicate_policy=:primary)
     # Limit each catalog to primary objects and objects where thing_id != -1
     # (thing_id == -1 indicates that the matching process failed)
     for cat in rawcatalogs
@@ -629,6 +592,58 @@ function read_photoobj_files(fts::Vector{RunCamcolField},
 end
 
 
+"""
+read_photoobj_files(fieldids, dirs) -> Vector{CatalogEntry}
+
+Combine photoobj catalogs for the given overlapping fields, returning a single
+joined catalog.
+
+The `duplicate_policy` argument controls how catalogs are joined.
+With `duplicate_policy = :primary`, only primary objects are included in the
+combined catalog.
+With `duplicate_policy = :first`, only the first detection is included in the
+combined catalog.
+"""
+function read_photoobj_files(fts::Vector{RunCamcolField}, datadir;
+                             duplicate_policy=:primary,
+                             slurp::Bool = false, drop_quickly::Bool = false)
+    @assert duplicate_policy == :primary || duplicate_policy == :first
+    @assert duplicate_policy == :primary || length(fts) == 1
+
+    #Log.info("reading photoobj catalogs for $(length(fts)) fields")
+
+    # the code below assumes there is at least one field.
+    if length(fts) == 0
+        return CatalogEntry[]
+    end
+
+    # Read in all photoobj catalogs.
+    rawcatalogs = Vector{Dict}(length(fts))
+    for i in eachindex(fts)
+        ft = fts[i]
+        basedir = isa(datadir, String) ? datadir : datadir(ft)
+        dir = "$basedir/$(ft.run)/$(ft.camcol)/$(ft.field)"
+        fname = "$dir/photoObj-$(dec(ft.run,6))-$(dec(ft.camcol))-$(dec(ft.field,4)).fits"
+        #Log.info("field $(fts[i]): reading $fname")
+        po = read_photoobj(fname, 'r';
+                           data=(slurp ? slurp_fits(fname) : nothing))
+        if !drop_quickly
+            rawcatalogs[i] = po
+        end
+    end
+
+    if drop_quickly
+        return CatalogEntry[]
+    end
+
+    #for i in eachindex(fts)
+    #    Log.info("field $(fts[i]): $(length(rawcatalogs[i]["objid"])) entries")
+    #end
+
+    return assemble_catalog(rawcatalogs; duplicate_policy=duplicate_policy)
+end
+
+
 # TODO: this is obsolete, remove it.
 """
 read_photoobj_celeste(fname)
@@ -639,5 +654,236 @@ function read_photoobj_celeste(fname)
     rawcatalog = read_photoobj(fname)
     convert(Vector{CatalogEntry}, rawcatalog)
 end
+
+
+# -----------------------------------------------------------------------------
+# big file I/O
+
+const NumRuns = 761
+const NumCamcols = 6
+const EachPhotoField = 3*1024*1024
+
+const NumRCFs = 924038
+const EachRCF = 97*1024*1024
+const GoodTransferSize = 4*1024*1024
+const EachBigFile = 3298534883328
+const NumRCFFiles = 12
+const MaxRCFFileSize = 12*1024*1024
+
+
+immutable BigFileIO
+    num_bf::Int
+    fds::Vector{Cint}
+    pffd::Cint
+end
+
+
+function init_bigfile_io(datadir::String)
+    all_b = NumRCFs * EachRCF
+    quot, rem = divrem(all_b, EachBigFile)
+    num_bf = quot + (rem > 0 ? 1 : 0)
+    fds = Vector{Cint}(num_bf)
+    for i = 1:num_bf
+        fn = joinpath(datadir, "celeste_sdss-$i")
+        fds[i] = ccall(:open, Cint, (Ptr{UInt8}, Cint, Cint), fn,
+                       Base.Filesystem.JL_O_RDONLY, 0)
+        if fds[i] == -1
+            @show fn
+            systemerror("open", true)
+        end
+    end
+
+    fn = joinpath(datadir, "celeste_sdss-photofields")
+    pffd = ccall(:open, Cint, (Ptr{UInt8}, Cint, Cint), fn,
+                       Base.Filesystem.JL_O_RDONLY, 0)
+    systemerror("open", pffd == -1)
+
+    return BigFileIO(num_bf, fds, pffd)
+end
+
+
+function shutdown_bigfile_io(bfo::BigFileIO)
+    ccall(:close, Cint, (Cint,), bfo.pffd)
+    bfo.pffd = convert(Cint, -1)
+    for i = 1:bfo.num_bf
+        ccall(:close, Cint, (Cint,), bfo.fds[i])
+    end
+    bfo.num_bf = 0
+    empty!(bfo.fds)
+end
+
+const fileOrder = Dict{Symbol, Int}(
+    :fpMg       =>  1,
+    :fpMi       =>  2,
+    :fpMr       =>  3,
+    :fpMu       =>  4,
+    :fpMz       =>  5,
+    :frameg     =>  6,
+    :framei     =>  7,
+    :framer     =>  8,
+    :frameu     =>  9,
+    :framez     => 10,
+    :photoObj   => 11,
+    :psField    => 12
+)
+
+struct RCFBundle
+    images::Dict{Symbol, Vector{UInt8}}
+    photofield_data::Vector{UInt8}
+end
+
+# No mutable state, so should be ok to manipulate GC state
+@noinline function pread64(fd::Cint, data::Ptr{UInt8}, size::Csize_t, offset::Csize_t)
+    gc_state = ccall(:jl_gc_safe_enter, Int8, ())
+    rsize = ccall(:pread64, Cint, (Cint, Ptr{UInt8}, Csize_t, Csize_t), fd, data, size, offset)
+    ccall(:jl_gc_safe_leave, Void, (Int8,), gc_state)
+    rsize
+end
+
+function load_rcf_bundle(bfo::BigFileIO, rcf::RunCamcolField, rcf_idx_map, run_idx_map;
+                         data_buf = zeros(UInt8, EachRCF + EachPhotoField))
+    ridx = rcf_idx_map[rcf] - 1
+    bfidx, bfofs = divrem(ridx * EachRCF, EachBigFile)
+    bfidx += 1
+    # We have a header, but it doesn't actually tell us how large the whole thing is, just slurp it all at once
+    rsize = pread64(bfo.fds[bfidx], pointer(data_buf), Csize_t(EachRCF), Csize_t(bfofs))
+    systemerror("pread", rsize != EachRCF)
+    fofs = reinterpret(Int64, data_buf[1:(NumRCFFiles * sizeof(Int64))])
+
+    # Now read the photofield data
+    pidx = ((run_idx_map[rcf.run]-1) * NumCamcols * EachPhotoField) +
+           ((rcf.camcol - 1) * EachPhotoField)
+    rsize = pread64(bfo.pffd, pointer(data_buf) + EachRCF, Csize_t(EachPhotoField), Csize_t(pidx))
+    systemerror("pread", rsize != EachPhotoField)
+    photofield_data = data_buf[EachRCF+1:end]
+
+    data = Dict{Symbol, Vector{UInt8}}()
+    for (k, v) in fileOrder
+        startidx = fofs[v]
+        endidx = v == 12 ? EachRCF : fofs[v+1]
+        (v == 1) && (@assert startidx == NumRCFFiles * sizeof(UInt64))
+        data[k] = data_buf[startidx+1:endidx]
+    end
+    RCFBundle(data, photofield_data)
+end
+function load_rcf_bundles(bfo::BigFileIO, rcfs::Vector{RunCamcolField}, rcf_idx_map, run_idx_map;
+                         data_buf = zeros(UInt8, EachRCF + EachPhotoField))
+    [load_rcf_bundle(bfo, rcf, rcf_idx_map, run_idx_map) for rcf in rcfs]
+end
+
+function read_bigfile_photoobjs(rcf_bundles::Vector{RCFBundle};
+                                duplicate_policy=:primary,
+                                drop_quickly=false)
+    @assert duplicate_policy == :primary || duplicate_policy == :first
+    @assert duplicate_policy == :primary || length(fts) == 1
+
+    if length(rcf_bundles) == 0
+        return CatalogEntry[]
+    end
+
+    rawcatalogs = Vector{Dict}(length(rcf_bundles))
+    for i in eachindex(rcf_bundles)
+        rcf_bundle = rcf_bundles[i]
+        po = read_photoobj(""; data=rcf_bundle.images[:photoObj])
+        if !drop_quickly
+            rawcatalogs[i] = po
+        end
+    end
+
+    if drop_quickly
+        return CatalogEntry[]
+    end
+
+    return assemble_catalog(rawcatalogs; duplicate_policy=duplicate_policy)
+end
+
+function load_raw_images_bigfile(rcf::RunCamcolField,
+                                 rcf_bundle::RCFBundle;
+                                 drop_quickly = false)
+    gains = read_field_gains("", rcf.field; data = rcf_bundle.photofield_data)
+    psffile = FITSIO.FITS(rcf_bundle.images[:psField])
+    raw_images = Vector{RawImage}(5)
+    for (b, band) in enumerate(['u', 'g', 'r', 'i', 'z'])
+        # load image data
+        r = parse_image(rcf, b, "", "", psffile, band, gains;
+            frame_data = rcf_bundle.images[Symbol("frame$band")],
+            mask_data = rcf_bundle.images[Symbol("fpM$band")])
+        if !drop_quickly
+            raw_images[b] = r
+        end
+    end
+    raw_images
+end
+
+function load_raw_images_bigfile(rcfs::Vector{RunCamcolField},
+                                 rcf_bundles::Vector{RCFBundle};
+                                 drop_quickly = false)
+    mapreduce(data->load_raw_images_bigfile(data...; drop_quickly=drop_quickly), vcat, zip(rcfs, rcf_bundles))
+end
+
+
+# IO Strategies
+abstract type IOStrategy end
+
+struct PlainFITSStrategy <: IOStrategy
+    stagedir::String
+    # Could be a string or rcf -> stagedir function
+    rcf_stagedir
+    slurp::Bool
+end
+PlainFITSStrategy(stagedir::String, slurp::Bool = false) = PlainFITSStrategy(stagedir, stagedir, slurp)
+
+struct BigFileStrategy <: IOStrategy
+    stagedir::String
+    bfo::BigFileIO
+    rcf_idx_map
+    run_idx_map
+end
+
+# We load data on demand, do nothing here
+preload_rcfs(::PlainFITSStrategy, rcfs) = [nothing for rcf in rcfs]
+preload_rcfs(strategy::BigFileStrategy, rcfs) = load_rcf_bundles(strategy.bfo, rcfs, strategy.rcf_idx_map, strategy.run_idx_map)
+
+read_photoobj(strategy::PlainFITSStrategy, rcf, state; duplicate_policy=:primary, drop_quickly::Bool=false) =
+    read_photoobj_files([rcf],strategy.rcf_stagedir,
+        duplicate_policy = duplicate_policy,
+        slurp = strategy.slurp,
+        drop_quickly = drop_quickly)
+
+read_photoobj(strategy::BigFileStrategy, rcf, rcf_bundle; duplicate_policy=:primary, drop_quickly::Bool=false) =
+    read_bigfile_photoobjs([rcf_bundle],
+        duplicate_policy = duplicate_policy,
+        drop_quickly = drop_quickly)
+
+load_raw_images(strategy::PlainFITSStrategy, rcfs, states, drop_quickly::Bool = false) =
+    SDSSIO.load_raw_images(rcfs, strategy.rcf_stagedir, strategy.slurp, drop_quickly)
+
+load_raw_images(strategy::BigFileStrategy, rcfs, states, drop_quickly::Bool = false) =
+    SDSSIO.load_raw_images_bigfile(rcfs, states; drop_quickly=drop_quickly)
+
+"""
+Read a SDSS run/camcol/field into an array of Images.
+"""
+function load_field_images(strategy::IOStrategy, rcfs, states, drop_quickly::Bool = false)
+    raw_images = SDSSIO.load_raw_images(strategy, rcfs, states, drop_quickly)
+
+    N = length(raw_images)
+    images = Vector{Image}(N)
+
+    drop_quickly && return images
+
+    #Threads.@threads for n in 1:N
+    for n in 1:N
+        try
+            images[n] = convert(Image, raw_images[n])
+        catch exc
+            Log.exception(exc)
+            rethrow()
+        end
+    end
+
+    return images
+end
+
 
 end  # module


### PR DESCRIPTION
Adds a `iostrategy=` option to `infer-boxes.jl` to select `fits` (the original), `mdtfits` (plan B), or `bigfiles` (plan whatever).

`infer-box.jl` should work as before.