### PR TITLE
Refactor IO strategies

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -11,3 +11,7 @@ JLD 0.6.0
 Optim 0.7.4
 StaticArrays 0.5.1
 WCS 0.1.3
+YAML
+TranscodingStreams
+CodecBzip2
+CodecZlib

--- a/src/Celeste.jl
+++ b/src/Celeste.jl
@@ -33,6 +33,8 @@ include("GalsimBenchmark.jl")
 
 include("ArgumentParse.jl")
 
+include("settings.jl")
+
 
 import .ParallelRun: BoundingBox, OptimizedSource
 import .SDSSIO: RunCamcolField, CatalogEntry

--- a/src/settings.jl
+++ b/src/settings.jl
@@ -1,0 +1,23 @@
+using YAML
+using Celeste.SDSSIO
+
+# For now this is only used for IO settings, but other settings could use this too
+function read_settings_file(file)
+    data = open(YAML.load, file)
+    ios = data["io"]
+    dataset = get(ios, "dataset", "sdss")
+    if dataset != "sdss"
+        error("Only SDSS is supported at the moment")
+    end
+    stagedir = get(ios, "basedir", get(ENV, "CELESTE_STAGE_DIR", ""))
+    isempty(stagedir) && error("No data directory set")
+    strategy = get(ios, "strategy", "fits")
+    if strategy == "fits"
+        dirlayout = Symbol(get(ios, "dirlayout", "celeste"))
+        slurp = get(ios, "slurp", false)
+        compressed = get(ios, "compressed", false)
+        return Celeste.SDSSIO.PlainFITSStrategy(stagedir, dirlayout, compressed, stagedir, slurp)
+    elseif strategy == "bigfiles"
+        error("TODO")
+    end
+end

--- a/test/SampleData.jl
+++ b/test/SampleData.jl
@@ -3,7 +3,7 @@ module SampleData
 using Celeste: Model, DeterministicVI
 import Celeste: Infer
 import Celeste: Synthetic
-import Celeste.SDSSIO: RunCamcolField, load_field_images
+import Celeste.SDSSIO: RunCamcolField, load_field_images, PlainFITSStrategy
 
 using Distributions
 using StaticArrays
@@ -39,7 +39,7 @@ cd(wd)
 
 
 const sample_rcf = RunCamcolField(3900, 6, 269)
