### PR TITLE
Clarification of image gain/calibration parameters, and a new utility script

### DIFF
--- a/benchmark/accuracy/extract_sdss_image.jl
+++ b/benchmark/accuracy/extract_sdss_image.jl
@@ -1,0 +1,48 @@
+#!/usr/bin/env julia
+
+import Celeste: AccuracyBenchmark
+import Celeste: ArgumentParse
+import Celeste: SDSSIO
+
+const OUTPUT_DIRECTORY = joinpath(splitdir(Base.source_path())[1], "output")
+
+parser = ArgumentParse.ArgumentParser()
+ArgumentParse.add_argument(
+    parser,
+    "run",
+    help="SDSS run #",
+    arg_type=Int,
+)
+ArgumentParse.add_argument(
+    parser,
+    "camcol",
+    help="SDSS camcol #",
+    arg_type=Int,
+)
+ArgumentParse.add_argument(
+    parser,
+    "field",
+    help="SDSS field #",
+    arg_type=Int,
+)
+parsed_args = ArgumentParse.parse_args(parser, ARGS)
+
+srand(12345)
+
+rcf = SDSSIO.RunCamcolField(
+    parsed_args["run"],
+    parsed_args["camcol"],
+    parsed_args["field"],
+)
+images = SDSSIO.load_field_images([rcf], AccuracyBenchmark.SDSS_DATA_DIR)
+@assert length(images) == 5
+
+if !isdir(OUTPUT_DIRECTORY)
+    mkdir(OUTPUT_DIRECTORY)
+end
+filename = joinpath(
+    OUTPUT_DIRECTORY,
+    @sprintf("sdss_%s_%s_%s_images.fits", rcf.run, rcf.camcol, rcf.field),
+)
+AccuracyBenchmark.save_images_to_fits(filename, images)
+AccuracyBenchmark.append_hash_to_file(filename)

--- a/benchmark/accuracy/generate_synthetic_field.jl
+++ b/benchmark/accuracy/generate_synthetic_field.jl
@@ -8,23 +8,11 @@ import Celeste.Model
 import Celeste.Synthetic
 
 const PSF_SIGMA_PX = 2.29 # similar to SDSS
+const BAND_SKY_LEVEL_NMGY = [0.2696, 0.3425, 0.7748, 1.6903, 4.9176]
+const BAND_NELEC_PER_NMGY = [146.9, 838.1, 829.8, 597.2, 129.8]
 const OUTPUT_DIRECTORY = joinpath(splitdir(Base.source_path())[1], "output")
 
 parser = Celeste.ArgumentParse.ArgumentParser()
