### PR TITLE
Added switch to disable prefetching and PeakFlops hacks

### DIFF
--- a/bin/infer-boxes.jl
+++ b/bin/infer-boxes.jl
@@ -10,7 +10,7 @@ function run_infer_boxes(args::Vector{String})
     if length(args) < 3
         println("""
 Usage:
-  infer-boxes.jl [--iostrategy=<strategy>] <rcf_nsrcs_file> <boxes_file> [<boxes_file>...] <out_dir>
+  infer-boxes.jl [--noprefetch] [--iostrategy=<strategy>] <rcf_nsrcs_file> <boxes_file> [<boxes_file>...] <out_dir>
 
 Supported IO Strategies (default is FITS):
   - fits: Load data from stagedir in original SDSS FITS format
@@ -24,6 +24,12 @@ Supported IO Strategies (default is FITS):
   <difficulty>	<#RCFs>	<#sources>	<ramin> <ramax> <decmin> <decmax>	<rcf1idx>,<rcf2idx>...
             """)
         exit(-1)
+    end
+
+    prefetch = true
+    if args[1] == "--noprefetch"
+        shift!(args)
+        prefetch = false
     end
 
     strategyarg = ""
@@ -75,7 +81,7 @@ Supported IO Strategies (default is FITS):
     end
 
     infer_boxes(all_rcfs, all_rcf_nsrcs, all_boxes, all_boxes_rcf_idxs,
-                strategy, args[end])
+                strategy, prefetch, args[end])
 end
 
 run_infer_boxes(ARGS)

--- a/src/ParallelRun.jl
+++ b/src/ParallelRun.jl
@@ -624,6 +624,7 @@ function multi_node_infer(all_rcfs::Vector{RunCamcolField},
                           all_boxes::Vector{Vector{BoundingBox}},
                           all_boxes_rcf_idxs::Vector{Vector{Vector{Int32}}},
                           strategy::SDSSIO.IOStrategy,
+                          prefetch::Bool,
                           outdir::String,
                           dl::Dlog)
     Log.one_message("ERROR: distributed functionality is disabled ",
@@ -641,9 +642,10 @@ function infer_boxes(all_rcfs::Vector{RunCamcolField},
                      all_boxes::Vector{Vector{BoundingBox}},
                      all_boxes_rcf_idxs::Vector{Vector{Vector{Int32}}},
                      strategy::SDSSIO.IOStrategy,
+                     prefetch::Bool,
                      outdir::String)
     # set up distributed log
-    dl = Dlog(outdir)
+    dl = Dlog(joinpath(outdir, "dlog"))
 
     # Base.@time hack for distributed environment
     gc_stats = ()
@@ -652,7 +654,7 @@ function infer_boxes(all_rcfs::Vector{RunCamcolField},
     elapsed_time = time_ns()
 
     multi_node_infer(all_rcfs, all_rcf_nsrcs, all_boxes, all_boxes_rcf_idxs,
-                     strategy, outdir, dl)
+                     strategy, prefetch, outdir, dl)
 
     # Base.@time hack for distributed environment
     elapsed_time = time_ns() - elapsed_time


### PR DESCRIPTION
Use `--noprefetch` as first argument to `infer-boxes.jl` to disable dedicating a thread for prefetching. Turn on/off the PeakFlops const at the top of `multinode_run.jl` to enable or disable the Peak FLOPS configuration (requires `--noprefetch`).