-const sample_images = load_field_images(sample_rcf, datadir)
+const sample_images = load_field_images(PlainFITSStrategy(datadir),sample_rcf)
 
 
 """

--- a/test/data/Makefile
+++ b/test/data/Makefile
@@ -32,19 +32,23 @@ all : $(SUBDIR3)/fpM-$(RUN6)-u$(CAMCOL)-$(FIELD4).fit \
 field_extents.fits :
 	curl -O http://portal.nersc.gov/project/dasrepo/celeste/field_extents.fits
 
-$(SUBDIR3)/fpM-$(RUN6)-%$(CAMCOL)-$(FIELD4).fit :
+$(SUBDIR3)/fpM-$(RUN6)-%$(CAMCOL)-$(FIELD4).fit.gz :
 	curl --create-dirs -o $(SUBDIR3)/fpM-$(RUN6)-$*$(CAMCOL)-$(FIELD4).fit.gz $(URLBASE)/photo/redux/301/$(RUN_STRIPPED)/objcs/$(CAMCOL)/fpM-$(RUN6)-$*$(CAMCOL)-$(FIELD4).fit.gz
-	gunzip $(SUBDIR3)/fpM-$(RUN6)-$*$(CAMCOL)-$(FIELD4).fit.gz
+$(SUBDIR3)/fpM-$(RUN6)-%$(CAMCOL)-$(FIELD4).fit : $(SUBDIR3)/fpM-$(RUN6)-%$(CAMCOL)-$(FIELD4).fit.gz
+	gunzip < $(SUBDIR3)/fpM-$(RUN6)-$*$(CAMCOL)-$(FIELD4).fit.gz > $(SUBDIR3)/fpM-$(RUN6)-$*$(CAMCOL)-$(FIELD4).fit
 
 $(SUBDIR3)/psField-$(RUN6)-$(CAMCOL)-$(FIELD4).fit :
 	curl --create-dirs -o $(SUBDIR3)/psField-$(RUN6)-$(CAMCOL)-$(FIELD4).fit $(URLBASE)/photo/redux/301/$(RUN_STRIPPED)/objcs/$(CAMCOL)/psField-$(RUN6)-$(CAMCOL)-$(FIELD4).fit
 
-$(SUBDIR3)/frame-%-$(RUN6)-$(CAMCOL)-$(FIELD4).fits :
+$(SUBDIR3)/frame-%-$(RUN6)-$(CAMCOL)-$(FIELD4).fits.bz2 :
 	curl --create-dirs -o $(SUBDIR3)/frame-$*-$(RUN6)-$(CAMCOL)-$(FIELD4).fits.bz2 $(URLBASE)/photoObj/frames/301/$(RUN_STRIPPED)/$(CAMCOL)/frame-$*-$(RUN6)-$(CAMCOL)-$(FIELD4).fits.bz2
-	bunzip2 $(SUBDIR3)/frame-$*-$(RUN6)-$(CAMCOL)-$(FIELD4).fits.bz2
+$(SUBDIR3)/frame-%-$(RUN6)-$(CAMCOL)-$(FIELD4).fits : $(SUBDIR3)/frame-%-$(RUN6)-$(CAMCOL)-$(FIELD4).fits.bz2
+	bunzip2 < $(SUBDIR3)/frame-$*-$(RUN6)-$(CAMCOL)-$(FIELD4).fits.bz2 > $(SUBDIR3)/frame-$*-$(RUN6)-$(CAMCOL)-$(FIELD4).fits
 
 $(SUBDIR3)/photoObj-$(RUN6)-$(CAMCOL)-$(FIELD4).fits :
 	curl --create-dirs -o $(SUBDIR3)/photoObj-$(RUN6)-$(CAMCOL)-$(FIELD4).fits $(URLBASE)/photoObj/301/$(RUN_STRIPPED)/$(CAMCOL)/photoObj-$(RUN6)-$(CAMCOL)-$(FIELD4).fits
 
 $(SUBDIR2)/photoField-$(RUN6)-$(CAMCOL).fits :
 	curl --create-dirs -o $(SUBDIR2)/photoField-$(RUN6)-$(CAMCOL).fits $(URLBASE)/photoObj/301/$(RUN_STRIPPED)/photoField-$(RUN6)-$(CAMCOL).fits
+
+.PRECIOUS: $(SUBDIR3)/frame-%-$(RUN6)-$(CAMCOL)-$(FIELD4).fits.bz2 $(SUBDIR3)/fpM-$(RUN6)-%$(CAMCOL)-$(FIELD4).fit.gz

--- a/test/ioconfigs/compressed.yml
+++ b/test/ioconfigs/compressed.yml
@@ -1,0 +1,7 @@
+io:
+    dataset: sdss
+    dirlayout: celeste
+    basedir: data
+    strategy: fits
+    compressed: true
+    slurp: false

--- a/test/ioconfigs/plain.yml
+++ b/test/ioconfigs/plain.yml
@@ -1,0 +1,7 @@
+io:
+    dataset: sdss
+    dirlayout: celeste
+    basedir: data
+    strategy: fits
+    compressed: false
+    slurp: false

--- a/test/ioconfigs/sdsslayout.yml
+++ b/test/ioconfigs/sdsslayout.yml
@@ -1,0 +1,7 @@
+io:
+    dataset: sdss
+    dirlayout: sdss
+    basedir: data/dr12
+    strategy: fits
+    compressed: false
+    slurp: false

--- a/test/ioconfigs/slurp.yml
+++ b/test/ioconfigs/slurp.yml
@@ -1,0 +1,7 @@
+io:
+    dataset: sdss
+    dirlayout: celeste
+    basedir: data
+    strategy: fits
+    compressed: false
+    slurp: true

--- a/test/test_images.jl
+++ b/test/test_images.jl
@@ -1,5 +1,6 @@
 using Base.Test
 using DataFrames
+using Celeste.SDSSIO: PlainFITSStrategy
 import WCS
 
 const rcf = RunCamcolField(3900, 6, 269)
@@ -33,11 +34,10 @@ end
 function test_images()
     # A lot of tests are in a single function to avoid having to reload
     # the full image multiple times.
-    images = SDSSIO.load_field_images(rcf, datadir)
+    strategy = PlainFITSStrategy(datadir)
+    images = SDSSIO.load_field_images(strategy, [rcf])
 
-    dir = "$datadir/$(rcf.run)/$(rcf.camcol)/$(rcf.field)"
-    fname = @sprintf "%s/photoObj-%06d-%d-%04d.fits" dir rcf.run rcf.camcol rcf.field
-    cat_entries = SDSSIO.read_photoobj_celeste(fname)
+    cat_entries = convert(Vector{CatalogEntry}, SDSSIO.read_photoobj(strategy, rcf))
 
     ea = make_elbo_args(images, cat_entries, patch_radius_pix=1e-6)
 

--- a/test/test_infer.jl
+++ b/test/test_infer.jl
@@ -2,7 +2,7 @@
 import JLD
 
 import Celeste.Configs
-
+using Celeste.SDSSIO
 
 """
 test infer with a single (run, camcol, field).