-ArgumentParse.add_argument(
-    parser,
-    "--sky_level_nmgy",
-    arg_type=Float64,
-    default=0.155,
-    help="Sky background noise level, nMgy",
-)
-ArgumentParse.add_argument(
-    parser,
-    "--nelec_per_nmgy",
-    arg_type=Float64,
-    default=180.0,
-    help="Nelec (units of pixel values) per nMgy of flux (aka iota)",
-)
 ArgumentParse.add_argument(
     parser,
     "catalog_csv",
@@ -42,8 +30,8 @@ catalog_entries = [
 template_images = AccuracyBenchmark.make_template_images(
     catalog_data,
     PSF_SIGMA_PX,
-    parsed_args["sky_level_nmgy"],
-    parsed_args["nelec_per_nmgy"],
+    BAND_SKY_LEVEL_NMGY,
+    BAND_NELEC_PER_NMGY,
 )
 generated_images = Synthetic.gen_blob(template_images, catalog_entries)
 

--- a/benchmark/accuracy/generate_synthetic_field.jl
+++ b/benchmark/accuracy/generate_synthetic_field.jl
@@ -8,11 +8,23 @@ import Celeste.Model
 import Celeste.Synthetic
 
 const PSF_SIGMA_PX = 2.29 # similar to SDSS
-const COUNTS_PER_NMGY = 180.0 # a.k.a. "iota" in Celeste
-const SKY_LEVEL_NMGY = 0.155
 const OUTPUT_DIRECTORY = joinpath(splitdir(Base.source_path())[1], "output")
 
 parser = Celeste.ArgumentParse.ArgumentParser()
+ArgumentParse.add_argument(
+    parser,
+    "--sky_level_nmgy",
+    arg_type=Float64,
+    default=0.155,
+    help="Sky background noise level, nMgy",
+)
+ArgumentParse.add_argument(
+    parser,
+    "--nelec_per_nmgy",
+    arg_type=Float64,
+    default=180.0,
+    help="Nelec (units of pixel values) per nMgy of flux (aka iota)",
+)
 ArgumentParse.add_argument(
     parser,
     "catalog_csv",
@@ -30,8 +42,8 @@ catalog_entries = [
 template_images = AccuracyBenchmark.make_template_images(
     catalog_data,
     PSF_SIGMA_PX,
-    SKY_LEVEL_NMGY,
-    COUNTS_PER_NMGY,
+    parsed_args["sky_level_nmgy"],
+    parsed_args["nelec_per_nmgy"],
 )
 generated_images = Synthetic.gen_blob(template_images, catalog_entries)
 

--- a/benchmark/galsim/generate_test_image.py
+++ b/benchmark/galsim/generate_test_image.py
@@ -7,7 +7,7 @@ import sys
 import astropy.io.fits
 import galsim
 
-_logger = logging.getLogger(__name__) 
+_logger = logging.getLogger(__name__)
 
 RANDOM_SEED = 1234
 FITS_COMMENT_PREPEND = 'Celeste: '
@@ -58,7 +58,7 @@ class ImageParameters(object):
         # 0.396 = resolution of SDSS images (https://github.com/jeff-regier/Celeste.jl/pull/411)
         self.arcsec_per_pixel = 0.396
         self.world_origin = WorldCoordinate(0, 0)
-        self.counts_per_nmgy = 1000.0
+        self.band_nelec_per_nmgy = [1000.0 for _ in range(5)]
 
     def degrees_per_pixel(self):
         return self.arcsec_per_pixel / ARCSEC_PER_DEGREE
@@ -179,11 +179,12 @@ class Star(LightSource):
         return self
 
     def get_galsim_light_source(self, band_index, psf_sigma_degrees, image_parameters):
-        flux_counts = (
-            self._common_fields.get_flux_nmgy(band_index) * image_parameters.counts_per_nmgy
+        flux_nelec = (
+            self._common_fields.get_flux_nmgy(band_index)
+            * image_parameters.band_nelec_per_nmgy[band_index]
         )
         return (
-            galsim.Gaussian(flux=flux_counts, sigma=psf_sigma_degrees)
+            galsim.Gaussian(flux=flux_nelec, sigma=psf_sigma_degrees)
                 .shift(self._common_fields.get_world_offset(image_parameters).as_galsim_position())
         )
 
@@ -241,20 +242,21 @@ class Galaxy(LightSource):
                 .shift(self._common_fields.get_world_offset(image_parameters).as_galsim_position())
             )
 
-        flux_counts = (
-            self._common_fields.get_flux_nmgy(band_index) * image_parameters.counts_per_nmgy
+        flux_nelec = (
+            self._common_fields.get_flux_nmgy(band_index)
+            * image_parameters.band_nelec_per_nmgy[band_index]
         )
         half_light_radius_deg = self._half_light_radius_arcsec / ARCSEC_PER_DEGREE
         exponential_profile = apply_shear_and_shift(
             galsim.Exponential(
                 half_light_radius=half_light_radius_deg,
-                flux=flux_counts * (1 - self._de_vaucouleurs_mixture_weight),
+                flux=flux_nelec * (1 - self._de_vaucouleurs_mixture_weight),
             )
         )
         de_vaucouleurs_profile = apply_shear_and_shift(
             galsim.DeVaucouleurs(
                 half_light_radius=half_light_radius_deg,
-                flux=flux_counts * self._de_vaucouleurs_mixture_weight,
+                flux=flux_nelec * self._de_vaucouleurs_mixture_weight,
             )
         )
         galaxy = exponential_profile + de_vaucouleurs_profile
@@ -285,7 +287,7 @@ class GalSimTestCase(object):
         self._light_sources = []
         self.image_parameters = ImageParameters()
         self.psf_sigma_pixels = 4
-        self.sky_level_nmgy = 0.01
+        self.band_sky_level_nmgy = [0.01 for _ in xrange(5)] # very low noise by default
         self.include_noise = False
         self.comment = None
 
@@ -299,8 +301,8 @@ class GalSimTestCase(object):
     def set_world_origin(self, right_ascension_deg, declination_deg):
         self.image_parameters.world_origin = WorldCoordinate(right_ascension_deg, declination_deg)
 
-    def set_counts_per_nmgy(self, counts_per_nmgy):
-        self.image_parameters.counts_per_nmgy = counts_per_nmgy
+    def set_band_nelec_per_nmgy(self, band_nelec_per_nmgy):
+        self.image_parameters.band_nelec_per_nmgy = band_nelec_per_nmgy
 
     def get_resolution(self):
         return self.image_parameters.arcsec_per_pixel
@@ -315,13 +317,16 @@ class GalSimTestCase(object):
         self._light_sources.append(galaxy)
         return galaxy
 
-    def _add_sky_background(self, image, uniform_deviate):
-        sky_level_counts = self.sky_level_nmgy * self.image_parameters.counts_per_nmgy
+    def _add_sky_background(self, image, band_index, uniform_deviate):
+        sky_level_nelec = (
+            self.band_sky_level_nmgy[band_index]
+            * self.image_parameters.band_nelec_per_nmgy[band_index]
+        )
         if self.include_noise:
-            poisson_deviate = galsim.PoissonDeviate(uniform_deviate, mean=sky_level_counts)
+            poisson_deviate = galsim.PoissonDeviate(uniform_deviate, mean=sky_level_nelec)
             image.addNoise(galsim.DeviateNoise(poisson_deviate))
         else:
-            image.array[:] = image.array + sky_level_counts
+            image.array[:] = image.array + sky_level_nelec
 
     def construct_image(self, band_index, uniform_deviate):
         world_origin = self.image_parameters.world_origin.as_galsim_position()
@@ -348,10 +353,12 @@ class GalSimTestCase(object):
                 image,
                 add_to_image=True,
                 method='phot',
-                max_extra_noise=self.sky_level_nmgy * self.image_parameters.counts_per_nmgy / 1000.0,
+                max_extra_noise=
+                    self.band_sky_level_nmgy[band_index]
+                    * self.image_parameters.band_nelec_per_nmgy[band_index] / 1000.0,
                 rng=uniform_deviate,
             )
-        self._add_sky_background(image, uniform_deviate)
+        self._add_sky_background(image, band_index, uniform_deviate)
         return image
 
     def get_fits_header(self, case_index, band_index):
@@ -360,8 +367,8 @@ class GalSimTestCase(object):
         header = collections.OrderedDict([
             ('CLCASEI', (case_index + 1, 'test case index')),
             ('CLDESCR', (self.comment, 'comment')),
-            ('CLIOTA', (self.image_parameters.counts_per_nmgy, 'nelec per nMgy')),
-            ('CLSKY', (self.sky_level_nmgy, 'background level (nMgy each px)')),
+            ('CLIOTA', (self.image_parameters.band_nelec_per_nmgy[band_index], 'nelec per nMgy')),
+            ('CLSKY', (self.band_sky_level_nmgy[band_index], 'background level (nMgy each px)')),
             ('CLNOISE', (self.include_noise, 'was Poisson noise added?')),
             ('CLSIGMA', (self.psf_sigma_pixels, 'Gaussian PSF sigma (px)')),
             ('CLBAND', (band_index + 1, 'color band')),

--- a/benchmark/galsim/generate_test_image.py
+++ b/benchmark/galsim/generate_test_image.py
@@ -360,8 +360,8 @@ class GalSimTestCase(object):
         header = collections.OrderedDict([
             ('CLCASEI', (case_index + 1, 'test case index')),
             ('CLDESCR', (self.comment, 'comment')),
-            ('CLIOTA', (self.image_parameters.counts_per_nmgy, 'counts per nMgy')),
-            ('CLSKY', (self.sky_level_nmgy, '"epsilon" sky level (nMgy each px)')),
+            ('CLIOTA', (self.image_parameters.counts_per_nmgy, 'nelec per nMgy')),
+            ('CLSKY', (self.sky_level_nmgy, 'background level (nMgy each px)')),
             ('CLNOISE', (self.include_noise, 'was Poisson noise added?')),
             ('CLSIGMA', (self.psf_sigma_pixels, 'Gaussian PSF sigma (px)')),
             ('CLBAND', (band_index + 1, 'color band')),

--- a/benchmark/galsim/latest_filenames/latest_galsim_benchmarks.txt
+++ b/benchmark/galsim/latest_filenames/latest_galsim_benchmarks.txt
@@ -1,1 +1,1 @@
-galsim_benchmarks_211593c76e.fits
+galsim_benchmarks_f06b9973a8.fits

--- a/src/AccuracyBenchmark.jl
+++ b/src/AccuracyBenchmark.jl
@@ -743,7 +743,9 @@ function save_images_to_fits(filename::String, images::Vector{Model.Image})
         header = parse_fits_header_from_string(WCS.to_header(band_image.wcs))
         serialize_psf_to_header(band_image.psf, header)
         header["CLSKY"] = mean(band_image.sky.sky_small) * mean(band_image.sky.calibration)
+        FITSIO.set_comment!(header, "CLSKY", "Mean sky background per pixel, nMgy")
         header["CLIOTA"] = mean(band_image.iota_vec)
+        FITSIO.set_comment!(header, "CLIOTA", "Gain, nelec per nMgy")
         write(
             fits_file,
             band_image.pixels,

--- a/src/AccuracyBenchmark.jl
+++ b/src/AccuracyBenchmark.jl
@@ -661,9 +661,11 @@ function get_image_geometry(catalog_data::DataFrame; field_expand_arcsec=20.0)
 end
 
 function make_template_images(
-    catalog_data::DataFrame, psf_sigma_px::Float64, sky_level_nmgy::Float64,
-    nelec_per_nmgy::Float64
+    catalog_data::DataFrame, psf_sigma_px::Float64, band_sky_level_nmgy::Vector{Float64},
+    band_nelec_per_nmgy::Vector{Float64}
 )
+    @assert length(band_sky_level_nmgy) == 5
+    @assert length(band_nelec_per_nmgy) == 5
     geometry = get_image_geometry(catalog_data)
     println("  Image dimensions $(geometry.height_px) H x $(geometry.width_px) W px")
     wcs = WCS.WCSTransform(
@@ -683,9 +685,9 @@ function make_template_images(
             zeros(Float32, (geometry.height_px, geometry.width_px)),
             band,
             wcs,
-            psf_sigma_px,
-            sky_level_nmgy,
-            nelec_per_nmgy,
+            make_simple_psf(psf_sigma_px),
+            band_sky_level_nmgy[band],
+            band_nelec_per_nmgy[band],
         )
     end
 end

--- a/src/SDSSIO.jl
+++ b/src/SDSSIO.jl
@@ -93,7 +93,7 @@ Read an SDSS \"frame\" FITS file and return a 4-tuple:
 function read_frame(fname; data=nothing)
     f = FITSIO.FITS(data != nothing ? data : fname)
     hdr = FITSIO.read_header(f[1], String)::String
-    image = read(f[1])::Array{Float32, 2}  # sky-subtracted & calibrated data
+    image = read(f[1])::Array{Float32, 2}  # sky-subtracted & calibrated data, in nMgy
     calibration = read(f[2])::Vector{Float32}
     sky_small, sky_x, sky_y = read_sky(f[3])
     close(f)
@@ -184,7 +184,7 @@ end
 immutable RawImage
     rcf::RunCamcolField
     b::Int  # band index
-    pixels::Matrix{Float32}
+    pixels::Matrix{Float32} # in nMgy, sky-subtracted and calibrated
     calibration::Vector{Float32}
     sky::SkyIntensity
     wcs::WCS.WCSTransform


### PR DESCRIPTION
This started as an investigation of #655, but I ended up finally understanding how image calibration and gain works, which was documented [here](https://github.com/jeff-regier/Celeste.jl/wiki/About-SDSS-and-Stripe-82), and I've updated the code in various places to more clearly reflect what I learned. I've updated the parameters used in synthetic field generation to more closely match SDSS. (It may eventually make sense for synthetic fields generation to automatically match the image parameters for the corresponding SDSS field, but that would requires various changes to the pipeline and doesn't seem worthwhile right now.) I also added a script, `extract_sdss_image.jl`, which writes a FITS file with raw SDSS data in "sky-added" nelec units, which is the form used internally by Celeste, and the form written for synthetic fields. This should aid debugging in the future and helps compare synthetic imagery to real imagery. As an example, here's a side-by-side of real (left) and Synthetic.jl (right) images for RCF 3325/5/110, "r" band:

![screenshot from 2017-05-02 15-35-44](https://cloud.githubusercontent.com/assets/1097616/25643886/1842219c-2f57-11e7-9fad-5efaee45cf1e.png)

Here I've ensured (I think?) that the color scalings are identical in both images. You can see that now they look very similar. (Note this is not the same synthetic imagery as before, because I didn't have quite the correct background/calibration/gain parameters before.)