### PR TITLE
Detect objects on images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@
 # Require force to add any data
 test/data/*
 
+# Omit deps build products
+deps/*
+
 *.swp
 *.jld
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -16,3 +16,4 @@ YAML
 TranscodingStreams
 CodecBzip2
 CodecZlib
+NearestNeighbors

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,5 @@
 julia 0.6
+BinDeps
 Compat 0.18.0
 DataFrames
 DataStructures 0.5.2

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,0 +1,36 @@
+using BinDeps
+
+@BinDeps.setup
+
+version = "1.0.1"
+url = "https://github.com/kbarbary/sep/archive/v$(version).tar.gz"
+
+libsep = library_dependency("libsep")
+println(libsep)
+downloadsdir = BinDeps.downloadsdir(libsep)
+libdir = BinDeps.libdir(libsep)
+srcdir = BinDeps.srcdir(libsep)
+if is_apple()
+    libfilename = "libsep.dylib"
+elseif is_unix()
+    libfilename = "libsep.so"
+end
+
+# Unix
+prefix = joinpath(BinDeps.depsdir(libsep), "usr")
+provides(Sources, URI(url), libsep, unpacked_dir="sep-$(version)")
+provides(BuildProcess,
+         (@build_steps begin
+             GetSources(libsep)
+             @build_steps begin
+                 ChangeDirectory(joinpath(srcdir, "sep-$(version)"))
+                 FileRule(joinpath(libdir, libfilename),
+                          @build_steps begin
+                              `make`
+                              `make PREFIX=$(prefix) install`
+                          end)
+             end
+          end), libsep, os = :Unix)
+
+
+@BinDeps.install Dict(:libsep => :libsep)

--- a/src/AccuracyBenchmark.jl
+++ b/src/AccuracyBenchmark.jl
@@ -175,10 +175,10 @@ function load_coadd_catalog(fits_filename)
     raw_df = load_stripe82_fits_catalog_as_data_frame(fits_filename, 2)
 
     usedev = raw_df[:fracdev_r] .> 0.5  # true=> use dev, false=> use exp
-    dev_or_exp(dev_column, exp_column) = ifelse(usedev, raw_df[dev_column], raw_df[exp_column])
+    dev_or_exp(dev_column, exp_column) = ifelse.(usedev, raw_df[dev_column], raw_df[exp_column])
     is_star = [x != 0 for x in raw_df[:probpsf]]
     function star_or_galaxy(star_column, galaxy_dev_column, galaxy_exp_column)
-        ifelse(is_star, raw_df[star_column], dev_or_exp(galaxy_dev_column, galaxy_exp_column))
+        ifelse.(is_star, raw_df[star_column], dev_or_exp(galaxy_dev_column, galaxy_exp_column))
     end
 
     mag_u = star_or_galaxy(:psfmag_u, :devmag_u, :expmag_u)
@@ -242,9 +242,9 @@ function load_primary(rcf::SDSSIO.RunCamcolField, stagedir::String)
     raw_df = object_dict_to_data_frame(SDSSIO.read_photoobj(strategy, rcf))
 
     usedev = raw_df[:frac_dev] .> 0.5  # true=> use dev, false=> use exp
-    dev_or_exp(dev_column, exp_column) = ifelse(usedev, raw_df[dev_column], raw_df[exp_column])
+    dev_or_exp(dev_column, exp_column) = ifelse.(usedev, raw_df[dev_column], raw_df[exp_column])
     function star_or_galaxy(star_column, galaxy_dev_column, galaxy_exp_column)
-        ifelse(raw_df[:is_star], raw_df[star_column], dev_or_exp(galaxy_dev_column, galaxy_exp_column))
+        ifelse.(raw_df[:is_star], raw_df[star_column], dev_or_exp(galaxy_dev_column, galaxy_exp_column))
     end
 
     flux_u = star_or_galaxy(:psfflux_u, :devflux_u, :expflux_u)
@@ -791,8 +791,8 @@ function get_error_df(truth::DataFrame, predicted::DataFrame)
 
     predicted_galaxy = predicted[:is_star] .< .5
     true_galaxy = truth[:is_star] .< .5
-    errors[:missed_stars] = ifelse(!true_galaxy, predicted_galaxy, NA)
-    errors[:missed_galaxies] = ifelse(true_galaxy, !predicted_galaxy, NA)
+    errors[:missed_stars] = ifelse.(!true_galaxy, predicted_galaxy, NA)
+    errors[:missed_galaxies] = ifelse.(true_galaxy, !predicted_galaxy, NA)
 
     errors[:position] = sky_distance_px.(
         truth[:right_ascension_deg],

--- a/src/Celeste.jl
+++ b/src/Celeste.jl
@@ -15,6 +15,8 @@ include("Log.jl")
 
 include("SensitiveFloats.jl")
 
+include("Coordinates.jl")
+
 include("Model.jl")
 include("Infer.jl")
 include("Transform.jl")
@@ -25,7 +27,6 @@ include("SEP.jl")
 include("MCMC.jl")
 include("StochasticVI.jl")
 include("DeterministicVI.jl")
-
 include("ParallelRun.jl")
 
 include("Synthetic.jl")

--- a/src/Celeste.jl
+++ b/src/Celeste.jl
@@ -20,6 +20,7 @@ include("Infer.jl")
 include("Transform.jl")
 include("PSF.jl")
 include("SDSSIO.jl")
+include("SEP.jl")
 
 include("MCMC.jl")
 include("StochasticVI.jl")

--- a/src/Coordinates.jl
+++ b/src/Coordinates.jl
@@ -1,0 +1,89 @@
+"""
+Utilities for distances between coordinates on the sphere and matching
+sets of coordinates.
+"""
+module Coordinates
+
+import NearestNeighbors: KDTree, knn
+
+"""
+    angular_separation(λ_1, ϕ_1, λ_2, ϕ_2)
+
+Angular separatation in *degrees* between two points on the sphere at
+longitude λ and latitude ϕ, both given in *degrees*.
+"""
+function angular_separation(λ_1, ϕ_1, λ_2, ϕ_2)
+    Δλ = λ_2 - λ_1
+    sin_Δλ = sind(Δλ)
+    cos_Δλ = cosd(Δλ)
+    sin_ϕ1 = sind(ϕ_1)
+    sin_ϕ2 = sind(ϕ_2)
+    cos_ϕ1 = cosd(ϕ_1)
+    cos_ϕ2 = cosd(ϕ_2)
+    return rad2deg(atan2(hypot(cos_ϕ2 * sin_Δλ,
+                               cos_ϕ1 * sin_ϕ2 - sin_ϕ1 * cos_ϕ2 * cos_Δλ),
+                         sin_ϕ1 * sin_ϕ2 + cos_ϕ1 * cos_ϕ2 * cos_Δλ))
+end
+
+
+"""
+convert (lon, lat) -> (x, y, z) unit vector for multiple coordinates
+where spherical coordinates are given in *degrees*.
+"""
+function _spherical_to_cartesian(lon::AbstractVector, lat::AbstractVector)
+    length(lon) == length(lat) || error("lengths of `lon` and `lat` must match")
+
+    T = float(promote_type(eltype(lon), eltype(lat)))
+    result = Array{T}(3, length(lon))
+    for i in eachindex(lon)
+        coslat = cosd(lat[i])
+        result[1, i] = coslat*cosd(lon[i])  # x
+        result[2, i] = coslat*sind(lon[i])  # y
+        result[3, i] = sind(lat[i])  # z
+    end
+    return result
+end
+
+
+"""
+    match_coordinates_sky(lon1, lat1, lon2, lat2; nneighbor=1)
+
+For each position in the set of coordinates `(lon1, lat1)`, find the
+`nneighbor`th nearest on-sky match in the set of coordinates `(lon2,
+lat2)`. Both sets of coordinates are in *degrees*.  Returns the indicies
+of each closest match (`Vector{Int}` of length `length(lon1)`) and the
+corresponding distances in degrees (`Vector{Float64}`). `nneighbor=2` can be
+used to match a catalog to itself.
+
+# Notes
+
+This function correctly accounts for wrap around and behavior near the poles.
+Works by transforming spherical coordinates to cartesian and using a KD tree
+to efficiently find nearest neighbors.
+
+An alternative approach that *might* be faster would be to use a hierarchical
+triangular mesh (HTM) or HEALPix to spatially index coordinates and then only
+search nearby indicies for matches.
+
+This function could potentially be incorporated into the SkyCoords
+package eventually, but for now it's unclear where it best fits.
+"""
+function match_coordinates(lon1::AbstractVector, lat1::AbstractVector,
+                           lon2::AbstractVector, lat2::AbstractVector;
+                           nneighbor::Int=1)
+    cartcoords1 = _spherical_to_cartesian(lon1, lat1)
+    cartcoords2 = _spherical_to_cartesian(lon2, lat2)
+    kdtree = KDTree(cartcoords2; leafsize = 10)
+    all_idxs, all_cartdists = knn(kdtree, cartcoords1, nneighbor)
+
+    # extract nneighbor-th index
+    idxs = [v[nneighbor] for v in all_idxs]
+
+    # extract nneighbor-th distance and convert from cartesian to spherical
+    dists = [2.0 * asind(v[nneighbor] / 2.0) for v in all_cartdists]
+
+    return idxs, dists
+end
+
+
+end  # module

--- a/src/SDSSIO.jl
+++ b/src/SDSSIO.jl
@@ -347,10 +347,11 @@ columns.
 The photoObj file format is documented here:
 https://data.sdss.org/datamodel/files/BOSS_PHOTOOBJ/RERUN/RUN/CAMCOL/photoObj.html
 """
-function read_photoobj(strategy, rcf, band::Char='r')
-    b = BAND_CHAR_TO_NUM[band]
+read_photoobj(strategy, rcf, band::Char='r') =
+    read_photoobj(readFITS(strategy, PhotoObj(rcf)), band, true)
 
-    f = readFITS(strategy, PhotoObj(rcf))
+function read_photoobj(f::FITSIO.FITS, band::Char='r', close_file=true)
+    b = BAND_CHAR_TO_NUM[band]
 
     # sometimes the expected table extension is only an empty generic FITS
     # header, indicating no objects. We check explicitly for this case here
@@ -442,7 +443,7 @@ function read_photoobj(strategy, rcf, band::Char='r')
     ab_exp = read(hdu, "ab_exp")::Matrix{Float32}
     ab_dev = read(hdu, "ab_dev")::Matrix{Float32}
 
-    close(f)
+    close_file && close(f)
 
     # construct result catalog
     catalog = Dict("objid"=>objid[mask],
@@ -478,7 +479,7 @@ end
 Convert from a catalog in dictionary-of-arrays, as returned by
 read_photoobj to Vector{CatalogEntry}.
 """
-function convert(::Type{Vector{CatalogEntry}}, catalog::Dict{String, Any})
+function convert(::Type{Vector{CatalogEntry}}, catalog::Dict)
     out = CatalogEntry[]
 
     for i=1:length(catalog["objid"])

--- a/src/SEP.jl
+++ b/src/SEP.jl
@@ -1,0 +1,416 @@
+"""
+Self-contained wrapper of C library based on Source Extractor
+(https://github.com/kbarbary/sep) for performing image background estimation
+and segmentation (detection). This is used in initialization in Celeste.
+
+In the future, this module could be replaced by a pure-Julia implementation.
+The background could be made an explicit part of the model.
+"""
+
+module SEP
+
+import Base: collect, broadcast!, broadcast, -, show
+
+if isfile(joinpath(dirname(@__FILE__),"..","deps","deps.jl"))
+    include("../deps/deps.jl")
+else
+    error("Celeste.SEP not properly installed. Please run Pkg.build(\"Celeste\")")
+end
+
+# Julia Type -> numeric type code from sep.h
+const SEPMaskType = Union{Bool, UInt8, Cint, Cfloat, Cdouble}
+const PixType = Union{UInt8, Cint, Cfloat, Cdouble}
+sep_typecode(::Type{Bool}) = Cint(11)
+sep_typecode(::Type{UInt8}) = Cint(11)
+sep_typecode(::Type{Cint}) = Cint(31)
+sep_typecode(::Type{Cfloat}) = Cint(42)
+sep_typecode(::Type{Cdouble}) = Cint(82)
+
+
+# definitions from sep.h
+const SEP_NOISE_NONE = Cshort(0)
+const SEP_NOISE_STDDEV = Cshort(1)
+const SEP_NOISE_VAR = Cshort(2)
+const SEP_THRESH_REL = Cint(0)
+const SEP_THRESH_ABS = Cint(1)
+const SEP_FILTER_CONV = Cint(0)
+const SEP_FILTER_MATCHED = Cint(1)
+
+function sep_assert_ok(status::Cint)
+    if status != 0
+        msg = Vector{UInt8}(61)
+        ccall((:sep_get_errmsg, libsep), Void, (Int32,Ptr{UInt8}), status, msg)
+        msg[end] = 0  # ensure NULL-termination, just in case.
+        error(unsafe_string(pointer(msg)))
+    end
+end
+
+# internal use only: mirrors `sep_image` struct in sep.h
+struct sep_image
+data::Ptr{Void}
+noise::Ptr{Void}
+mask::Ptr{Void}
+dtype::Cint
+ndtype::Cint
+mdtype::Cint
+w::Cint
+h::Cint
+noiseval::Cdouble
+noise_type::Cshort
+gain::Cdouble
+maskthresh::Cdouble
+end
+
+function sep_image(data::Array{T, 2};
+                   noise=nothing, mask=nothing, noise_type=:stddev,
+                   gain=0.0, mask_thresh=0.0) where {T<:PixType}
+    sz = size(data)
+
+    # data is required
+    data_ptr = Ptr{Void}(pointer(data))
+    dtype = sep_typecode(T)
+
+    # mask options
+    mask_ptr = C_NULL
+    mdtype = Cint(0)
+    if mask !== nothing
+        isa(mask, Matrix) || error("mask must be a 2-d array")
+        size(mask) == sz || error("data and mask must be same size")
+        mask_ptr = Ptr{Void}(pointer(mask))
+        mdtype = sep_typecode(eltype(mask))
+    end
+
+    # noise options
+    ndtype = Cint(0)
+    noise_ptr = C_NULL
+    noiseval = 0.0
+    noise_typecode = SEP_NOISE_NONE
+    if noise !== nothing
+        if isa(noise, Matrix)
+            size(noise) == sz || error("noise array must be same size as data")
+            noise_ptr = Ptr{Void}(pointer(noise))
+            ndtype = sep_typecode(eltype(noise))
+        elseif isa(noise, Real)
+            noiseval = Cdouble(noise)
+        else
+            error("noise must be array or number")
+        end
+        noise_typecode = ((noise_type == :stddev) ? SEP_NOISE_STDDEV :
+                          (noise_type == :var) ? SEP_NOISE_VAR :
+                          error("noise_type must be :stddev or :var"))
+    end
+            
+    return sep_image(data_ptr, noise_ptr, mask_ptr,
+                     dtype, ndtype, mdtype,
+                     sz[1], sz[2],
+                     noiseval, noise_typecode,
+                     Cdouble(gain),
+                     Cdouble(mask_thresh))
+end
+
+# ---------------------------------------------------------------------------
+# Background functions
+
+"""
+    Background(data::Matrix; <keyword arguments>)
+
+Spline representation of the variable background and noise of an image.
+
+# Arguments
+
+- `data::Matrix`: 
+- `mask=nothing`:
+- `boxsize=(64, 64)`:
+- `filtersize=(3, 3)`:
+- `filterthresh=0.0`:
+- `mask_thresh=0`: 
+"""
+mutable struct Background
+    ptr::Ptr{Void}
+    data_size::Tuple{Int, Int}
+
+    function Background(data::Array{T, 2} where T<:PixType;
+                        mask=nothing, boxsize=(64, 64), filtersize=(3, 3),
+                        filterthresh=0.0, mask_thresh=0)
+        im = sep_image(data; mask=mask, mask_thresh=mask_thresh)
+        result = Ref{Ptr{Void}}(C_NULL)
+        status = ccall((:sep_background, libsep), Cint,
+                       (Ptr{sep_image}, Cint, Cint, Cint, Cint, Cdouble,
+                        Ref{Ptr{Void}}),
+                       &im, boxsize[1], boxsize[2], filtersize[1],
+                       filtersize[2], filterthresh, result)
+        sep_assert_ok(status)
+        bkg = new(result[], size(data))
+        finalizer(bkg, free!)
+        return bkg
+    end
+end
+
+free!(bkg::Background) = ccall((:sep_bkg_free, libsep), Void, (Ptr{Void},),
+                               bkg.ptr)
+
+global_mean(bkg::Background) = ccall((:sep_bkg_global, libsep), Cfloat,
+                                     (Ptr{Void},), bkg.ptr)
+
+global_rms(bkg::Background) = ccall((:sep_bkg_globalrms, libsep), Cfloat,
+                                    (Ptr{Void},), bkg.ptr)
+
+function show(io::IO, bkg::Background)
+    print(io, "Background $(bkg.data_size[1])×$(bkg.data_size[2])\n")
+    print(io, " - global mean: $(global_mean(bkg))\n")
+    print(io, " - global rms : $(global_rms(bkg))\n")
+end
+
+function collect(::Type{T}, bkg::Background) where {T<:PixType}
+    result = Array{T}(bkg.data_size)
+    status = ccall((:sep_bkg_array, libsep), Cint, (Ptr{Void}, Ptr{Void}, Cint),
+                   bkg.ptr, result, sep_typecode(T))
+    sep_assert_ok(status)
+    return result
+end
+# default collection type is Float32, because that's what's natively stored in
+# background.
+# TODO: make default the input array type in `background` instead?
+collect(bkg::Background) = collect(Float32, bkg)
+
+
+"""
+    rms(bkg)
+    rms(T, bkg)
+
+Return an array of the standard deviation of the background. The result is
+the size of the original image and is of type `T`, if given.
+"""
+function rms(::Type{T}, bkg::Background) where {T<:PixType}
+    result = Array{T}(bkg.data_size)
+    status = ccall((:sep_bkg_rmsarray, libsep), Cint,
+                   (Ptr{Void}, Ptr{Void}, Cint),
+                   bkg.ptr, result, sep_typecode(T))
+    sep_assert_ok(status)
+    return result
+end
+rms(bkg::Background) = rms(Float32, bkg)
+
+
+# In-place background subtraction: A .-= bkg
+function broadcast!(-, A::Array{T, 2},  ::Array{T, 2}, bkg::Background) where {T<:PixType}
+    if size(A) != bkg.data_size
+         throw(DimensionMismatch("dimensions must match"))
+    end
+    status = ccall((:sep_bkg_subarray, libsep), Cint,
+                   (Ptr{Void}, Ptr{Void}, Cint),
+                   bkg.ptr, A, sep_typecode(T))
+    sep_assert_ok(status)
+end
+function broadcast(-, A::Array{T, 2} where T<:PixType, bkg::Background)
+    B = copy(A)
+    B .-= bkg
+    return B
+end
+    
+function (-)(A::Array{T, 2}, bkg::Background) where {T<:PixType}
+    B = copy(A)
+    B .-= bkg
+    return B
+end
+
+
+# -----------------------------------------------------------------------------
+# Source Extraction
+
+# Internal use only: Mirror of C struct
+struct sep_catalog
+    nobj::Cint                 # number of objects (length of all arrays)
+    thresh::Ptr{Cfloat}              # threshold (ADU)
+    npix::Ptr{Cint}              # # pixels extracted (size of pix array)
+    tnpix::Ptr{Cint}                # # pixels above thresh (unconvolved)
+    xmin::Ptr{Cint}
+    xmax::Ptr{Cint}
+    ymin::Ptr{Cint}
+    ymax::Ptr{Cint}
+    x::Ptr{Cdouble}              # barycenter (first moments)
+    y::Ptr{Cdouble}
+    x2::Ptr{Cdouble}     # second moments
+    y2::Ptr{Cdouble}
+    xy::Ptr{Cdouble}
+    errx2::Ptr{Cdouble}  # second moment errors
+    erry2::Ptr{Cdouble}
+    errxy::Ptr{Cdouble}
+    a::Ptr{Cfloat}       # ellipse parameters
+    b::Ptr{Cfloat}
+    theta::Ptr{Cfloat}
+    cxx::Ptr{Cfloat}     # alternative ellipse parameters
+    cyy::Ptr{Cfloat}
+    cxy::Ptr{Cfloat}
+    cflux::Ptr{Cfloat}   # total flux of pixels (convolved)
+    flux::Ptr{Cfloat}    # total flux of pixels (unconvolved)
+    cpeak::Ptr{Cfloat}   # peak pixel flux (convolved)
+    peak::Ptr{Cfloat}    # peak pixel flux (unconvolved)
+    xcpeak::Ptr{Cint}    # x, y coords of peak (convolved) pixel
+    ycpeak::Ptr{Cint}
+    xpeak::Ptr{Cint}     # x, y coords of peak (unconvolved) pixel
+    ypeak::Ptr{Cint}
+    flag::Ptr{Cshort}    # extraction flags
+    pix::Ptr{Ptr{Cint}}  # array giving indicies of object's pixels in
+                         # image (linearly indexed). Length is `npix`.
+                         # (pointer to within the `objectspix` buffer)
+    objectspix::Ptr{Cint}  # buffer holding pixel indicies for all objects
+end
+
+
+struct Catalog
+npix::Vector{Cint}
+xmin::Vector{Cint}
+xmax::Vector{Cint}
+ymin::Vector{Cint}
+ymax::Vector{Cint}
+x::Vector{Cdouble}
+y::Vector{Cdouble}
+a::Vector{Cfloat}
+b::Vector{Cfloat}
+theta::Vector{Cfloat}
+cxx::Vector{Cfloat}
+cyy::Vector{Cfloat}
+cxy::Vector{Cfloat}
+pix::Vector{Vector{Cint}}
+end
+
+function show(io::IO, cat::Catalog)
+    print(io, "SEP.Catalog with $(length(cat.x)) entries")
+end
+
+"""
+    unsafe_copy(src::Ptr{T}, N)
+
+Create a `Vector{T}` and copy `N` elements from `Ptr{T}` into it.
+"""
+function unsafe_copy(src::Ptr{T}, N) where {T}
+    dest = Vector{T}(N)
+    unsafe_copy!(pointer(dest), src, N)
+    return dest
+end
+
+"""
+    extract(data, thresh; <keyword arguments>)
+
+Perform image segmentation on the data and return a catalog of sources.
+
+# Arguments
+
+- `data::Matrix`: Image data.
+- `thresh::Real`: Threshold for detection in absolute units, or in standard
+  deviations if noise is given.
+- `noise=nothing`: 
+- `noise_type=:stddev`:
+- `mask=nothing`:
+- `mask_thresh=0`: 
+- `minarea=5`:
+- `filter_kernel`:
+- `filter_type=:conv`:
+- `deblend_nthresh=32`:
+- `deblend_cont=0.005`: Minimum contrast in deblending. Set to 1.0 to disable
+  deblending.
+- `clean=true`: Perform cleaning?
+- `clean_param=1.0`
+- `gain=0.0`
+"""
+function extract(data::Array{T, 2} where T, thresh::Real;
+                 noise=nothing, mask=nothing, noise_type=:stddev,
+                 minarea=5,
+                 filter_kernel=Float32[1 2 1; 2 4 2; 1 2 1],
+                 filter_type=:convolution,
+                 deblend_nthresh=32, deblend_cont=0.005,
+                 clean=true, clean_param=1.0,
+                 gain=0.0, mask_thresh=0)
+
+    im = sep_image(data; noise=noise, mask=mask, noise_type=noise_type,
+                   gain=gain, mask_thresh=mask_thresh)
+
+    thresh_typecode = noise === nothing ? SEP_THRESH_ABS : SEP_THRESH_REL
+
+    filter_typecode = ((filter_type == :matched)? SEP_FILTER_MATCHED :
+                       (filter_type == :convolution)? SEP_FILTER_CONV :
+                       error("filter_type must be :matched or :convolution"))
+
+    # convert filter kernel to Cfloat array
+    filter_kernel_cfloat = convert(Array{Cfloat, 2}, filter_kernel)
+    filter_size = size(filter_kernel_cfloat)
+    
+    ccatalog_ptr_ref = Ref{Ptr{sep_catalog}}(C_NULL)
+    status = ccall((:sep_extract, libsep), Cint,
+                   (Ptr{sep_image},
+                    Cfloat, Cint, # thresh, thresh_type
+                    Cint,  # minarea  
+                    Ptr{Cfloat}, Cint, Cint,  # conv, convw, convh
+                    Cint, # filter_type
+                    Cint, Cdouble,  # deblend_nthresh, deblend_cont
+                    Cint, Cdouble,  # clean_flag, clean_param
+                    Ref{Ptr{sep_catalog}}),
+                   &im,
+                   thresh, thresh_typecode,
+                   minarea,
+                   filter_kernel_cfloat, filter_size[1], filter_size[2],
+                   filter_typecode,
+                   deblend_nthresh, deblend_cont,
+                   clean, clean_param,
+                   ccatalog_ptr_ref)
+    sep_assert_ok(status)
+
+    # get pointer to C-allocated result
+    ccatalog_ptr = ccatalog_ptr_ref[]
+
+    # copy result arrays into jula-managed memory
+    ccatalog = unsafe_load(ccatalog_ptr)
+    nobj = ccatalog.nobj
+    # translate pixel index vectors
+    npix = unsafe_copy(ccatalog.npix, nobj)
+    pix = Vector{Vector{Cint}}(nobj)
+    for i in eachindex(pix)
+        ptr = unsafe_load(ccatalog.pix, i)  # ptr to pixel indicies for i-th obj
+        pix[i] = unsafe_copy(ptr, npix[i])
+        pix[i] .+= Cint(1) # change to 1-indexing
+    end
+        
+    result = Catalog(npix,
+                     unsafe_copy(ccatalog.xmin, nobj),
+                     unsafe_copy(ccatalog.xmax, nobj),
+                     unsafe_copy(ccatalog.ymin, nobj),
+                     unsafe_copy(ccatalog.ymax, nobj),
+                     unsafe_copy(ccatalog.x, nobj),
+                     unsafe_copy(ccatalog.y, nobj),
+                     unsafe_copy(ccatalog.a, nobj),
+                     unsafe_copy(ccatalog.b, nobj),
+                     unsafe_copy(ccatalog.theta, nobj),
+                     unsafe_copy(ccatalog.cxx, nobj),
+                     unsafe_copy(ccatalog.cyy, nobj),
+                     unsafe_copy(ccatalog.cxy, nobj),
+                     pix)
+
+    # switch to 1 indexing
+    result.x .+= 1.0
+    result.y .+= 1.0
+    
+    # free result allocated in sep_extract
+    ccall((:sep_catalog_free, libsep), Void, (Ptr{sep_catalog},), ccatalog_ptr)
+
+    return result
+end
+
+
+# mask ellipse
+"""
+    mask_ellipse(data, x, y, cxx, cyy, cxy; r=1.0)
+
+Set values within ellipse to `true`.
+"""
+function mask_ellipse(data::Array{T, 2} where T <: Union{UInt8, Bool},
+                      x::Real, y::Real, cxx::Real, cyy::Real, cxy::Real;
+                      r=1.0)
+    w, h = size(data)
+    ccall((:sep_set_ellipse, libsep), Void,
+          (Ptr{Cuchar}, Cint, Cint, Cdouble, Cdouble, Cdouble, Cdouble,
+           Cdouble, Cdouble, Cuchar), data, w, h, x-1.0, y-1.0, cxx, cyy,
+          cxy, r, true)
+end
+
+end # module

--- a/src/SEP.jl
+++ b/src/SEP.jl
@@ -272,6 +272,7 @@ theta::Vector{Cfloat}
 cxx::Vector{Cfloat}
 cyy::Vector{Cfloat}
 cxy::Vector{Cfloat}
+flux::Vector{Cfloat}
 pix::Vector{Vector{Cint}}
 end
 
@@ -384,6 +385,7 @@ function extract(data::Array{T, 2} where T, thresh::Real;
                      unsafe_copy(ccatalog.cxx, nobj),
                      unsafe_copy(ccatalog.cyy, nobj),
                      unsafe_copy(ccatalog.cxy, nobj),
+                     unsafe_copy(ccatalog.flux, nobj),
                      pix)
 
     # switch to 1 indexing

--- a/test/test_coordinates.jl
+++ b/test/test_coordinates.jl
@@ -1,0 +1,19 @@
+
+import Celeste.Coordinates: angular_separation, match_coordinates
+
+@testset "coordinates" begin
+
+    @test angular_separation(180., 45., 0., -45.) == 180.
+    @test angular_separation(0., 0., 0., 1.) == 1.
+    
+    ra1 = [2., 4., 5.]
+    dec1 = [70., -80., 90.]
+    ra2 = [5., 2., 0., 50.]
+    dec2 = [89.9, 70.1, 0., -90.]
+    idxs, dists = match_coordinates(ra1, dec1, ra2, dec2)
+
+    @test length(idxs) == length(ra1)
+    @test idxs[1] == 2 && dists[1] ≈ 0.1
+    @test idxs[2] == 4 && dists[2] ≈ 10.
+    @test idxs[3] == 1 && dists[3] ≈ 0.1
+end

--- a/test/test_joint_infer.jl
+++ b/test/test_joint_infer.jl
@@ -75,27 +75,19 @@ Return true if vp params are the same, false otherwise
 """
 function compare_vp_params(r1, r2)
 
-    # Create a map from thingid -> vp for r1
-    r1_vp = Dict{Int64, Vector{Float64}}()
-    for r1_result in r1
-        r1_vp[r1_result.thingid] = r1_result.vs
-    end
+    length(r1) == length(r2) || return false
 
     # Check the existence and equivalence of each source's vp in r2
-    for r2_result in r2
-        if haskey(r1_vp, r2_result.thingid)
-            a, b = r1_vp[r2_result.thingid], r2_result.vs
-            if !(isapprox(a, b))
-                println("compare_vp_params: Mismatch - $(a) vs $(b)")
-                print("norm(a - b): ", norm(a - b))
-                return false
-            end
-        else
+    for i in eachindex(r1)
+        a = r1[i].vs
+        b = r2[i].vs
+        if !(isapprox(a, b))
+            println("compare_vp_params: Mismatch - $(a) vs $(b)")
+            print("norm(a - b): ", norm(a - b))
             return false
         end
     end
-
-    return length(r1) == length(r2)
+    return true
 end
 
 """

--- a/test/test_sep.jl
+++ b/test/test_sep.jl
@@ -1,0 +1,36 @@
+import Celeste: SEP
+using Base.Test
+using FITSIO
+
+@testset "sep" begin
+    
+    # use test image in SEP source directory
+    sep_testdata_dir = joinpath(dirname(@__FILE__), "..", "deps", "src",
+                                "sep-1.0.1", "data")
+
+    data = read(FITS(joinpath(sep_testdata_dir, "image.fits"))[1])
+    back_sextractor = read(FITS(joinpath(sep_testdata_dir, "back.fits"))[1])
+    rms_sextractor = read(FITS(joinpath(sep_testdata_dir, "rms.fits"))[1])
+
+    # test background
+    bkg = SEP.Background(data)
+    @test collect(bkg) ≈ back_sextractor
+
+    for T in (Float32, Float64)
+        A = zeros(T, size(data))
+        back = collect(T, bkg)
+        @test back ≈ back_sextractor
+    end
+
+    # test that broadcast subtraction methods work and return same result
+    A = zeros(Float32, size(data))
+    A .-= bkg
+    B = zeros(Float32, size(data)) .- bkg
+    C = zeros(Float32, size(data)) - bkg
+    @test A == B == C
+
+    # test source extraction
+    data .-= bkg
+    catalog = SEP.extract(data, 3.0; noise=SEP.rms(bkg))
+    @test length(catalog.x) == 39
+end


### PR DESCRIPTION
This PR does the following in pursuit of initializing sources directly from images rather than using the SDSS catalog: 

- Add a self-contained submodule `SEP` that wraps the C library from http://github.com/kbarbary/sep . This library does heuristic spatially-variable background / noise estimation, image segmentation (source detection), source deblending, and calculates some basic source statistics. This is a wrapper that could eventually be moved to a package, but for now it is easier to only wrap what we need and be able to change the API rapidly.
- Add a `BinDeps`-based build script for the above.
- Add a `detect_sources()` function (in ParallelRun.jl) that takes a bunch of `RawImage`s and returns a `Vector{CatalogEntry}`.
- Changes `infer_init()` to use the above function.
- New neighbor map implementation in `infer_init` based on extent of a source's pixels that are "above background noise" (since we now have that information in `detect_sources()`.
- Removes `thingid` from `compare_vp_params` in tests, instead simply requiring that both vectors of parameters be ordered the same.

Still to do: Update accuracy benchmarks to be independent of `obj_id` / `thingid`.