@@ -128,9 +128,10 @@ end
     run(`make RUN=4114 CAMCOL=4 FIELD=127`)
     cd(wd)
 
-    rcfs= [RunCamcolField(4114, 3, 127), RunCamcolField(4114, 4, 127)]
-    images = SDSSIO.load_field_images(rcfs, datadir)
-    catalog = SDSSIO.read_photoobj_files(rcfs, datadir)
+    rcfs = [RunCamcolField(4114, 3, 127), RunCamcolField(4114, 4, 127)]
+    strategy = PlainFITSStrategy(datadir)
+    images = SDSSIO.load_field_images(strategy, rcfs)
+    catalog = SDSSIO.read_photoobj_files(strategy, rcfs)
     entry_id = findfirst((ce)->ce.objid == "1237663143711147274", catalog)
     entry = catalog[entry_id]
 

--- a/test/test_io.jl
+++ b/test/test_io.jl
@@ -1,0 +1,44 @@
+using Celeste
+
+const read_with_strategy = function(strategy)
+    rcf = Celeste.RunCamcolField(4263, 5, 119)
+    Celeste.SDSSIO.load_field_images(strategy, [rcf])
+    Celeste.SDSSIO.read_photoobj_files(strategy, [rcf])
+end
+
+function test_config(config)
+    strategy = Celeste.read_settings_file(joinpath("ioconfigs", config))
+    read_with_strategy(strategy)
+end
+
+for config in ["compressed.yml", "plain.yml", "slurp.yml"]
+    test_config(config)
+end
+
+rm("data/dr12", force = true, recursive=true)
+cd("data") do
+    # Create the original SDSS directory layout for testing purposes
+    mkpath("dr12/boss/photo/redux/301/4263/objcs/5")
+    mkpath("dr12/boss/photoObj/frames/301/4263/5")
+    mkpath("dr12/boss/photoObj/301/4263/5")
+    for band in ['z','g','r','i','u']
+        cp("4263/5/119/frame-$band-004263-5-0119.fits", "dr12/boss/photoObj/frames/301/4263/5/frame-$band-004263-5-0119.fits")
+        cp("4263/5/119/fpM-004263-$(band)5-0119.fit", "dr12/boss/photo/redux/301/4263/objcs/5/fpM-004263-$(band)5-0119.fit")
+    end
+    cp("4263/5/119/psField-004263-5-0119.fit", "dr12/boss/photo/redux/301/4263/objcs/5/psField-004263-5-0119.fit")
+    cp("4263/5/119/photoObj-004263-5-0119.fits", "dr12/boss/photoObj/301/4263/5/photoObj-004263-5-0119.fits")
+    cp("4263/5/photoField-004263-5.fits", "dr12/boss/photoObj/301/4263/photoField-004263-5.fits")
+end
+
+test_config("sdsslayout.yml")
+
+rm("data/dr12", recursive=true)
+
+worker = addprocs(1)[]
+fetch(@spawnat worker Base.require(:Celeste))
+
+# Test fetching over the network
+# The basedir is relative, if the worker doesn't try to fetch via the network after this, it'll fail
+fetch(@spawnat worker cd("/tmp"))
+remotecall_fetch(read_with_strategy, worker, Celeste.SDSSIO.MasterRPCStrategy(Celeste.read_settings_file(joinpath("ioconfigs", "plain.yml"))))
+rmprocs([worker])

--- a/test/test_sdssio.jl
+++ b/test/test_sdssio.jl
@@ -1,3 +1,4 @@
+using Celeste.SDSSIO
 import Celeste.SDSSIO: SkyIntensity
 
 
@@ -33,11 +34,12 @@ end
 
 @testset "read_photoobj handles missing table extensions" begin
     # get an example of a photoobj file with a missing table
-    fname = joinpath(Pkg.dir("Celeste"), "test", "data",
-                     "photoObj-006597-4-0025.fits")
+    strategy = PlainFITSStrategy(joinpath(Pkg.dir("Celeste"), "test", "data"))
+    rcf = RunCamcolField(6597, 4, 25)
+    fname = SDSSIO.compute_fname(strategy, SDSSIO.PhotoObj(rcf))[1]
     if !isfile(fname)
         run(`curl --create-dirs -o $fname https://data.sdss.org/sas/dr12/boss/photoObj/301/6597/4/photoObj-006597-4-0025.fits`)
     end
 
-    catalog = SDSSIO.read_photoobj(fname)
+    catalog = SDSSIO.read_photoobj(strategy, rcf)
 end

--- a/test/test_wcs.jl
+++ b/test/test_wcs.jl
@@ -1,7 +1,7 @@
 import DataFrames
 import FITSIO
 import WCS
-
+using Celeste.SDSSIO
 
 const band_letters = ['u', 'g', 'r', 'i', 'z']
 
@@ -14,8 +14,8 @@ end
 
 
 @testset "linear_world_to_pix works" begin
-    rcf = SDSSIO.RunCamcolField(3900, 6, 269)
-    image = SDSSIO.load_field_images(rcf, datadir)[1]
+    image = SDSSIO.load_field_images(PlainFITSStrategy(datadir),
+                SDSSIO.RunCamcolField(3900, 6, 269))[1]
     wcs = image.wcs
 
     pix_center = Float64[0.5 * image.H, 0.5 * image.W]


### PR DESCRIPTION
This adds some more flexibity to I/O, for non-NERSC environemnts.
In particular it allows:
- Data in the original SDSS directory layout, rather than the one that Celeste puts them in
- Decompresing data on the fly rather than requiring it to be decompressed on disk
- Clusters without shared filesystems by doing RPC to a master process

Since the options were getting a bit out of hand with these additions,
I also added a YAML based configuration format to specify these options.
I plan to extend that settings file to cover other aspects of the system
as well (e.g. the distributed options).

Finally, I removed the big file option. That was always a bit of a stopgap.
We didn't document the format. The scripts to create them are not in tree.
With more time, we can probably come up with a better way to do it. Also,
it's untested. It's still in the history of course, so we can always bring
it back.

Lastly, I added tests for all the new I/O modes.