### PR TITLE
rename math variables

### DIFF
--- a/bin/write_celeste_expectation.jl
+++ b/bin/write_celeste_expectation.jl
@@ -90,8 +90,8 @@ function load_sources(
         sources::Vector{ParallelRun.OptimizedSource} = JLD.load(file_path)["results"]
         Log.info("  Found $(length(sources)) sources in $file_path")
         for source in sources
-            source_ra_deg = source.vs[Model.ids.u[1]]
-            source_dec_deg = source.vs[Model.ids.u[2]]
+            source_ra_deg = source.vs[Model.ids.pos[1]]
+            source_dec_deg = source.vs[Model.ids.pos[2]]
             if source_ra_deg < ra_min_deg || source_ra_deg > ra_max_deg
                 continue
             elseif source_dec_deg < dec_min_deg || source_dec_deg > dec_max_deg

--- a/cfg/gen_priors.jl
+++ b/cfg/gen_priors.jl
@@ -71,15 +71,15 @@ else
     fit_r = fit_mle(LogNormal, r0)
     println(fit_r)
 
-    D = 8
+    num_color_components = 8
     c0_train = c0
     #c0_test = c0[120001:end, :]
-    fit_gmm = GMM(D, c0_train, kind=:full, method=:split)
+    fit_gmm = GMM(num_color_components, c0_train, kind=:full, method=:split)
     println("train avll:", GaussianMixtures.avll(fit_gmm, c0_train))
     #println("test avll:", GaussianMixtures.avll(fit_gmm, c0_test))
 
     save(ARGS[2], "r_params", params(fit_r),
         "c_weights", weights(fit_gmm),
-        "c_means", means(fit_gmm)',
-        "c_covs", vecmat_to_tensor(covars(fit_gmm)))
+        "color_means", means(fit_gmm)',
+        "color_covs", vecmat_to_tensor(covars(fit_gmm)))
 end

--- a/cfg/gen_priors.jl
+++ b/cfg/gen_priors.jl
@@ -71,10 +71,10 @@ else
     fit_r = fit_mle(LogNormal, r0)
     println(fit_r)
 
-    num_color_components = 8
+    NUM_COLOR_COMPONENTS = 8
     c0_train = c0
     #c0_test = c0[120001:end, :]
-    fit_gmm = GMM(num_color_components, c0_train, kind=:full, method=:split)
+    fit_gmm = GMM(NUM_COLOR_COMPONENTS, c0_train, kind=:full, method=:split)
     println("train avll:", GaussianMixtures.avll(fit_gmm, c0_train))
     #println("test avll:", GaussianMixtures.avll(fit_gmm, c0_test))
 

--- a/src/AccuracyBenchmark.jl
+++ b/src/AccuracyBenchmark.jl
@@ -368,10 +368,10 @@ function draw_source_params(prior, object_id)
     ))
 
     color_mixture_weights = prior.k[:, source_type_index]
-    num_color_components = length(color_mixture_weights)
+    NUM_COLOR_COMPONENTS = length(color_mixture_weights)
     color_components = MvNormal[
         MvNormal(prior.color_mean[:, k, source_type_index], prior.color_cov[:, :, k, source_type_index])
-        for k in 1:num_color_components
+        for k in 1:NUM_COLOR_COMPONENTS
     ]
     color_log_ratios = rand(MixtureModel(color_components, color_mixture_weights))
 

--- a/src/AccuracyBenchmark.jl
+++ b/src/AccuracyBenchmark.jl
@@ -18,19 +18,19 @@ const SDSS_ARCSEC_PER_PIXEL = 0.396
 const SDSS_DATA_DIR = joinpath(Pkg.dir("Celeste"), "test", "data")
 const STRIPE82_RCF = SDSSIO.RunCamcolField(4263, 5, 119)
 
-immutable BenchmarkFitsFileNotFound <: Exception
+struct BenchmarkFitsFileNotFound <: Exception
     filename::String
 end
 
-immutable MatchException <: Exception
+struct MatchException <: Exception
     msg::String
 end
 
-immutable ObjectsMissingFromGroundTruth <: Exception
+struct ObjectsMissingFromGroundTruth <: Exception
     missing_objids::Vector{String}
 end
 
-immutable MissingColumnsError <: Exception
+struct MissingColumnsError <: Exception
     missing_columns::Vector{Symbol}
 end
 
@@ -429,7 +429,7 @@ end
 
 ## Load a multi-extension FITS imagery file
 
-immutable FitsImage
+struct FitsImage
     pixels::Matrix{Float32}
     header::FITSIO.FITSHeader
     wcs::WCS.WCSTransform
@@ -629,7 +629,7 @@ end
 # Support for generating imagery using Synthetic.jl
 ################################################################################
 
-immutable ImageGeometry
+struct ImageGeometry
     height_px::Int64
     width_px::Int64
     world_coordinate_origin::Tuple{Float64, Float64} # (ra, dec)

--- a/src/ArgumentParse.jl
+++ b/src/ArgumentParse.jl
@@ -3,17 +3,17 @@ module ArgumentParse
 const KEYWORD_ARGUMENT_PREFIX = "--"
 const HELP_ARGUMENTS = ["--help", "-h"]
 
-immutable NoDefault end
+struct NoDefault end
 
-immutable ArgumentParsingError <: Exception
+struct ArgumentParsingError <: Exception
     message::String
 end
 
-immutable ShowHelp <: Exception
+struct ShowHelp <: Exception
     message::String
 end
 
-immutable ArgumentSpecification
+struct ArgumentSpecification
     name::String
     argument_string::String
     help::String
@@ -23,7 +23,7 @@ immutable ArgumentSpecification
     action::Symbol
 end
 
-type ArgumentParser
+struct ArgumentParser
     program_name::String
     propagate_errors::Bool
     positional_arguments::Vector{ArgumentSpecification}

--- a/src/Configs.jl
+++ b/src/Configs.jl
@@ -1,6 +1,6 @@
 module Configs
 
-type Config
+mutable struct Config
     # A minimum pixel radius to be included around each source.
     min_radius_pix::Float64
 

--- a/src/DeterministicVI.jl
+++ b/src/DeterministicVI.jl
@@ -40,17 +40,17 @@ Return a default-initialized VariationalParams instance.
 """
 function generic_init_source(init_pos::Vector{Float64})
     ret = Vector{Float64}(length(CanonicalParams))
-    ret[ids.a] = 0.5
-    ret[ids.u] = init_pos
-    ret[ids.r1] = log(2.0)
-    ret[ids.r2] = 1e-3
-    ret[ids.e_dev] = 0.5
-    ret[ids.e_axis] = 0.5
-    ret[ids.e_angle] = 0.0
-    ret[ids.e_scale] = 1.0
+    ret[ids.is_star] = 0.5
+    ret[ids.pos] = init_pos
+    ret[ids.flux_loc] = log(2.0)
+    ret[ids.flux_scale] = 1e-3
+    ret[ids.gal_fracdev] = 0.5
+    ret[ids.gal_ab] = 0.5
+    ret[ids.gal_angle] = 0.0
+    ret[ids.gal_scale] = 1.0
     ret[ids.k] = 1.0 / size(ids.k, 1)
-    ret[ids.c1] = 0.0
-    ret[ids.c2] =  1e-2
+    ret[ids.color_mean] = 0.0
+    ret[ids.color_var] =  1e-2
     ret
 end
 
@@ -64,30 +64,30 @@ function catalog_init_source(ce::CatalogEntry; max_gal_scale=Inf)
 
     # TODO: don't do this thresholding for background sources,
     # just for sources that are being optimized
-    ret[ids.a[1]] = ce.is_star ? 0.8: 0.2
-    ret[ids.a[2]] = ce.is_star ? 0.2: 0.8
+    ret[ids.is_star[1]] = ce.is_star ? 0.8: 0.2
+    ret[ids.is_star[2]] = ce.is_star ? 0.2: 0.8
 
-    ret[ids.r1[1]] = log(max(0.1, ce.star_fluxes[3]))
-    ret[ids.r1[2]] = log(max(0.1, ce.gal_fluxes[3]))
+    ret[ids.flux_loc[1]] = log(max(0.1, ce.star_fluxes[3]))
+    ret[ids.flux_loc[2]] = log(max(0.1, ce.gal_fluxes[3]))
 
-    function get_color(c2, c1)
-        c2 > 0 && c1 > 0 ? min(max(log(c2 / c1), -9.), 9.) :
-            c2 > 0 && c1 <= 0 ? 3.0 :
-                c2 <= 0 && c1 > 0 ? -3.0 : 0.0
+    function get_color(color_var, color_mean)
+        color_var > 0 && color_mean > 0 ? min(max(log(color_var / color_mean), -9.), 9.) :
+            color_var > 0 && color_mean <= 0 ? 3.0 :
+                color_var <= 0 && color_mean > 0 ? -3.0 : 0.0
     end
 
     function get_colors(raw_fluxes)
         [get_color(raw_fluxes[c+1], raw_fluxes[c]) for c in 1:4]
     end
 
-    ret[ids.c1[:, 1]] = get_colors(ce.star_fluxes)
-    ret[ids.c1[:, 2]] = get_colors(ce.gal_fluxes)
+    ret[ids.color_mean[:, 1]] = get_colors(ce.star_fluxes)
+    ret[ids.color_mean[:, 2]] = get_colors(ce.gal_fluxes)
 
-    ret[ids.e_dev] = min(max(ce.gal_frac_dev, 0.015), 0.985)
+    ret[ids.gal_fracdev] = min(max(ce.gal_frac_dev, 0.015), 0.985)
 
-    ret[ids.e_axis] = ce.is_star ? .8 : min(max(ce.gal_ab, 0.015), 0.985)
-    ret[ids.e_angle] = ce.gal_angle
-    ret[ids.e_scale] = ce.is_star ? 0.2 : min(max_gal_scale, max(ce.gal_scale, 0.2))
+    ret[ids.gal_ab] = ce.is_star ? .8 : min(max(ce.gal_ab, 0.015), 0.985)
+    ret[ids.gal_angle] = ce.gal_angle
+    ret[ids.gal_scale] = ce.is_star ? 0.2 : min(max_gal_scale, max(ce.gal_scale, 0.2))
 
     ret
 end

--- a/src/Infer.jl
+++ b/src/Infer.jl
@@ -29,13 +29,13 @@ Arguments:
 function find_neighbors(target_sources::Vector{Int64},
                         catalog::Vector{CatalogEntry},
                         images::Vector{Image})
-    psf_width_ub = zeros(num_bands)
+    psf_width_ub = zeros(NUM_BANDS)
     for img in images
         psf_width = Model.get_psf_width(img.psf)
         psf_width_ub[img.b] = max(psf_width_ub[img.b], psf_width)
     end
 
-    epsilon_lb = fill(Inf, num_bands)
+    epsilon_lb = fill(Inf, NUM_BANDS)
     for img in images
         epsilon = img.sky[div(img.H, 2), div(img.W, 2)]
         epsilon_lb[img.b] = min(epsilon_lb[img.b], epsilon)

--- a/src/Infer.jl
+++ b/src/Infer.jl
@@ -29,13 +29,13 @@ Arguments:
 function find_neighbors(target_sources::Vector{Int64},
                         catalog::Vector{CatalogEntry},
                         images::Vector{Image})
-    psf_width_ub = zeros(B)
+    psf_width_ub = zeros(num_bands)
     for img in images
         psf_width = Model.get_psf_width(img.psf)
         psf_width_ub[img.b] = max(psf_width_ub[img.b], psf_width)
     end
 
-    epsilon_lb = fill(Inf, B)
+    epsilon_lb = fill(Inf, num_bands)
     for img in images
         epsilon = img.sky[div(img.H, 2), div(img.W, 2)]
         epsilon_lb[img.b] = min(epsilon_lb[img.b], epsilon)
@@ -166,7 +166,7 @@ function load_active_pixels!(config::Configs.Config,
             # Note: This is risky because bright pixels are disproportionately likely
             # to get included, even if it's because of noise. Therefore it's important
             # to keep the noise fraction pretty low.
-            threshold = img.iota_vec[h] * img.sky[h, w] * (1. + noise_fraction)
+            threshold = img.nelec_per_nmgy[h] * img.sky[h, w] * (1. + noise_fraction)
             p.active_pixel_bitmap[h2, w2] = img.pixels[h, w] > threshold
         end
     end

--- a/src/Model.jl
+++ b/src/Model.jl
@@ -16,8 +16,8 @@ export Image, SkyPatch, PsfComponent,
 export align
 
 # constants
-export band_letters, num_color_components, num_source_types, num_bands,
-       galaxy_prototypes, prior,
+export NUM_COLOR_COMPONENTS, NUM_SOURCE_TYPES, NUM_BANDS,
+       BAND_LETTERS, galaxy_prototypes, prior,
        shape_standard_alignment,
        brightness_standard_alignment,
        gal_shape_alignment,
@@ -37,10 +37,10 @@ import Base.length
 
 const cfgdir = joinpath(Pkg.dir("Celeste"), "cfg")
 
-const band_letters = ['u', 'g', 'r', 'i', 'z']
+const BAND_LETTERS = "ugriz"
 
 # The number of bands (colors).
-const num_bands = length(band_letters)
+const NUM_BANDS = length(BAND_LETTERS)
 
 
 include("model/light_source_model.jl")

--- a/src/Model.jl
+++ b/src/Model.jl
@@ -16,7 +16,7 @@ export Image, SkyPatch, PsfComponent,
 export align
 
 # constants
-export band_letters, D, Ia, B,
+export band_letters, num_color_components, num_source_types, num_bands,
        galaxy_prototypes, prior,
        shape_standard_alignment,
        brightness_standard_alignment,
@@ -40,7 +40,7 @@ const cfgdir = joinpath(Pkg.dir("Celeste"), "cfg")
 const band_letters = ['u', 'g', 'r', 'i', 'z']
 
 # The number of bands (colors).
-const B = length(band_letters)
+const num_bands = length(band_letters)
 
 
 include("model/light_source_model.jl")

--- a/src/PSF.jl
+++ b/src/PSF.jl
@@ -30,7 +30,7 @@ A data type to store functions related to optimizing a PSF fit. Initialize
 using the transform and number of components, and then call fit_psf
 to perform a fit to a specificed psf and initial parameters.
 """
-type PsfOptimizer
+mutable struct PsfOptimizer
     psf_transform::DataTransform
     ftol::Float64
     grtol::Float64

--- a/src/PSF.jl
+++ b/src/PSF.jl
@@ -232,16 +232,16 @@ function initialize_psf_params(K::Int; for_test::Bool=false)
             # Choose asymmetric values for testing.
             psf_params[k] = zeros(length(PsfParams))
             psf_params[k][psf_ids.mu] = [0.1, 0.2]
-            psf_params[k][psf_ids.e_axis] = 0.8
-            psf_params[k][psf_ids.e_angle] = pi / 4
-            psf_params[k][psf_ids.e_scale] = sqrt(2 * k)
+            psf_params[k][psf_ids.gal_ab] = 0.8
+            psf_params[k][psf_ids.gal_angle] = pi / 4
+            psf_params[k][psf_ids.gal_scale] = sqrt(2 * k)
             psf_params[k][psf_ids.weight] = 1 / K + k / 10
         else
             psf_params[k] = zeros(length(PsfParams))
             psf_params[k][psf_ids.mu] = [0.0, 0.0]
-            psf_params[k][psf_ids.e_axis] = 0.95
-            psf_params[k][psf_ids.e_angle] = 0.0
-            psf_params[k][psf_ids.e_scale] = sqrt(2 * k)
+            psf_params[k][psf_ids.gal_ab] = 0.95
+            psf_params[k][psf_ids.gal_angle] = 0.0
+            psf_params[k][psf_ids.gal_scale] = sqrt(2 * k)
             psf_params[k][psf_ids.weight] = 1 / K
         end
     end
@@ -272,11 +272,11 @@ function get_psf_transform(
         bounds[k] = ParamBounds()
         bounds[k][:mu] = ParamBox[ ParamBox(-5.0, 5.0, scale[psf_ids.mu[1]]),
                                    ParamBox(-5.0, 5.0, scale[psf_ids.mu[2]]) ]
-        bounds[k][:e_axis] = ParamBox[ ParamBox(0.1, 1.0, scale[psf_ids.e_axis] ) ]
-        bounds[k][:e_angle] =
-            ParamBox[ ParamBox(-4 * pi, 4 * pi, scale[psf_ids.e_angle] ) ]
-        bounds[k][:e_scale] =
-            ParamBox[ ParamBox(0.05, 10.0, scale[psf_ids.e_scale] ) ]
+        bounds[k][:gal_ab] = ParamBox[ ParamBox(0.1, 1.0, scale[psf_ids.gal_ab] ) ]
+        bounds[k][:gal_angle] =
+            ParamBox[ ParamBox(-4 * pi, 4 * pi, scale[psf_ids.gal_angle] ) ]
+        bounds[k][:gal_scale] =
+            ParamBox[ ParamBox(0.05, 10.0, scale[psf_ids.gal_scale] ) ]
 
         # Note that the weights do not need to sum to one.
         bounds[k][:weight] = ParamBox[ ParamBox(0.05, 2.0, scale[psf_ids.weight] ) ]
@@ -407,7 +407,7 @@ function evaluate_psf_pixel_fit!{NumType <: Number}(
     clear!(pixel_value)
 
     K = length(psf_params)
-    sigma_ids = (psf_ids.e_axis, psf_ids.e_angle, psf_ids.e_scale)
+    sigma_ids = (psf_ids.gal_ab, psf_ids.gal_angle, psf_ids.gal_scale)
     @inbounds for k = 1:K
         # I will put in the weights later so that the log pdf sensitive float
         # is accurate.
@@ -490,13 +490,13 @@ function get_sigma_from_params{NumType <: Number}(psf_params::Vector{Vector{NumT
     sig_sf_vec = Vector{GalaxySigmaDerivs{NumType}}(K)
     bvn_vec = Vector{BvnComponent{NumType}}(K)
     for k = 1:K
-        sigma_vec[k] = get_bvn_cov(psf_params[k][psf_ids.e_axis],
-            psf_params[k][psf_ids.e_angle],
-            psf_params[k][psf_ids.e_scale])
+        sigma_vec[k] = get_bvn_cov(psf_params[k][psf_ids.gal_ab],
+            psf_params[k][psf_ids.gal_angle],
+            psf_params[k][psf_ids.gal_scale])
         sig_sf_vec[k] = GalaxySigmaDerivs(
-            psf_params[k][psf_ids.e_angle],
-            psf_params[k][psf_ids.e_axis],
-            psf_params[k][psf_ids.e_scale], sigma_vec[k], 1.0, true)
+            psf_params[k][psf_ids.gal_angle],
+            psf_params[k][psf_ids.gal_ab],
+            psf_params[k][psf_ids.gal_scale], sigma_vec[k], 1.0, true)
 
         bvn_vec[k] =
             BvnComponent(SVector{2,NumType}(psf_params[k][psf_ids.mu]), sigma_vec[k], 1.0)

--- a/src/ParallelRun.jl
+++ b/src/ParallelRun.jl
@@ -30,7 +30,7 @@ const is_production_run = haskey(ENV, "CELESTE_PROD") && ENV["CELESTE_PROD"] != 
 
 #
 # ------ bounding box ------
-immutable BoundingBox
+struct BoundingBox
     ramin::Float64
     ramax::Float64
     decmin::Float64
@@ -47,7 +47,7 @@ end
 
 # ------
 # to time parts of Celeste
-type InferTiming
+mutable struct InferTiming
     query_fids::Float64
     read_photoobj::Float64
     read_img::Float64
@@ -480,7 +480,7 @@ end
 # ------
 # optimization result container
 
-immutable OptimizedSource
+struct OptimizedSource
     thingid::Int64
     objid::String
     init_ra::Float64
@@ -704,7 +704,7 @@ end
 Store the contents of the `field_extents.fits` file, so it doesn't
 have to be loaded repeatedly.
 """
-type FieldExtent
+struct FieldExtent
     run::Int16
     camcol::UInt8
     field::Int16

--- a/src/ParallelRun.jl
+++ b/src/ParallelRun.jl
@@ -214,7 +214,7 @@ function detect_sources(images::Vector{SDSSIO.RawImage})
             # threshold. Set other band fluxes to NaN, to indicate which
             # band the flux is measured in. We'll use this information below
             # when merging detections in different bands.
-            gal_fluxes = fill(NaN, B)
+            gal_fluxes = fill(NaN, num_bands)
             gal_fluxes[image.b] = sep_catalog.flux[i]
 
             gal_ab = sep_catalog.a[i] / sep_catalog.b[i]

--- a/src/ParallelRun.jl
+++ b/src/ParallelRun.jl
@@ -214,7 +214,7 @@ function detect_sources(images::Vector{SDSSIO.RawImage})
             # threshold. Set other band fluxes to NaN, to indicate which
             # band the flux is measured in. We'll use this information below
             # when merging detections in different bands.
-            gal_fluxes = fill(NaN, num_bands)
+            gal_fluxes = fill(NaN, NUM_BANDS)
             gal_fluxes[image.b] = sep_catalog.flux[i]
 
             gal_ab = sep_catalog.a[i] / sep_catalog.b[i]

--- a/src/SDSSIO.jl
+++ b/src/SDSSIO.jl
@@ -21,7 +21,7 @@ const DEFAULT_MASK_PLANES = ["S_MASK_INTERP",  # bad pixel (was interpolated)
 const BAND_CHAR_TO_NUM = Dict('u'=>1, 'g'=>2, 'r'=>3, 'i'=>4, 'z'=>5)
 
 
-immutable RunCamcolField
+struct RunCamcolField
     run::Int16
     camcol::UInt8
     field::Int16
@@ -195,7 +195,7 @@ function read_mask(strategy, rcf, b, mask_planes=DEFAULT_MASK_PLANES; data=nothi
 end
 
 
-immutable RawImage
+struct RawImage
     rcf::RunCamcolField
     b::Int  # band index
     pixels::Matrix{Float32} # in nMgy, sky-subtracted and calibrated

--- a/src/SDSSIO.jl
+++ b/src/SDSSIO.jl
@@ -286,11 +286,11 @@ function convert(::Type{Image}, r::RawImage)
         r.pixels[i, j] = (r.gain / r.calibration[i]) * (r.pixels[i, j] + sky_ij)
     end
 
-    iota_vec = r.gain ./ r.calibration
+    nelec_per_nmgy = r.gain ./ r.calibration
 
     Image(H, W, r.pixels, r.b, r.wcs, celeste_psf,
           r.rcf.run, r.rcf.camcol, r.rcf.field,
-          r.sky, iota_vec, r.raw_psf_comp)
+          r.sky, nelec_per_nmgy, r.raw_psf_comp)
 end
 
 # -----------------------------------------------------------------------------

--- a/src/SEP.jl
+++ b/src/SEP.jl
@@ -99,7 +99,7 @@ function sep_image(data::Array{T, 2};
                           (noise_type == :var) ? SEP_NOISE_VAR :
                           error("noise_type must be :stddev or :var"))
     end
-            
+
     return sep_image(data_ptr, noise_ptr, mask_ptr,
                      dtype, ndtype, mdtype,
                      sz[1], sz[2],
@@ -118,12 +118,12 @@ Spline representation of the variable background and noise of an image.
 
 # Arguments
 
-- `data::Matrix`: 
+- `data::Matrix`:
 - `mask=nothing`:
 - `boxsize=(64, 64)`:
 - `filtersize=(3, 3)`:
 - `filterthresh=0.0`:
-- `mask_thresh=0`: 
+- `mask_thresh=0`:
 """
 mutable struct Background
     ptr::Ptr{Void}
@@ -207,7 +207,7 @@ function broadcast(-, A::Array{T, 2} where T<:PixType, bkg::Background)
     B .-= bkg
     return B
 end
-    
+
 function (-)(A::Array{T, 2}, bkg::Background) where {T<:PixType}
     B = copy(A)
     B .-= bkg
@@ -301,10 +301,10 @@ Perform image segmentation on the data and return a catalog of sources.
 - `data::Matrix`: Image data.
 - `thresh::Real`: Threshold for detection in absolute units, or in standard
   deviations if noise is given.
-- `noise=nothing`: 
+- `noise=nothing`:
 - `noise_type=:stddev`:
 - `mask=nothing`:
-- `mask_thresh=0`: 
+- `mask_thresh=0`:
 - `minarea=5`:
 - `filter_kernel`:
 - `filter_type=:conv`:
@@ -336,12 +336,12 @@ function extract(data::Array{T, 2} where T, thresh::Real;
     # convert filter kernel to Cfloat array
     filter_kernel_cfloat = convert(Array{Cfloat, 2}, filter_kernel)
     filter_size = size(filter_kernel_cfloat)
-    
+
     ccatalog_ptr_ref = Ref{Ptr{sep_catalog}}(C_NULL)
     status = ccall((:sep_extract, libsep), Cint,
                    (Ptr{sep_image},
                     Cfloat, Cint, # thresh, thresh_type
-                    Cint,  # minarea  
+                    Cint,  # minarea
                     Ptr{Cfloat}, Cint, Cint,  # conv, convw, convh
                     Cint, # filter_type
                     Cint, Cdouble,  # deblend_nthresh, deblend_cont
@@ -371,7 +371,7 @@ function extract(data::Array{T, 2} where T, thresh::Real;
         pix[i] = unsafe_copy(ptr, npix[i])
         pix[i] .+= Cint(1) # change to 1-indexing
     end
-        
+
     result = Catalog(npix,
                      unsafe_copy(ccatalog.xmin, nobj),
                      unsafe_copy(ccatalog.xmax, nobj),
@@ -391,7 +391,7 @@ function extract(data::Array{T, 2} where T, thresh::Real;
     # switch to 1 indexing
     result.x .+= 1.0
     result.y .+= 1.0
-    
+
     # free result allocated in sep_extract
     ccall((:sep_catalog_free, libsep), Void, (Ptr{sep_catalog},), ccatalog_ptr)
 

--- a/src/SensitiveFloats.jl
+++ b/src/SensitiveFloats.jl
@@ -21,7 +21,7 @@ Attributes:
       in the same format as d.  This is used for the full Hessian
       with respect to all the sources.
 """
-immutable SensitiveFloat{NumType}
+struct SensitiveFloat{NumType}
     v::Base.RefValue{NumType}
 
     # local_P x local_S matrix of gradients

--- a/src/Transform.jl
+++ b/src/Transform.jl
@@ -9,7 +9,7 @@ using Compat
 using ..SensitiveFloats
 import ..Log
 
-import ..Model: num_source_types, ParamSet, num_bands, num_color_components
+import ..Model: NUM_SOURCE_TYPES, ParamSet, NUM_BANDS, NUM_COLOR_COMPONENTS
 
 export DataTransform, ParamBounds, ParamBox, SimplexBox,
        get_mp_transform, enforce_bounds!,
@@ -41,15 +41,15 @@ struct CanonicalParams <: ParamSet
     k::Matrix{Int}
     CanonicalParams() =
         new([1, 2], 3, 4, 5, 6,
-            collect(7:(7+num_source_types-1)),  # flux_loc
-            collect((7+num_source_types):(7+2num_source_types-1)), # flux_scale
-            reshape((7+2num_source_types):(7+2num_source_types+(num_bands-1)*num_source_types-1), (num_bands-1, num_source_types)),  # color_mean
-            reshape((7+2num_source_types+(num_bands-1)*num_source_types):(7+2num_source_types+2*(num_bands-1)*num_source_types-1), (num_bands-1, num_source_types)),  # color_var
-            reshape((7+2num_source_types+2*(num_bands-1)*num_source_types):(7+3num_source_types+2*(num_bands-1)*num_source_types-1), (num_source_types, 1)),  # a
-            reshape((7+3num_source_types+2*(num_bands-1)*num_source_types):(7+3num_source_types+2*(num_bands-1)*num_source_types+num_color_components*num_source_types-1), (num_color_components, num_source_types))) # k
+            collect(7:(7+NUM_SOURCE_TYPES-1)),  # flux_loc
+            collect((7+NUM_SOURCE_TYPES):(7+2NUM_SOURCE_TYPES-1)), # flux_scale
+            reshape((7+2NUM_SOURCE_TYPES):(7+2NUM_SOURCE_TYPES+(NUM_BANDS-1)*NUM_SOURCE_TYPES-1), (NUM_BANDS-1, NUM_SOURCE_TYPES)),  # color_mean
+            reshape((7+2NUM_SOURCE_TYPES+(NUM_BANDS-1)*NUM_SOURCE_TYPES):(7+2NUM_SOURCE_TYPES+2*(NUM_BANDS-1)*NUM_SOURCE_TYPES-1), (NUM_BANDS-1, NUM_SOURCE_TYPES)),  # color_var
+            reshape((7+2NUM_SOURCE_TYPES+2*(NUM_BANDS-1)*NUM_SOURCE_TYPES):(7+3NUM_SOURCE_TYPES+2*(NUM_BANDS-1)*NUM_SOURCE_TYPES-1), (NUM_SOURCE_TYPES, 1)),  # a
+            reshape((7+3NUM_SOURCE_TYPES+2*(NUM_BANDS-1)*NUM_SOURCE_TYPES):(7+3NUM_SOURCE_TYPES+2*(NUM_BANDS-1)*NUM_SOURCE_TYPES+NUM_COLOR_COMPONENTS*NUM_SOURCE_TYPES-1), (NUM_COLOR_COMPONENTS, NUM_SOURCE_TYPES))) # k
 end
 const ids = CanonicalParams()
-Base.length(::Type{CanonicalParams}) = 6 + 3*num_source_types + 2*(num_bands-1)*num_source_types + num_color_components*num_source_types
+Base.length(::Type{CanonicalParams}) = 6 + 3*NUM_SOURCE_TYPES + 2*(NUM_BANDS-1)*NUM_SOURCE_TYPES + NUM_COLOR_COMPONENTS*NUM_SOURCE_TYPES
 
 struct UnconstrainedParams <: ParamSet
     pos::Vector{Int}
@@ -65,17 +65,17 @@ struct UnconstrainedParams <: ParamSet
     k::Matrix{Int}
     UnconstrainedParams() =
         new([1, 2], 3, 4, 5, 6,
-            collect(7:(7+num_source_types-1)),  # flux_loc
-            collect((7+num_source_types):(7+2num_source_types-1)), # flux_scale
-            reshape((7+2num_source_types):(7+2num_source_types+(num_bands-1)*num_source_types-1), (num_bands-1, num_source_types)),  # color_mean
-            reshape((7+2num_source_types+(num_bands-1)*num_source_types):(7+2num_source_types+2*(num_bands-1)*num_source_types-1), (num_bands-1, num_source_types)),  # color_var
-            reshape((7+2num_source_types+2*(num_bands-1)*num_source_types):
-                    (7+2num_source_types+2*(num_bands-1)*num_source_types+(num_source_types-1)-1), (num_source_types - 1, 1)),  # a
-            reshape((7+2num_source_types+2*(num_bands-1)*num_source_types+(num_source_types-1)):
-                    (7+2num_source_types+2*(num_bands-1)*num_source_types+(num_source_types-1)+(num_color_components-1)*num_source_types-1), (num_color_components-1, num_source_types))) # k
+            collect(7:(7+NUM_SOURCE_TYPES-1)),  # flux_loc
+            collect((7+NUM_SOURCE_TYPES):(7+2NUM_SOURCE_TYPES-1)), # flux_scale
+            reshape((7+2NUM_SOURCE_TYPES):(7+2NUM_SOURCE_TYPES+(NUM_BANDS-1)*NUM_SOURCE_TYPES-1), (NUM_BANDS-1, NUM_SOURCE_TYPES)),  # color_mean
+            reshape((7+2NUM_SOURCE_TYPES+(NUM_BANDS-1)*NUM_SOURCE_TYPES):(7+2NUM_SOURCE_TYPES+2*(NUM_BANDS-1)*NUM_SOURCE_TYPES-1), (NUM_BANDS-1, NUM_SOURCE_TYPES)),  # color_var
+            reshape((7+2NUM_SOURCE_TYPES+2*(NUM_BANDS-1)*NUM_SOURCE_TYPES):
+                    (7+2NUM_SOURCE_TYPES+2*(NUM_BANDS-1)*NUM_SOURCE_TYPES+(NUM_SOURCE_TYPES-1)-1), (NUM_SOURCE_TYPES - 1, 1)),  # a
+            reshape((7+2NUM_SOURCE_TYPES+2*(NUM_BANDS-1)*NUM_SOURCE_TYPES+(NUM_SOURCE_TYPES-1)):
+                    (7+2NUM_SOURCE_TYPES+2*(NUM_BANDS-1)*NUM_SOURCE_TYPES+(NUM_SOURCE_TYPES-1)+(NUM_COLOR_COMPONENTS-1)*NUM_SOURCE_TYPES-1), (NUM_COLOR_COMPONENTS-1, NUM_SOURCE_TYPES))) # k
 end
 const ids_free = UnconstrainedParams()
-Base.length(::Type{UnconstrainedParams}) =  6 + 2*num_source_types + 2*(num_bands-1)*num_source_types + (num_color_components-1)*num_source_types + num_source_types-1
+Base.length(::Type{UnconstrainedParams}) =  6 + 2*NUM_SOURCE_TYPES + 2*(NUM_BANDS-1)*NUM_SOURCE_TYPES + (NUM_COLOR_COMPONENTS-1)*NUM_SOURCE_TYPES + NUM_SOURCE_TYPES-1
 
 ################################
 # Elementary functions.
@@ -744,14 +744,14 @@ function get_mp_transform{NumType <: Number}(
             bounds[si][:pos][axis] =
                 ParamBox(pos[axis] - loc_width, pos[axis] + loc_width, loc_scale)
         end
-        bounds[si][:flux_loc] = Vector{ParamBox}(num_source_types)
-        bounds[si][:flux_scale] = Vector{ParamBox}(num_source_types)
-        for i in 1:num_source_types
+        bounds[si][:flux_loc] = Vector{ParamBox}(NUM_SOURCE_TYPES)
+        bounds[si][:flux_scale] = Vector{ParamBox}(NUM_SOURCE_TYPES)
+        for i in 1:NUM_SOURCE_TYPES
             bounds[si][:flux_loc][i] = ParamBox(-1.0, 10., 1.0)
             bounds[si][:flux_scale][i] = ParamBox(1e-4, 0.1, 1.0)
         end
-        bounds[si][:color_mean] = Vector{ParamBox}(4 * num_source_types)
-        bounds[si][:color_var] = Vector{ParamBox}(4 * num_source_types)
+        bounds[si][:color_mean] = Vector{ParamBox}(4 * NUM_SOURCE_TYPES)
+        bounds[si][:color_var] = Vector{ParamBox}(4 * NUM_SOURCE_TYPES)
         for ind in 1:length(ids.color_mean)
             bounds[si][:color_mean][ind] = ParamBox(-10., 10., 1.0)
             bounds[si][:color_var][ind] = ParamBox(1e-4, 1., 1.0)
@@ -764,9 +764,9 @@ function get_mp_transform{NumType <: Number}(
         bounds[si][:a] = Vector{SimplexBox}(1)
         bounds[si][:a][1] = SimplexBox(0.005, 1.0, 2)
 
-        bounds[si][:k] = Vector{SimplexBox}(num_source_types)
-        for i in 1:num_source_types
-            bounds[si][:k][i] = SimplexBox(0.01 / num_color_components, 1.0, num_color_components)
+        bounds[si][:k] = Vector{SimplexBox}(NUM_SOURCE_TYPES)
+        for i in 1:NUM_SOURCE_TYPES
+            bounds[si][:k][i] = SimplexBox(0.01 / NUM_COLOR_COMPONENTS, 1.0, NUM_COLOR_COMPONENTS)
         end
     end
 

--- a/src/Transform.jl
+++ b/src/Transform.jl
@@ -19,15 +19,15 @@ export DataTransform, ParamBounds, ParamBox, SimplexBox,
 # A vector of variational parameters.  The outer index is
 # of celestial objects, and the inner index is over individual
 # parameters for that object (referenced using ParamIndex).
-@compat const VariationalParams{NumType <: Number}     = Vector{Vector{NumType}}
-@compat const FreeVariationalParams{NumType <: Number} = Vector{Vector{NumType}}
+const VariationalParams{NumType <: Number} = Vector{Vector{NumType}}
+const FreeVariationalParams{NumType <: Number} = Vector{Vector{NumType}}
 
 #####################################################################################
 # this is essentially a compatibility layer since Model has gotten rid of this code
 # it's messy, but this doesn't really matter too much, since Transforms.jl is going
 # the way of the dinosaur
 
-type CanonicalParams <: ParamSet
+struct CanonicalParams <: ParamSet
     pos::Vector{Int}
     gal_fracdev::Int
     gal_ab::Int
@@ -51,7 +51,7 @@ end
 const ids = CanonicalParams()
 Base.length(::Type{CanonicalParams}) = 6 + 3*num_source_types + 2*(num_bands-1)*num_source_types + num_color_components*num_source_types
 
-type UnconstrainedParams <: ParamSet
+struct UnconstrainedParams <: ParamSet
     pos::Vector{Int}
     gal_fracdev::Int
     gal_ab::Int
@@ -135,7 +135,7 @@ end
 ################################
 # The transforms for Celeste.
 
-immutable ParamBox
+struct ParamBox
     lb::Float64  # lower bound
     ub::Float64  # upper bound
     scale::Float64
@@ -148,7 +148,7 @@ immutable ParamBox
     end
 end
 
-immutable SimplexBox
+struct SimplexBox
     lb::Float64  # lower bound
     scale::Float64
     n::Int
@@ -161,7 +161,7 @@ immutable SimplexBox
 end
 
 # The vector of transform parameters for a Symbol.
-@compat const ParamBounds = Dict{Symbol, Union{Vector{ParamBox}, Vector{SimplexBox}}}
+const ParamBounds = Dict{Symbol, Union{Vector{ParamBox}, Vector{SimplexBox}}}
 
 
 ###############################################
@@ -345,7 +345,7 @@ Members:
   d2param_dfree2: A vector of hessians.  Each element is the Hessian of one
                   component of the aforementioned f()
 """
-type TransformDerivatives{NumType <: Number}
+struct TransformDerivatives{NumType <: Number}
     dparam_dfree::Matrix{NumType}
     d2param_dfree2::Vector{Matrix{NumType}}
     Sa::Int
@@ -587,7 +587,7 @@ bounds: The bounds for each parameter and each object in ElboArgs.
 active_sources: The sources that are being optimized.    Only these sources'
     parameters are transformed into the parameter vector.
 """
-type DataTransform
+struct DataTransform
     bounds::Vector{ParamBounds}
     active_sources::Vector{Int}
     S::Int

--- a/src/aliasscopes.jl
+++ b/src/aliasscopes.jl
@@ -5,13 +5,13 @@ immutable Const{T}
     a::T
 end
 
-Base.getindex(A::Const{<:Array}, i1::Int) = Core.const_arrayref(A.a, i1)
-@inline Base.getindex(A::Const{<:Array}, i1::Int, i2::Int, I::Int...) =  Core.const_arrayref(A.a, i1, i2, I...)
+Base.getindex(A::Const{<:Array}, i1::Int) = Core.const_arrayref(A.is_star, i1)
+@inline Base.getindex(A::Const{<:Array}, i1::Int, i2::Int, I::Int...) =  Core.const_arrayref(A.is_star, i1, i2, I...)
 
 @generated function Base.getindex{SM<:SizedMatrix}(m::Const{SM}, i1::Integer, i2::Integer)
     quote
       $(Expr(:meta, :inline, :propagate_inbounds))
-      data = m.a.data
+      data = m.is_star.data
       @boundscheck if (i1 < 1 || i1 > $(size(SM,1)) || i2 < 1 || i2 > $(size(SM, 2)))
           throw(BoundsError(data, (i1,i2)))
       end

--- a/src/aliasscopes.jl
+++ b/src/aliasscopes.jl
@@ -1,7 +1,7 @@
 using StaticArrays
 
 if isdefined(Base.SimdLoop, Symbol("@unroll_annotation"))
-immutable Const{T}
+struct Const{T}
     a::T
 end
 

--- a/src/bivariate_normals.jl
+++ b/src/bivariate_normals.jl
@@ -37,7 +37,7 @@ end
 Pre-allocated memory for quantities related to derivatives of bivariate
 normals.
 """
-type BivariateNormalDerivatives{NumType <: Number}
+struct BivariateNormalDerivatives{NumType <: Number}
 
   # Pre-allocated memory for py1, py2, and f when evaluating BVNs
   py1::Array{NumType, 1}
@@ -129,7 +129,7 @@ Attributes:
    dsiginv_dsig: The derivative of sigma inverse with respect to sigma.
    major_sd: The standard deviation of the major axis.
 """
-immutable BvnComponent{NumType <: Number}
+struct BvnComponent{NumType <: Number}
     the_mean::SVector{2,NumType}
     precision::SMatrix{2,2,NumType,4}
     z::NumType
@@ -313,7 +313,7 @@ parameters are indexed by GalaxyShapeParams.
  - t: A Sigma x GalaxyShapeParams x GalaxyShapeParams tensor of second
       derivatives d2 Sigma / d GalaxyShapeParams d GalaxyShapeParams.
 """
-immutable GalaxySigmaDerivs{NumType <: Number}
+struct GalaxySigmaDerivs{NumType <: Number}
     j::SMatrix{3,gal_shape_ids_len,NumType,9}
     t::SArray{Tuple{3,gal_shape_ids_len,gal_shape_ids_len},NumType,3,27}
 end
@@ -388,7 +388,7 @@ Attributes:
      [Sigma11, Sigma12, Sigma22] (in the rows) with respect to
      [gal_ab, gal_angle, gal_scale] (in the columns)
 """
-immutable GalaxyCacheComponent{NumType <: Number}
+struct GalaxyCacheComponent{NumType <: Number}
     gal_fracdev_dir::Float64
     gal_fracdev_i::NumType
     bmc::BvnComponent{NumType}
@@ -589,7 +589,7 @@ function transform_bvn_derivs!{NumType <: Number}(
     end
 end
 
-immutable BvnBundle{T<:Real}
+struct BvnBundle{T<:Real}
     bvn_derivs::BivariateNormalDerivatives{T}
     star_mcs::Matrix{BvnComponent{T}}
     gal_mcs::Array{GalaxyCacheComponent{T},4}

--- a/src/bivariate_normals.jl
+++ b/src/bivariate_normals.jl
@@ -55,7 +55,7 @@ type BivariateNormalDerivatives{NumType <: Number}
   dpy1_dsig::Array{NumType, 1}
   dpy2_dsig::Array{NumType, 1}
 
-  # Derivatives of a bvn with respect to (u, shape)
+  # Derivatives of a bvn with respect to (pos, shape)
   bvn_u_d::Array{NumType, 1}
   bvn_uu_h::SizedMatrix{2, 2, NumType, 2}
   bvn_s_d::Array{NumType, 1}
@@ -76,7 +76,7 @@ type BivariateNormalDerivatives{NumType <: Number}
     dpy1_dsig = zeros(NumType, 3)
     dpy2_dsig = zeros(NumType, 3)
 
-    # Derivatives wrt u.
+    # Derivatives wrt pos.
     bvn_u_d = zeros(NumType, 2)
     bvn_uu_h = zeros(NumType, 2, 2)
 
@@ -321,37 +321,37 @@ end
 
 """
 Args:
-  - e_angle: Phi in the notes
-  - e_axis: Rho in the notes
-  - e_scale: Lower case sigma in the notes
+  - gal_angle: Phi in the notes
+  - gal_ab: Rho in the notes
+  - gal_scale: Lower case sigma in the notes
   - XiXi: The value of sigma.
 
 Note that nubar is not included.
 """
 function GalaxySigmaDerivs{NumType <: Number}(
-    e_angle::NumType, e_axis::NumType, e_scale::NumType,
+    gal_angle::NumType, gal_ab::NumType, gal_scale::NumType,
     XiXi::SMatrix{2,2,NumType,4}, nuBar::Float64=1.0, calculate_tensor::Bool=true)
 
-  cos_sin = cos(e_angle)sin(e_angle)
-  sin_sq  = sin(e_angle)^2
-  cos_sq  = cos(e_angle)^2
+  cos_sin = cos(gal_angle)sin(gal_angle)
+  sin_sq  = sin(gal_angle)^2
+  cos_sq  = cos(gal_angle)^2
 
-  j = hcat(2 * e_axis * e_scale^2 * SVector{3,NumType}(sin_sq, -cos_sin, cos_sq),
-           e_scale^2 * (e_axis^2 - 1) * SVector{3,NumType}(2cos_sin, sin_sq - cos_sq, -2cos_sin),
-           2 * SVector{3,NumType}(XiXi[1], XiXi[2], XiXi[4]) / e_scale)
+  j = hcat(2 * gal_ab * gal_scale^2 * SVector{3,NumType}(sin_sq, -cos_sin, cos_sq),
+           gal_scale^2 * (gal_ab^2 - 1) * SVector{3,NumType}(2cos_sin, sin_sq - cos_sq, -2cos_sin),
+           2 * SVector{3,NumType}(XiXi[1], XiXi[2], XiXi[4]) / gal_scale)
 
   if calculate_tensor
     # Second derivatives.
 
-    t = SArray{Tuple{3,3,3}, NumType, 3, 27}(sin_sq * 2 * e_scale^2, -cos_sin * 2 * e_scale^2, cos_sq * 2 * e_scale^2,
-      2cos_sin * 2 * e_scale^2 * e_axis, (sin_sq - cos_sq) * 2 * e_scale^2 * e_axis, -2cos_sin * 2 * e_scale^2 * e_axis,
-      2 * j[1, gal_shape_ids.e_axis]  / e_scale, 2 * j[2, gal_shape_ids.e_axis]  / e_scale, 2 * j[3, gal_shape_ids.e_axis]  / e_scale,
-      2cos_sin * 2 * e_scale^2 * e_axis, (sin_sq - cos_sq) * 2 * e_scale^2 * e_axis, -2cos_sin * 2 * e_scale^2 * e_axis,
-      (cos_sq - sin_sq) * 2 * e_scale^2 * (e_axis^2 - 1), 2cos_sin * 2 * e_scale^2 * (e_axis^2 - 1), (sin_sq - cos_sq) * 2 * e_scale^2 * (e_axis^2 - 1),
-      2 * j[1, gal_shape_ids.e_angle] / e_scale, 2 * j[2, gal_shape_ids.e_angle] / e_scale, 2 * j[3, gal_shape_ids.e_angle] / e_scale,
-      2 * j[1, gal_shape_ids.e_axis]  / e_scale, 2 * j[2, gal_shape_ids.e_axis]  / e_scale, 2 * j[3, gal_shape_ids.e_axis]  / e_scale,
-      2 * j[1, gal_shape_ids.e_angle] / e_scale, 2 * j[2, gal_shape_ids.e_angle] / e_scale, 2 * j[3, gal_shape_ids.e_angle] / e_scale,
-      2 * XiXi[1 << (1 - 1)] / e_scale^2, 2 * XiXi[1 << (2 - 1)] / e_scale^2, 2 * XiXi[1 << (3 - 1)] / e_scale^2)
+    t = SArray{Tuple{3,3,3}, NumType, 3, 27}(sin_sq * 2 * gal_scale^2, -cos_sin * 2 * gal_scale^2, cos_sq * 2 * gal_scale^2,
+      2cos_sin * 2 * gal_scale^2 * gal_ab, (sin_sq - cos_sq) * 2 * gal_scale^2 * gal_ab, -2cos_sin * 2 * gal_scale^2 * gal_ab,
+      2 * j[1, gal_shape_ids.gal_ab]  / gal_scale, 2 * j[2, gal_shape_ids.gal_ab]  / gal_scale, 2 * j[3, gal_shape_ids.gal_ab]  / gal_scale,
+      2cos_sin * 2 * gal_scale^2 * gal_ab, (sin_sq - cos_sq) * 2 * gal_scale^2 * gal_ab, -2cos_sin * 2 * gal_scale^2 * gal_ab,
+      (cos_sq - sin_sq) * 2 * gal_scale^2 * (gal_ab^2 - 1), 2cos_sin * 2 * gal_scale^2 * (gal_ab^2 - 1), (sin_sq - cos_sq) * 2 * gal_scale^2 * (gal_ab^2 - 1),
+      2 * j[1, gal_shape_ids.gal_angle] / gal_scale, 2 * j[2, gal_shape_ids.gal_angle] / gal_scale, 2 * j[3, gal_shape_ids.gal_angle] / gal_scale,
+      2 * j[1, gal_shape_ids.gal_ab]  / gal_scale, 2 * j[2, gal_shape_ids.gal_ab]  / gal_scale, 2 * j[3, gal_shape_ids.gal_ab]  / gal_scale,
+      2 * j[1, gal_shape_ids.gal_angle] / gal_scale, 2 * j[2, gal_shape_ids.gal_angle] / gal_scale, 2 * j[3, gal_shape_ids.gal_angle] / gal_scale,
+      2 * XiXi[1 << (1 - 1)] / gal_scale^2, 2 * XiXi[1 << (2 - 1)] / gal_scale^2, 2 * XiXi[1 << (3 - 1)] / gal_scale^2)
 
   else
     t = @SArray zeros(NumType, 3, 3, 3)
@@ -365,60 +365,60 @@ end
 The convolution of a one galaxy component with one PSF component.
 It also contains the derivatives of sigma with respect to the shape parameters.
 It does not contain the derivatives with respect to other parameters
-(u and e_dev) because they have easy expressions in terms of other known
+(pos and gal_fracdev) because they have easy expressions in terms of other known
 quantities.
 
 Args:
- - e_dev_dir: "Theta direction": this is 1 or -1, depending on whether
-     increasing e_dev increases the weight of this GalaxyCacheComponent
+ - gal_fracdev_dir: "Theta direction": this is 1 or -1, depending on whether
+     increasing gal_fracdev increases the weight of this GalaxyCacheComponent
      (1) or decreases it (-1).
- - e_dev_i: The weight given to this type of galaxy for this celestial object.
-     This is either e_dev or (1 - e_dev).
+ - gal_fracdev_i: The weight given to this type of galaxy for this celestial object.
+     This is either gal_fracdev or (1 - gal_fracdev).
  - gc: The galaxy component to be convolved
  - pc: The psf component to be convolved
- - u: The location of the celestial object in pixel coordinates as a 2x1 vector
- - e_axis: The ratio of the galaxy minor axis to major axis (0 < e_axis <= 1)
- - e_scale: The scale of the galaxy major axis
+ - pos: The location of the celestial object in pixel coordinates as a 2x1 vector
+ - gal_ab: The ratio of the galaxy minor axis to major axis (0 < gal_ab <= 1)
+ - gal_scale: The scale of the galaxy major axis
 
 Attributes:
- - e_dev_dir: Same as input
- - e_dev_i: Same as input
+ - gal_fracdev_dir: Same as input
+ - gal_fracdev_i: Same as input
  - bmc: A BvnComponent with the convolution.
  - dSigma: A 3x3 matrix containing the derivates of
      [Sigma11, Sigma12, Sigma22] (in the rows) with respect to
-     [e_axis, e_angle, e_scale] (in the columns)
+     [gal_ab, gal_angle, gal_scale] (in the columns)
 """
 immutable GalaxyCacheComponent{NumType <: Number}
-    e_dev_dir::Float64
-    e_dev_i::NumType
+    gal_fracdev_dir::Float64
+    gal_fracdev_i::NumType
     bmc::BvnComponent{NumType}
     sig_sf::GalaxySigmaDerivs{NumType}
-    # [Sigma11, Sigma12, Sigma22] x [e_axis, e_angle, e_scale]
+    # [Sigma11, Sigma12, Sigma22] x [gal_ab, gal_angle, gal_scale]
 end
 
 
 function GalaxyCacheComponent{NumType <: Number}(
-    e_dev_dir::Float64, e_dev_i::NumType,
-    gc::GalaxyComponent, pc::PsfComponent, u::Vector{NumType},
-    e_axis::NumType, e_angle::NumType, e_scale::NumType,
+    gal_fracdev_dir::Float64, gal_fracdev_i::NumType,
+    gc::GalaxyComponent, pc::PsfComponent, pos::Vector{NumType},
+    gal_ab::NumType, gal_angle::NumType, gal_scale::NumType,
     calculate_gradient::Bool, calculate_hessian::Bool)
 
-  XiXi = get_bvn_cov(e_axis, e_angle, e_scale)
-  mean_s = @SVector NumType[pc.xiBar[1] + u[1], pc.xiBar[2] + u[2]]
+  XiXi = get_bvn_cov(gal_ab, gal_angle, gal_scale)
+  mean_s = @SVector NumType[pc.xiBar[1] + pos[1], pc.xiBar[2] + pos[2]]
   var_s = pc.tauBar + gc.nuBar * XiXi
-  weight = pc.alphaBar * gc.etaBar  # excludes e_dev
+  weight = pc.alphaBar * gc.etaBar  # excludes gal_fracdev
 
   # d siginv / dsigma is only necessary for the Hessian.
   bmc = BvnComponent(mean_s, var_s, weight, calculate_gradient && calculate_hessian)
 
   if calculate_gradient
     sig_sf = GalaxySigmaDerivs(
-      e_angle, e_axis, e_scale, XiXi, gc.nuBar, calculate_hessian)
+      gal_angle, gal_ab, gal_scale, XiXi, gc.nuBar, calculate_hessian)
   else
     sig_sf = GalaxySigmaDerivs(NumType)
   end
 
-  GalaxyCacheComponent(e_dev_dir, e_dev_i, bmc, sig_sf)
+  GalaxyCacheComponent(gal_fracdev_dir, gal_fracdev_i, bmc, sig_sf)
 end
 
 GalaxySigmaDerivs{NumType}(::Type{NumType}) = GalaxySigmaDerivs(
@@ -430,7 +430,7 @@ GalaxySigmaDerivs{NumType}(::Type{NumType}) = GalaxySigmaDerivs(
 
 """
 Transform the bvn derivatives and hessians from (x) to the
-galaxy parameters (u). Updates bvn_u_d and bvn_uu_h in place.
+galaxy parameters (pos). Updates bvn_u_d and bvn_uu_h in place.
 
 bvn_x_d and bvn_xx_h should already have been set using get_bvn_derivs!()
 """
@@ -456,7 +456,7 @@ function transform_bvn_ux_derivs!{NumType <: Number}(
     bvn_uu_h = bvn_derivs.bvn_uu_h
     bvn_xx_h = bvn_derivs.bvn_xx_h
     fill!(bvn_uu_h, 0.0)
-    # Second derivatives involving only u.
+    # Second derivatives involving only pos.
     # As above, dxA_duB = -wcs_jacobian[A, B] and d2x / du2 = 0.
     # TODO: time consuming **************
     @inbounds for x_id2 in 1:2, x_id1 in 1:2, u_id2 in 1:2
@@ -528,7 +528,7 @@ function transform_bvn_derivs_hessian!{NumType <: Number}(
       end
     end
 
-    # Second derivates involving both a shape term and a u term.
+    # Second derivates involving both a shape term and a pos term.
     # TODO: time consuming **************
     bvn_xsig_h = Const(bvn_derivs.bvn_xsig_h)
     @unroll_loop for shape_id in 1:length(gal_shape_ids)
@@ -546,7 +546,7 @@ end
 
 
 """
-Transform all the bvn derivatives from x and sigma to u and the model
+Transform all the bvn derivatives from x and sigma to pos and the model
 parameters.
 
 These values should already have been set using get_bvn_derivs!():
@@ -561,7 +561,7 @@ function transform_bvn_derivs!{NumType <: Number}(
     sig_sf::GalaxySigmaDerivs{NumType},
     wcs_jacobian, calculate_hessian::Bool)
 
-  # Transform the u derivates first.
+  # Transform the pos derivates first.
   # bvn_x_d and bvn_xx_h should already have been set using get_bvn_derivs!()
   transform_bvn_ux_derivs!(bvn_derivs, wcs_jacobian, calculate_hessian)
 

--- a/src/deterministic_vi/ConstraintTransforms.jl
+++ b/src/deterministic_vi/ConstraintTransforms.jl
@@ -10,9 +10,9 @@ using Compat
 # Constraint Types #
 ####################
 
-@compat abstract type Constraint end
+abstract type Constraint end
 
-immutable BoxConstraint <: Constraint
+struct BoxConstraint <: Constraint
     lower::Float64
     upper::Float64
     scale::Float64
@@ -25,7 +25,7 @@ immutable BoxConstraint <: Constraint
     end
 end
 
-immutable SimplexConstraint <: Constraint
+struct SimplexConstraint <: Constraint
     lower::Float64
     scale::Float64
     n::Int # length of the simplex in the free parameterization
@@ -37,7 +37,7 @@ immutable SimplexConstraint <: Constraint
     end
 end
 
-immutable ParameterConstraint{C<:Constraint} <: Constraint
+struct ParameterConstraint{C<:Constraint} <: Constraint
     constraint::C
     indices::UnitRange{Int} # indices in the bound parameterization
 end
@@ -45,7 +45,7 @@ end
 ParameterConstraint(c::Constraint, i::Vector) = ParameterConstraint(c, first(i):last(i))
 ParameterConstraint(c::Constraint, i::Int) = ParameterConstraint(c, i:i)
 
-immutable ConstraintBatch
+struct ConstraintBatch
     boxes::Vector{Vector{ParameterConstraint{BoxConstraint}}}
     simplexes::Vector{Vector{ParameterConstraint{SimplexConstraint}}}
     function ConstraintBatch(boxes, simplexes)
@@ -319,9 +319,9 @@ using ForwardDiff: Dual, jacobian!, JacobianConfig
 
 const NUM_ELBO_BOUND_PARAMS = length(CanonicalParams)
 
-@compat const TransformJacobianConfig{M,N,T} = JacobianConfig{N,T,Tuple{Array{Dual{N,T},M},Vector{Dual{N,T}}}}
+const TransformJacobianConfig{M,N,T} = JacobianConfig{N,T,Tuple{Array{Dual{N,T},M},Vector{Dual{N,T}}}}
 
-immutable TransformDerivatives{N,T}
+struct TransformDerivatives{N,T}
     jacobian::Matrix{T}
     hessian::Array{T,3}
     output_dual::Vector{Dual{N,T}}

--- a/src/deterministic_vi/ElboMaximize.jl
+++ b/src/deterministic_vi/ElboMaximize.jl
@@ -22,7 +22,7 @@ using ..DeterministicVI.ConstraintTransforms: TransformDerivatives,
 # defaults for optional arguments to `maximize!` #
 ##################################################
 
-immutable Config{N,T}
+struct Config{N,T}
     bound_params::VariationalParams{T}
     free_params::VariationalParams{T}
     free_initial_input::Vector{T}
@@ -171,7 +171,7 @@ end
 # Objective #
 #-----------#
 
-immutable Objective{N,T} <: Function
+struct Objective{N,T} <: Function
     ea::ElboArgs
     vp::VariationalParams{T}
     cfg::Config{N,T}
@@ -185,7 +185,7 @@ end
 # Gradient #
 #----------#
 
-immutable Gradient{N,T} <: Function
+struct Gradient{N,T} <: Function
     ea::ElboArgs
     vp::VariationalParams{T}
     cfg::Config{N,T}
@@ -203,7 +203,7 @@ end
 # Hessian #
 #---------#
 
-immutable Hessian{N,T} <: Function
+struct Hessian{N,T} <: Function
     ea::ElboArgs
     vp::VariationalParams{T}
     cfg::Config{N,T}

--- a/src/deterministic_vi/ElboMaximize.jl
+++ b/src/deterministic_vi/ElboMaximize.jl
@@ -82,8 +82,8 @@ function elbo_constraints{T}(bound::VariationalParams{T},
         ]
         simplexes[src] = [
             ParameterConstraint(SimplexConstraint(0.005, 1.0, 2), ids.is_star),
-            ParameterConstraint(SimplexConstraint(0.01/num_color_components, 1.0, num_color_components), ids.k[:, 1]),
-            ParameterConstraint(SimplexConstraint(0.01/num_color_components, 1.0, num_color_components), ids.k[:, 2])
+            ParameterConstraint(SimplexConstraint(0.01/NUM_COLOR_COMPONENTS, 1.0, NUM_COLOR_COMPONENTS), ids.k[:, 1]),
+            ParameterConstraint(SimplexConstraint(0.01/NUM_COLOR_COMPONENTS, 1.0, NUM_COLOR_COMPONENTS), ids.k[:, 2])
         ]
     end
     return ConstraintBatch(boxes, simplexes)

--- a/src/deterministic_vi/ElboMaximize.jl
+++ b/src/deterministic_vi/ElboMaximize.jl
@@ -64,26 +64,26 @@ function elbo_constraints{T}(bound::VariationalParams{T},
     boxes = Vector{Vector{ParameterConstraint{BoxConstraint}}}(n_sources)
     simplexes = Vector{Vector{ParameterConstraint{SimplexConstraint}}}(n_sources)
     for src in 1:n_sources
-        i1, i2 = ids.u[1], ids.u[2]
+        i1, i2 = ids.pos[1], ids.pos[2]
         u1, u2 = bound[src][i1], bound[src][i2]
         boxes[src] = [
             ParameterConstraint(BoxConstraint(u1 - loc_width, u1 + loc_width, loc_scale), i1),
             ParameterConstraint(BoxConstraint(u2 - loc_width, u2 + loc_width, loc_scale), i2),
-            ParameterConstraint(BoxConstraint(1e-2, 0.99, 1.0), ids.e_dev),
-            ParameterConstraint(BoxConstraint(1e-2, 0.99, 1.0), ids.e_axis),
-            ParameterConstraint(BoxConstraint(-10.0, 10.0, 1.0), ids.e_angle),
-            ParameterConstraint(BoxConstraint(0.10, 70.0, 1.0), ids.e_scale),
-            ParameterConstraint(BoxConstraint(-1.0, 10.0, 1.0), ids.r1),
-            ParameterConstraint(BoxConstraint(1e-4, 0.10, 1.0), ids.r2),
-            ParameterConstraint(BoxConstraint(-10.0, 10.0, 1.0), ids.c1[:, 1]),
-            ParameterConstraint(BoxConstraint(-10.0, 10.0, 1.0), ids.c1[:, 2]),
-            ParameterConstraint(BoxConstraint(1e-4, 1.0, 1.0), ids.c2[:, 1]),
-            ParameterConstraint(BoxConstraint(1e-4, 1.0, 1.0), ids.c2[:, 2])
+            ParameterConstraint(BoxConstraint(1e-2, 0.99, 1.0), ids.gal_fracdev),
+            ParameterConstraint(BoxConstraint(1e-2, 0.99, 1.0), ids.gal_ab),
+            ParameterConstraint(BoxConstraint(-10.0, 10.0, 1.0), ids.gal_angle),
+            ParameterConstraint(BoxConstraint(0.10, 70.0, 1.0), ids.gal_scale),
+            ParameterConstraint(BoxConstraint(-1.0, 10.0, 1.0), ids.flux_loc),
+            ParameterConstraint(BoxConstraint(1e-4, 0.10, 1.0), ids.flux_scale),
+            ParameterConstraint(BoxConstraint(-10.0, 10.0, 1.0), ids.color_mean[:, 1]),
+            ParameterConstraint(BoxConstraint(-10.0, 10.0, 1.0), ids.color_mean[:, 2]),
+            ParameterConstraint(BoxConstraint(1e-4, 1.0, 1.0), ids.color_var[:, 1]),
+            ParameterConstraint(BoxConstraint(1e-4, 1.0, 1.0), ids.color_var[:, 2])
         ]
         simplexes[src] = [
-            ParameterConstraint(SimplexConstraint(0.005, 1.0, 2), ids.a),
-            ParameterConstraint(SimplexConstraint(0.01/D, 1.0, D), ids.k[:, 1]),
-            ParameterConstraint(SimplexConstraint(0.01/D, 1.0, D), ids.k[:, 2])
+            ParameterConstraint(SimplexConstraint(0.005, 1.0, 2), ids.is_star),
+            ParameterConstraint(SimplexConstraint(0.01/num_color_components, 1.0, num_color_components), ids.k[:, 1]),
+            ParameterConstraint(SimplexConstraint(0.01/num_color_components, 1.0, num_color_components), ids.k[:, 2])
         ]
     end
     return ConstraintBatch(boxes, simplexes)

--- a/src/deterministic_vi/elbo_args.jl
+++ b/src/deterministic_vi/elbo_args.jl
@@ -2,7 +2,7 @@
 Store pre-allocated memory in this data structures, which contains
 intermediate values used in the ELBO calculation.
 """
-immutable HessianSubmatrices{NumType <: Number}
+struct HessianSubmatrices{NumType <: Number}
     u_u::Matrix{NumType}
     shape_shape::Matrix{NumType}
 end
@@ -26,7 +26,7 @@ function HessianSubmatrices(NumType::DataType, i::Int)
 end
 
 
-immutable ElboIntermediateVariables{NumType <: Number}
+struct ElboIntermediateVariables{NumType <: Number}
     # Vectors of star and galaxy bvn quantities from all sources for a pixel.
     # The vector has one element for each active source, in the same order
     # as ea.active_sources.
@@ -152,7 +152,7 @@ end
 Some parameter to a function has invalid values. The message should explain what parameter is
 invalid and why.
 """
-type InvalidInputError <: Exception
+struct InvalidInputError <: Exception
     message::String
 end
 
@@ -161,7 +161,7 @@ end
 ElboArgs stores the arguments needed to evaluate the variational objective
 function.
 """
-immutable ElboArgs
+struct ElboArgs
     # the overall number of sources: we don't necessarily visit them
     # all or optimize them all, but if we do visit a pixel where any
     # of these are active, we use it in the elbo calculation

--- a/src/deterministic_vi/elbo_args.jl
+++ b/src/deterministic_vi/elbo_args.jl
@@ -14,10 +14,10 @@ of the E_G_s and E_G2_s Hessian.
 
 Args:
     NumType: The numeric type of the hessian.
-    i: The type of celestial source, from 1:num_source_types
+    i: The type of celestial source, from 1:NUM_SOURCE_TYPES
 """
 function HessianSubmatrices(NumType::DataType, i::Int)
-    @assert 1 <= i <= num_source_types
+    @assert 1 <= i <= NUM_SOURCE_TYPES
     shape_p = length(shape_standard_alignment[i])
 
     u_u = zeros(NumType, 2, 2)
@@ -41,7 +41,7 @@ struct ElboIntermediateVariables{NumType <: Number}
 
     # Subsets of the Hessian of E_G_s and E_G2_s that allow us to use BLAS
     # functions to accumulate Hessian terms. There is one submatrix for
-    # each celestial object type in 1:num_source_types
+    # each celestial object type in 1:NUM_SOURCE_TYPES
     E_G_s_hsub_vec::Vector{HessianSubmatrices{NumType}}
     E_G2_s_hsub_vec::Vector{HessianSubmatrices{NumType}}
 
@@ -91,9 +91,9 @@ function ElboIntermediateVariables(NumType::DataType,
     var_G_s = SensitiveFloat(E_G_s)
 
     E_G_s_hsub_vec =
-        HessianSubmatrices{NumType}[ HessianSubmatrices(NumType, i) for i=1:num_source_types ]
+        HessianSubmatrices{NumType}[ HessianSubmatrices(NumType, i) for i=1:NUM_SOURCE_TYPES ]
     E_G2_s_hsub_vec =
-        HessianSubmatrices{NumType}[ HessianSubmatrices(NumType, i) for i=1:num_source_types ]
+        HessianSubmatrices{NumType}[ HessianSubmatrices(NumType, i) for i=1:NUM_SOURCE_TYPES ]
 
     E_G = SensitiveFloat{NumType}(length(CanonicalParams), num_active_sources,
                                   calculate_gradient, calculate_hessian)
@@ -119,7 +119,7 @@ function clear!{NumType <: Number}(elbo_vars::ElboIntermediateVariables{NumType}
     clear!(elbo_vars.E_G2_s)
     clear!(elbo_vars.var_G_s)
 
-    for i in 1:num_source_types
+    for i in 1:NUM_SOURCE_TYPES
         fill!(elbo_vars.E_G_s_hsub_vec[i].u_u, zero(NumType))
         fill!(elbo_vars.E_G_s_hsub_vec[i].shape_shape, zero(NumType))
         fill!(elbo_vars.E_G2_s_hsub_vec[i].u_u, zero(NumType))

--- a/src/deterministic_vi/elbo_args.jl
+++ b/src/deterministic_vi/elbo_args.jl
@@ -14,10 +14,10 @@ of the E_G_s and E_G2_s Hessian.
 
 Args:
     NumType: The numeric type of the hessian.
-    i: The type of celestial source, from 1:Ia
+    i: The type of celestial source, from 1:num_source_types
 """
 function HessianSubmatrices(NumType::DataType, i::Int)
-    @assert 1 <= i <= Ia
+    @assert 1 <= i <= num_source_types
     shape_p = length(shape_standard_alignment[i])
 
     u_u = zeros(NumType, 2, 2)
@@ -41,7 +41,7 @@ immutable ElboIntermediateVariables{NumType <: Number}
 
     # Subsets of the Hessian of E_G_s and E_G2_s that allow us to use BLAS
     # functions to accumulate Hessian terms. There is one submatrix for
-    # each celestial object type in 1:Ia
+    # each celestial object type in 1:num_source_types
     E_G_s_hsub_vec::Vector{HessianSubmatrices{NumType}}
     E_G2_s_hsub_vec::Vector{HessianSubmatrices{NumType}}
 
@@ -91,9 +91,9 @@ function ElboIntermediateVariables(NumType::DataType,
     var_G_s = SensitiveFloat(E_G_s)
 
     E_G_s_hsub_vec =
-        HessianSubmatrices{NumType}[ HessianSubmatrices(NumType, i) for i=1:Ia ]
+        HessianSubmatrices{NumType}[ HessianSubmatrices(NumType, i) for i=1:num_source_types ]
     E_G2_s_hsub_vec =
-        HessianSubmatrices{NumType}[ HessianSubmatrices(NumType, i) for i=1:Ia ]
+        HessianSubmatrices{NumType}[ HessianSubmatrices(NumType, i) for i=1:num_source_types ]
 
     E_G = SensitiveFloat{NumType}(length(CanonicalParams), num_active_sources,
                                   calculate_gradient, calculate_hessian)
@@ -119,7 +119,7 @@ function clear!{NumType <: Number}(elbo_vars::ElboIntermediateVariables{NumType}
     clear!(elbo_vars.E_G2_s)
     clear!(elbo_vars.var_G_s)
 
-    for i in 1:Ia
+    for i in 1:num_source_types
         fill!(elbo_vars.E_G_s_hsub_vec[i].u_u, zero(NumType))
         fill!(elbo_vars.E_G_s_hsub_vec[i].shape_shape, zero(NumType))
         fill!(elbo_vars.E_G2_s_hsub_vec[i].u_u, zero(NumType))

--- a/src/deterministic_vi/elbo_kl.jl
+++ b/src/deterministic_vi/elbo_kl.jl
@@ -160,11 +160,11 @@ end
 using ForwardDiff: Dual, JacobianConfig, pickchunksize
 using ReverseDiff: TrackedArray, TrackedReal, CompiledTape, GradientTape
 
-@compat const KLGradientTape{T} = GradientTape{typeof(subtract_kl),
-                                               TrackedArray{T,T,1,Vector{T},Vector{T}},
-                                               TrackedReal{T,T,Void}}
+const KLGradientTape{T} = GradientTape{typeof(subtract_kl),
+                                       TrackedArray{T,T,1,Vector{T},Vector{T}},
+                                       TrackedReal{T,T,Void}}
 
-immutable KLHelper{N,T}
+struct KLHelper{N,T}
     gradient_tape::CompiledTape{:kl_gradient,KLGradientTape{T}}
     nested_gradient_tape::CompiledTape{:kl_nested_gradient,KLGradientTape{Dual{N,T}}}
     dual_buffer::Vector{Dual{N,T}}

--- a/src/deterministic_vi/elbo_kl.jl
+++ b/src/deterministic_vi/elbo_kl.jl
@@ -1,7 +1,7 @@
 module KLDivergence
 
 using ..DeterministicVI: ElboArgs, VariationalParams, init_thread_pool!
-using ...Model: CanonicalParams, ids, prior, num_source_types, num_color_components
+using ...Model: CanonicalParams, ids, prior, NUM_SOURCE_TYPES, NUM_COLOR_COMPONENTS
 using ...SensitiveFloats: SensitiveFloat, add_sources_sf!
 using Compat
 using ForwardDiff, ReverseDiff, DiffBase
@@ -95,7 +95,7 @@ kl_source_a(vs) = categorical_kl(vs[ids.is_star], prior.is_star)
 
 function kl_source_r(vs)
     kl = zero(eltype(vs))
-    for i in 1:num_source_types
+    for i in 1:NUM_SOURCE_TYPES
         kl += vs[ids.is_star[i]] * gaussian_kl(vs[ids.flux_loc[i]], vs[ids.flux_scale[i]],
                                             prior.flux_mean[i], prior.flux_var[i])
     end
@@ -105,7 +105,7 @@ end
 
 function kl_source_k(vs)
     kl = zero(eltype(vs))
-    for i in 1:num_source_types
+    for i in 1:NUM_SOURCE_TYPES
         kl += vs[ids.is_star[i]] * categorical_kl(vs[ids.k[:, i]], prior.k[:, i])
     end
     assert(!isnan(kl))
@@ -114,10 +114,10 @@ end
 
 function kl_source_c(vs)
     kl = zero(eltype(vs))
-    for i in 1:num_source_types
+    for i in 1:NUM_SOURCE_TYPES
         μ₁, var₁ = vs[ids.color_mean[:, i]], vs[ids.color_var[:, i]]
         a = vs[ids.is_star[i]]
-        for d in 1:num_color_components
+        for d in 1:NUM_COLOR_COMPONENTS
             μ₂, Σ₂ = prior.color_mean[:, d, i], prior.color_cov[:, :, d, i]
             kl += a * vs[ids.k[d, i]] * diagmvn_mvn_kl(μ₁, var₁, μ₂, Σ₂)
         end

--- a/src/deterministic_vi/elbo_kl.jl
+++ b/src/deterministic_vi/elbo_kl.jl
@@ -1,7 +1,7 @@
 module KLDivergence
 
 using ..DeterministicVI: ElboArgs, VariationalParams, init_thread_pool!
-using ...Model: CanonicalParams, ids, prior, Ia, D
+using ...Model: CanonicalParams, ids, prior, num_source_types, num_color_components
 using ...SensitiveFloats: SensitiveFloat, add_sources_sf!
 using Compat
 using ForwardDiff, ReverseDiff, DiffBase
@@ -91,13 +91,13 @@ end
 # Subtracting KL divergences from sources #
 ###########################################
 
-kl_source_a(vs) = categorical_kl(vs[ids.a], prior.a)
+kl_source_a(vs) = categorical_kl(vs[ids.is_star], prior.is_star)
 
 function kl_source_r(vs)
     kl = zero(eltype(vs))
-    for i in 1:Ia
-        kl += vs[ids.a[i]] * gaussian_kl(vs[ids.r1[i]], vs[ids.r2[i]],
-                                            prior.r_μ[i], prior.r_σ²[i])
+    for i in 1:num_source_types
+        kl += vs[ids.is_star[i]] * gaussian_kl(vs[ids.flux_loc[i]], vs[ids.flux_scale[i]],
+                                            prior.flux_mean[i], prior.flux_var[i])
     end
     assert(!isnan(kl))
     return kl
@@ -105,8 +105,8 @@ end
 
 function kl_source_k(vs)
     kl = zero(eltype(vs))
-    for i in 1:Ia
-        kl += vs[ids.a[i]] * categorical_kl(vs[ids.k[:, i]], prior.k[:, i])
+    for i in 1:num_source_types
+        kl += vs[ids.is_star[i]] * categorical_kl(vs[ids.k[:, i]], prior.k[:, i])
     end
     assert(!isnan(kl))
     return kl
@@ -114,11 +114,11 @@ end
 
 function kl_source_c(vs)
     kl = zero(eltype(vs))
-    for i in 1:Ia
-        μ₁, var₁ = vs[ids.c1[:, i]], vs[ids.c2[:, i]]
-        a = vs[ids.a[i]]
-        for d in 1:D
-            μ₂, Σ₂ = prior.c_mean[:, d, i], prior.c_cov[:, :, d, i]
+    for i in 1:num_source_types
+        μ₁, var₁ = vs[ids.color_mean[:, i]], vs[ids.color_var[:, i]]
+        a = vs[ids.is_star[i]]
+        for d in 1:num_color_components
+            μ₂, Σ₂ = prior.color_mean[:, d, i], prior.color_cov[:, :, d, i]
             kl += a * vs[ids.k[d, i]] * diagmvn_mvn_kl(μ₁, var₁, μ₂, Σ₂)
         end
     end
@@ -128,9 +128,9 @@ end
 
 
 function source_e_log_prob(vs)
-    x = vs[ids.e_scale]
-    μ = prior.e_scale_μ
-    σ² = prior.e_scale_σ²
+    x = vs[ids.gal_scale]
+    μ = prior.gal_scale_mean
+    σ² = prior.gal_scale_var
     kl = -0.5 * (log(2pi) + log(σ²) + (x - μ)^2 / σ²)
     assert(!isnan(kl))
     return kl

--- a/src/deterministic_vi/elbo_objective.jl
+++ b/src/deterministic_vi/elbo_objective.jl
@@ -41,9 +41,9 @@ function calculate_G_s!{NumType <: Number}(
         var_G_s.v[] = 0.0
     end
 
-    @inbounds for i in 1:Ia # Celestial object types (e.g. stars and galaxies)
+    @inbounds for i in 1:num_source_types # Celestial object types (e.g. stars and galaxies)
         fsm_i = (i == 1) ? elbo_vars.fs0m : elbo_vars.fs1m
-        a_i = vp[s][ids.a[i]]
+        a_i = vp[s][ids.is_star[i]]
         sb_E_l_a_b_i = sb.E_l_a[b, i]
         sb_E_ll_a_b_i = sb.E_ll_a[b, i]
 
@@ -69,12 +69,12 @@ function calculate_G_s!{NumType <: Number}(
         ############ Only gradient and hessian code below ##############
         (is_active_source && elbo_vars.elbo.has_gradient) || continue
 
-        E_G_s_d[ids.a[i], 1] += lf
-        E_G2_s_d[ids.a[i], 1] += llff
+        E_G_s_d[ids.is_star[i], 1] += lf
+        E_G2_s_d[ids.is_star[i], 1] += llff
 
         p0_shape = shape_standard_alignment[i]
         p0_bright = brightness_standard_alignment[i]
-        u_ind = i == 1 ? star_ids.u : gal_ids.u
+        u_ind = i == 1 ? star_ids.pos : gal_ids.pos
 
         # Derivatives with respect to the spatial parameters
         tmp1 = sb_E_l_a_b_i_v * a_i
@@ -143,26 +143,26 @@ function calculate_G_s!{NumType <: Number}(
 
         # The (a, bright) blocks:
         for p0_ind in 1:length(p0_bright)
-            E_G_s_h[p0_bright[p0_ind], ids.a[i]] =
+            E_G_s_h[p0_bright[p0_ind], ids.is_star[i]] =
                 fsm_i_v * sb_E_l_a_b_i_d[p0_ind, 1]
-            E_G2_s_h[p0_bright[p0_ind], ids.a[i]] =
+            E_G2_s_h[p0_bright[p0_ind], ids.is_star[i]] =
                 (fsm_i_v ^ 2) * sb_E_ll_a_b_i_d[p0_ind, 1]
-            E_G_s_h[ids.a[i], p0_bright[p0_ind]] =
-                E_G_s_h[p0_bright[p0_ind], ids.a[i]]
-            E_G2_s_h[ids.a[i], p0_bright[p0_ind]] =
-                E_G2_s_h[p0_bright[p0_ind], ids.a[i]]
+            E_G_s_h[ids.is_star[i], p0_bright[p0_ind]] =
+                E_G_s_h[p0_bright[p0_ind], ids.is_star[i]]
+            E_G2_s_h[ids.is_star[i], p0_bright[p0_ind]] =
+                E_G2_s_h[p0_bright[p0_ind], ids.is_star[i]]
         end
 
         # The (a, shape) blocks.
         for p0_ind in 1:length(p0_shape)
-            E_G_s_h[p0_shape[p0_ind], ids.a[i]] =
+            E_G_s_h[p0_shape[p0_ind], ids.is_star[i]] =
                 sb_E_l_a_b_i_v * fsm_i_d[p0_ind, 1]
-            E_G2_s_h[p0_shape[p0_ind], ids.a[i]] =
+            E_G2_s_h[p0_shape[p0_ind], ids.is_star[i]] =
                 sb_E_ll_a_b_i_v * 2 * fsm_i_v * fsm_i_d[p0_ind, 1]
-            E_G_s_h[ids.a[i], p0_shape[p0_ind]] =
-                E_G_s_h[p0_shape[p0_ind], ids.a[i]]
-            E_G2_s_h[ids.a[i], p0_shape[p0_ind]] =
-                E_G2_s_h[p0_shape[p0_ind], ids.a[i]]
+            E_G_s_h[ids.is_star[i], p0_shape[p0_ind]] =
+                E_G_s_h[p0_shape[p0_ind], ids.is_star[i]]
+            E_G2_s_h[ids.is_star[i], p0_shape[p0_ind]] =
+                E_G2_s_h[p0_shape[p0_ind], ids.is_star[i]]
         end
 
         for ind_b in 1:length(p0_bright), ind_s in 1:length(p0_shape)
@@ -179,21 +179,21 @@ function calculate_G_s!{NumType <: Number}(
     end # i loop
 
     if elbo_vars.elbo.has_hessian
-        # Accumulate the u Hessian. u is the only parameter that is shared between
+        # Accumulate the pos Hessian. pos is the only parameter that is shared between
         # different values of i.
 
         # This is
-        # for i = 1:Ia
+        # for i = 1:num_source_types
         #     E_G_u_u_hess += elbo_vars.E_G_s_hsub_vec[i].u_u
         #     E_G2_u_u_hess += elbo_vars.E_G2_s_hsub_vec[i].u_u
         # end
-        # For each value in 1:Ia, written this way for speed.
+        # For each value in 1:num_source_types, written this way for speed.
         for u_ind1 = 1:2, u_ind2 = 1:2
-            elbo_vars.E_G_s.h[ids.u[u_ind1], ids.u[u_ind2]] =
+            elbo_vars.E_G_s.h[ids.pos[u_ind1], ids.pos[u_ind2]] =
                 elbo_vars.E_G_s_hsub_vec[1].u_u[u_ind1, u_ind2] +
                 elbo_vars.E_G_s_hsub_vec[2].u_u[u_ind1, u_ind2]
 
-            elbo_vars.E_G2_s.h[ids.u[u_ind1], ids.u[u_ind2]] =
+            elbo_vars.E_G2_s.h[ids.pos[u_ind1], ids.pos[u_ind2]] =
                 elbo_vars.E_G2_s_hsub_vec[1].u_u[u_ind1, u_ind2] +
                 elbo_vars.E_G2_s_hsub_vec[2].u_u[u_ind1, u_ind2]
         end
@@ -382,10 +382,10 @@ function add_pixel_term!{NumType <: Number}(
                        elbo_vars.var_G,
                        elbo_vars.elbo,
                        img.pixels[h,w],
-                       img.iota_vec[h])
+                       img.nelec_per_nmgy[h])
     add_scaled_sfs!(elbo_vars.elbo,
                     elbo_vars.E_G,
-                    -img.iota_vec[h])
+                    -img.nelec_per_nmgy[h])
 
     # Subtract the log factorial term. This is not a function of the
     # parameters so the derivatives don't need to be updated. Note that

--- a/src/deterministic_vi/elbo_objective.jl
+++ b/src/deterministic_vi/elbo_objective.jl
@@ -41,7 +41,7 @@ function calculate_G_s!{NumType <: Number}(
         var_G_s.v[] = 0.0
     end
 
-    @inbounds for i in 1:num_source_types # Celestial object types (e.g. stars and galaxies)
+    @inbounds for i in 1:NUM_SOURCE_TYPES # Celestial object types (e.g. stars and galaxies)
         fsm_i = (i == 1) ? elbo_vars.fs0m : elbo_vars.fs1m
         a_i = vp[s][ids.is_star[i]]
         sb_E_l_a_b_i = sb.E_l_a[b, i]
@@ -183,11 +183,11 @@ function calculate_G_s!{NumType <: Number}(
         # different values of i.
 
         # This is
-        # for i = 1:num_source_types
+        # for i = 1:NUM_SOURCE_TYPES
         #     E_G_u_u_hess += elbo_vars.E_G_s_hsub_vec[i].u_u
         #     E_G2_u_u_hess += elbo_vars.E_G2_s_hsub_vec[i].u_u
         # end
-        # For each value in 1:num_source_types, written this way for speed.
+        # For each value in 1:NUM_SOURCE_TYPES, written this way for speed.
         for u_ind1 = 1:2, u_ind2 = 1:2
             elbo_vars.E_G_s.h[ids.pos[u_ind1], ids.pos[u_ind2]] =
                 elbo_vars.E_G_s_hsub_vec[1].u_u[u_ind1, u_ind2] +

--- a/src/deterministic_vi/source_brightness.jl
+++ b/src/deterministic_vi/source_brightness.jl
@@ -8,10 +8,10 @@ Attributes:
 Each matrix has one row for each color and a column for
 star / galaxy.  Row 3 is the gamma distribute baseline brightness,
 and all other rows are lognormal offsets.
-- E_l_a: A B x Ia matrix of expectations and derivatives of
+- E_l_a: A num_bands x num_source_types matrix of expectations and derivatives of
   color terms.  The rows are bands, and the columns
   are star / galaxy.
-- E_ll_a: A B x Ia matrix of expectations and derivatives of
+- E_ll_a: A num_bands x num_source_types matrix of expectations and derivatives of
   squared color terms.  The rows are bands, and the columns
   are star / galaxy.
 """
@@ -27,81 +27,81 @@ end
 function SourceBrightness{NumType <: Number}(vs::Vector{NumType};
                                              calculate_gradient=true,
                                              calculate_hessian=true)
-    r1 = vs[ids.r1]
-    r2 = vs[ids.r2]
-    c1 = vs[ids.c1]
-    c2 = vs[ids.c2]
+    flux_loc = vs[ids.flux_loc]
+    flux_scale = vs[ids.flux_scale]
+    color_mean = vs[ids.color_mean]
+    color_var = vs[ids.color_var]
 
     # E_l_a has a row for each of the five colors and columns
     # for star / galaxy.
-    E_l_a  = Matrix{SensitiveFloat{NumType}}(B, Ia)
-    E_ll_a = Matrix{SensitiveFloat{NumType}}(B, Ia)
+    E_l_a  = Matrix{SensitiveFloat{NumType}}(num_bands, num_source_types)
+    E_ll_a = Matrix{SensitiveFloat{NumType}}(num_bands, num_source_types)
 
-    for i = 1:Ia
-        for b = 1:B
+    for i = 1:num_source_types
+        for b = 1:num_bands
             E_l_a[b, i] = SensitiveFloat{NumType}(length(BrightnessParams), 1,
                                        calculate_gradient, calculate_hessian)
         end
 
-        E_l_a[3, i].v[] = exp(r1[i] + 0.5 * r2[i])
-        E_l_a[4, i].v[] = exp(c1[3, i] + .5 * c2[3, i])
-        E_l_a[5, i].v[] = exp(c1[4, i] + .5 * c2[4, i])
-        E_l_a[2, i].v[] = exp(-c1[2, i] + .5 * c2[2, i])
-        E_l_a[1, i].v[] = exp(-c1[1, i] + .5 * c2[1, i])
+        E_l_a[3, i].v[] = exp(flux_loc[i] + 0.5 * flux_scale[i])
+        E_l_a[4, i].v[] = exp(color_mean[3, i] + .5 * color_var[3, i])
+        E_l_a[5, i].v[] = exp(color_mean[4, i] + .5 * color_var[4, i])
+        E_l_a[2, i].v[] = exp(-color_mean[2, i] + .5 * color_var[2, i])
+        E_l_a[1, i].v[] = exp(-color_mean[1, i] + .5 * color_var[1, i])
 
         if calculate_gradient
             # band 3 is the reference band, relative to which the colors are
             # specified.
             # It is denoted r_s and has a lognormal expectation.
-            E_l_a[3, i].d[bids.r1] = E_l_a[3, i].v[]
-            E_l_a[3, i].d[bids.r2] = E_l_a[3, i].v[] * .5
+            E_l_a[3, i].d[bids.flux_loc] = E_l_a[3, i].v[]
+            E_l_a[3, i].d[bids.flux_scale] = E_l_a[3, i].v[] * .5
 
             if calculate_hessian
-                set_hess!(E_l_a[3, i], bids.r1, bids.r1, E_l_a[3, i].v[])
-                set_hess!(E_l_a[3, i], bids.r1, bids.r2, E_l_a[3, i].v[] * 0.5)
-                set_hess!(E_l_a[3, i], bids.r2, bids.r2, E_l_a[3, i].v[] * 0.25)
+                set_hess!(E_l_a[3, i], bids.flux_loc, bids.flux_loc, E_l_a[3, i].v[])
+                set_hess!(E_l_a[3, i], bids.flux_loc, bids.flux_scale, E_l_a[3, i].v[] * 0.5)
+                set_hess!(E_l_a[3, i], bids.flux_scale, bids.flux_scale, E_l_a[3, i].v[] * 0.25)
             end
 
             # The remaining indices involve c_s and have lognormal
             # expectations times E_c_3.
 
             # band 4 = band 3 * color 3.
-            E_l_a[4, i].d[bids.c1[3]] = E_l_a[4, i].v[]
-            E_l_a[4, i].d[bids.c2[3]] = E_l_a[4, i].v[] * .5
+            E_l_a[4, i].d[bids.color_mean[3]] = E_l_a[4, i].v[]
+            E_l_a[4, i].d[bids.color_var[3]] = E_l_a[4, i].v[] * .5
             if calculate_hessian
-                set_hess!(E_l_a[4, i], bids.c1[3], bids.c1[3], E_l_a[4, i].v[])
-                set_hess!(E_l_a[4, i], bids.c1[3], bids.c2[3], E_l_a[4, i].v[] * 0.5)
-                set_hess!(E_l_a[4, i], bids.c2[3], bids.c2[3], E_l_a[4, i].v[] * 0.25)
+                set_hess!(E_l_a[4, i], bids.color_mean[3], bids.color_mean[3], E_l_a[4, i].v[])
+                set_hess!(E_l_a[4, i], bids.color_mean[3], bids.color_var[3], E_l_a[4, i].v[] * 0.5)
+                set_hess!(E_l_a[4, i], bids.color_var[3], bids.color_var[3], E_l_a[4, i].v[] * 0.25)
             end
             multiply_sfs!(E_l_a[4, i], E_l_a[3, i])
 
             # Band 5 = band 4 * color 4.
-            E_l_a[5, i].d[bids.c1[4]] = E_l_a[5, i].v[]
-            E_l_a[5, i].d[bids.c2[4]] = E_l_a[5, i].v[] * .5
+            E_l_a[5, i].d[bids.color_mean[4]] = E_l_a[5, i].v[]
+            E_l_a[5, i].d[bids.color_var[4]] = E_l_a[5, i].v[] * .5
             if calculate_hessian
-                set_hess!(E_l_a[5, i], bids.c1[4], bids.c1[4], E_l_a[5, i].v[])
-                set_hess!(E_l_a[5, i], bids.c1[4], bids.c2[4], E_l_a[5, i].v[] * 0.5)
-                set_hess!(E_l_a[5, i], bids.c2[4], bids.c2[4], E_l_a[5, i].v[] * 0.25)
+                set_hess!(E_l_a[5, i], bids.color_mean[4], bids.color_mean[4], E_l_a[5, i].v[])
+                set_hess!(E_l_a[5, i], bids.color_mean[4], bids.color_var[4], E_l_a[5, i].v[] * 0.5)
+                set_hess!(E_l_a[5, i], bids.color_var[4], bids.color_var[4], E_l_a[5, i].v[] * 0.25)
             end
             multiply_sfs!(E_l_a[5, i], E_l_a[4, i])
 
             # Band 2 = band 3 * color 2.
-            E_l_a[2, i].d[bids.c1[2]] = E_l_a[2, i].v[] * -1.
-            E_l_a[2, i].d[bids.c2[2]] = E_l_a[2, i].v[] * .5
+            E_l_a[2, i].d[bids.color_mean[2]] = E_l_a[2, i].v[] * -1.
+            E_l_a[2, i].d[bids.color_var[2]] = E_l_a[2, i].v[] * .5
             if calculate_hessian
-                set_hess!(E_l_a[2, i], bids.c1[2], bids.c1[2], E_l_a[2, i].v[])
-                set_hess!(E_l_a[2, i], bids.c1[2], bids.c2[2], E_l_a[2, i].v[] * -0.5)
-                set_hess!(E_l_a[2, i], bids.c2[2], bids.c2[2], E_l_a[2, i].v[] * 0.25)
+                set_hess!(E_l_a[2, i], bids.color_mean[2], bids.color_mean[2], E_l_a[2, i].v[])
+                set_hess!(E_l_a[2, i], bids.color_mean[2], bids.color_var[2], E_l_a[2, i].v[] * -0.5)
+                set_hess!(E_l_a[2, i], bids.color_var[2], bids.color_var[2], E_l_a[2, i].v[] * 0.25)
             end
             multiply_sfs!(E_l_a[2, i], E_l_a[3, i])
 
             # Band 1 = band 2 * color 1.
-            E_l_a[1, i].d[bids.c1[1]] = E_l_a[1, i].v[] * -1.
-            E_l_a[1, i].d[bids.c2[1]] = E_l_a[1, i].v[] * .5
+            E_l_a[1, i].d[bids.color_mean[1]] = E_l_a[1, i].v[] * -1.
+            E_l_a[1, i].d[bids.color_var[1]] = E_l_a[1, i].v[] * .5
             if calculate_hessian
-                set_hess!(E_l_a[1, i], bids.c1[1], bids.c1[1], E_l_a[1, i].v[])
-                set_hess!(E_l_a[1, i], bids.c1[1], bids.c2[1], E_l_a[1, i].v[] * -0.5)
-                set_hess!(E_l_a[1, i], bids.c2[1], bids.c2[1], E_l_a[1, i].v[] * 0.25)
+                set_hess!(E_l_a[1, i], bids.color_mean[1], bids.color_mean[1], E_l_a[1, i].v[])
+                set_hess!(E_l_a[1, i], bids.color_mean[1], bids.color_var[1], E_l_a[1, i].v[] * -0.5)
+                set_hess!(E_l_a[1, i], bids.color_var[1], bids.color_var[1], E_l_a[1, i].v[] * 0.25)
             end
             multiply_sfs!(E_l_a[1, i], E_l_a[2, i])
         else
@@ -115,77 +115,77 @@ function SourceBrightness{NumType <: Number}(vs::Vector{NumType};
         ################################
         # Squared terms.
 
-        for b = 1:B
+        for b = 1:num_bands
             E_ll_a[b, i] = SensitiveFloat{NumType}(length(BrightnessParams), 1,
                                            calculate_gradient, calculate_hessian)
         end
 
-        E_ll_a[3, i].v[] = exp(2 * r1[i] + 2 * r2[i])
-        E_ll_a[4, i].v[] = exp(2 * c1[3, i] + 2 * c2[3, i])
-        E_ll_a[5, i].v[] = exp(2 * c1[4, i] + 2 * c2[4, i])
-        E_ll_a[2, i].v[] = exp(-2 * c1[2, i] + 2 * c2[2, i])
-        E_ll_a[1, i].v[] = exp(-2 * c1[1, i] + 2 * c2[1, i])
+        E_ll_a[3, i].v[] = exp(2 * flux_loc[i] + 2 * flux_scale[i])
+        E_ll_a[4, i].v[] = exp(2 * color_mean[3, i] + 2 * color_var[3, i])
+        E_ll_a[5, i].v[] = exp(2 * color_mean[4, i] + 2 * color_var[4, i])
+        E_ll_a[2, i].v[] = exp(-2 * color_mean[2, i] + 2 * color_var[2, i])
+        E_ll_a[1, i].v[] = exp(-2 * color_mean[1, i] + 2 * color_var[1, i])
 
         if calculate_gradient
             # Band 3, the reference band.
-            E_ll_a[3, i].d[bids.r1] = 2 * E_ll_a[3, i].v[]
-            E_ll_a[3, i].d[bids.r2] = 2 * E_ll_a[3, i].v[]
+            E_ll_a[3, i].d[bids.flux_loc] = 2 * E_ll_a[3, i].v[]
+            E_ll_a[3, i].d[bids.flux_scale] = 2 * E_ll_a[3, i].v[]
             if calculate_hessian
-                for hess_ids in [(bids.r1, bids.r1),
-                                 (bids.r1, bids.r2),
-                                 (bids.r2, bids.r2)]
+                for hess_ids in [(bids.flux_loc, bids.flux_loc),
+                                 (bids.flux_loc, bids.flux_scale),
+                                 (bids.flux_scale, bids.flux_scale)]
                     set_hess!(E_ll_a[3, i], hess_ids..., 4.0 * E_ll_a[3, i].v[])
                 end
             end
 
             # Band 4 = band 3 * color 3.
-            E_ll_a[4, i].d[bids.c1[3]] = E_ll_a[4, i].v[] * 2.
-            E_ll_a[4, i].d[bids.c2[3]] = E_ll_a[4, i].v[] * 2.
+            E_ll_a[4, i].d[bids.color_mean[3]] = E_ll_a[4, i].v[] * 2.
+            E_ll_a[4, i].d[bids.color_var[3]] = E_ll_a[4, i].v[] * 2.
             if calculate_hessian
-                for hess_ids in [(bids.c1[3], bids.c1[3]),
-                                 (bids.c1[3], bids.c2[3]),
-                                 (bids.c2[3], bids.c2[3])]
+                for hess_ids in [(bids.color_mean[3], bids.color_mean[3]),
+                                 (bids.color_mean[3], bids.color_var[3]),
+                                 (bids.color_var[3], bids.color_var[3])]
                     set_hess!(E_ll_a[4, i], hess_ids..., E_ll_a[4, i].v[] * 4.0)
                 end
             end
             multiply_sfs!(E_ll_a[4, i], E_ll_a[3, i])
 
             # Band 5 = band 4 * color 4.
-            tmp4 = exp(2 * c1[4, i] + 2 * c2[4, i])
-            E_ll_a[5, i].d[bids.c1[4]] = E_ll_a[5, i].v[] * 2.
-            E_ll_a[5, i].d[bids.c2[4]] = E_ll_a[5, i].v[] * 2.
+            tmp4 = exp(2 * color_mean[4, i] + 2 * color_var[4, i])
+            E_ll_a[5, i].d[bids.color_mean[4]] = E_ll_a[5, i].v[] * 2.
+            E_ll_a[5, i].d[bids.color_var[4]] = E_ll_a[5, i].v[] * 2.
             if calculate_hessian
-                for hess_ids in [(bids.c1[4], bids.c1[4]),
-                                 (bids.c1[4], bids.c2[4]),
-                                 (bids.c2[4], bids.c2[4])]
+                for hess_ids in [(bids.color_mean[4], bids.color_mean[4]),
+                                 (bids.color_mean[4], bids.color_var[4]),
+                                 (bids.color_var[4], bids.color_var[4])]
                     set_hess!(E_ll_a[5, i], hess_ids..., E_ll_a[5, i].v[] * 4.0)
                 end
             end
             multiply_sfs!(E_ll_a[5, i], E_ll_a[4, i])
 
             # Band 2 = band 3 * color 2
-            tmp2 = exp(-2 * c1[2, i] + 2 * c2[2, i])
-            E_ll_a[2, i].d[bids.c1[2]] = E_ll_a[2, i].v[] * -2.
-            E_ll_a[2, i].d[bids.c2[2]] = E_ll_a[2, i].v[] * 2.
+            tmp2 = exp(-2 * color_mean[2, i] + 2 * color_var[2, i])
+            E_ll_a[2, i].d[bids.color_mean[2]] = E_ll_a[2, i].v[] * -2.
+            E_ll_a[2, i].d[bids.color_var[2]] = E_ll_a[2, i].v[] * 2.
             if calculate_hessian
-                for hess_ids in [(bids.c1[2], bids.c1[2]),
-                                 (bids.c2[2], bids.c2[2])]
+                for hess_ids in [(bids.color_mean[2], bids.color_mean[2]),
+                                 (bids.color_var[2], bids.color_var[2])]
                     set_hess!(E_ll_a[2, i], hess_ids..., E_ll_a[2, i].v[] * 4.0)
                 end
-                set_hess!(E_ll_a[2, i], bids.c1[2], bids.c2[2],
+                set_hess!(E_ll_a[2, i], bids.color_mean[2], bids.color_var[2],
                           E_ll_a[2, i].v[] * -4.0)
             end
             multiply_sfs!(E_ll_a[2, i], E_ll_a[3, i])
 
             # Band 1 = band 2 * color 1
-            E_ll_a[1, i].d[bids.c1[1]] = E_ll_a[1, i].v[] * -2.
-            E_ll_a[1, i].d[bids.c2[1]] = E_ll_a[1, i].v[] * 2.
+            E_ll_a[1, i].d[bids.color_mean[1]] = E_ll_a[1, i].v[] * -2.
+            E_ll_a[1, i].d[bids.color_var[1]] = E_ll_a[1, i].v[] * 2.
             if calculate_hessian
-                for hess_ids in [(bids.c1[1], bids.c1[1]),
-                                 (bids.c2[1], bids.c2[1])]
+                for hess_ids in [(bids.color_mean[1], bids.color_mean[1]),
+                                 (bids.color_var[1], bids.color_var[1])]
                     set_hess!(E_ll_a[1, i], hess_ids..., E_ll_a[1, i].v[] * 4.0)
                 end
-                set_hess!(E_ll_a[1, i], bids.c1[1], bids.c2[1],
+                set_hess!(E_ll_a[1, i], bids.color_mean[1], bids.color_var[1],
                           E_ll_a[1, i].v[] * -4.0)
             end
             multiply_sfs!(E_ll_a[1, i], E_ll_a[2, i])

--- a/src/deterministic_vi/source_brightness.jl
+++ b/src/deterministic_vi/source_brightness.jl
@@ -15,7 +15,7 @@ and all other rows are lognormal offsets.
   squared color terms.  The rows are bands, and the columns
   are star / galaxy.
 """
-immutable SourceBrightness{NumType <: Number}
+struct SourceBrightness{NumType <: Number}
     # [E[l|a=0], E[l]|a=1]]
     E_l_a::Matrix{SensitiveFloat{NumType}}
 

--- a/src/deterministic_vi/source_brightness.jl
+++ b/src/deterministic_vi/source_brightness.jl
@@ -8,10 +8,10 @@ Attributes:
 Each matrix has one row for each color and a column for
 star / galaxy.  Row 3 is the gamma distribute baseline brightness,
 and all other rows are lognormal offsets.
-- E_l_a: A num_bands x num_source_types matrix of expectations and derivatives of
+- E_l_a: A NUM_BANDS x NUM_SOURCE_TYPES matrix of expectations and derivatives of
   color terms.  The rows are bands, and the columns
   are star / galaxy.
-- E_ll_a: A num_bands x num_source_types matrix of expectations and derivatives of
+- E_ll_a: A NUM_BANDS x NUM_SOURCE_TYPES matrix of expectations and derivatives of
   squared color terms.  The rows are bands, and the columns
   are star / galaxy.
 """
@@ -34,11 +34,11 @@ function SourceBrightness{NumType <: Number}(vs::Vector{NumType};
 
     # E_l_a has a row for each of the five colors and columns
     # for star / galaxy.
-    E_l_a  = Matrix{SensitiveFloat{NumType}}(num_bands, num_source_types)
-    E_ll_a = Matrix{SensitiveFloat{NumType}}(num_bands, num_source_types)
+    E_l_a  = Matrix{SensitiveFloat{NumType}}(NUM_BANDS, NUM_SOURCE_TYPES)
+    E_ll_a = Matrix{SensitiveFloat{NumType}}(NUM_BANDS, NUM_SOURCE_TYPES)
 
-    for i = 1:num_source_types
-        for b = 1:num_bands
+    for i = 1:NUM_SOURCE_TYPES
+        for b = 1:NUM_BANDS
             E_l_a[b, i] = SensitiveFloat{NumType}(length(BrightnessParams), 1,
                                        calculate_gradient, calculate_hessian)
         end
@@ -115,7 +115,7 @@ function SourceBrightness{NumType <: Number}(vs::Vector{NumType};
         ################################
         # Squared terms.
 
-        for b = 1:num_bands
+        for b = 1:NUM_BANDS
             E_ll_a[b, i] = SensitiveFloat{NumType}(length(BrightnessParams), 1,
                                            calculate_gradient, calculate_hessian)
         end

--- a/src/joint_infer.jl
+++ b/src/joint_infer.jl
@@ -20,7 +20,7 @@ gdlog = nothing
 const BoxMaxThreshold = convert(UInt64, 20*60*1e9)::UInt64
 const OneMinute = 0x0000000df8475800 # in nanoseconds
 
-type BoxKillSwitch <: Function
+mutable struct BoxKillSwitch <: Function
     started::UInt64
     numfin_threshold::Int64
     numfin::Atomic{Int64}
@@ -417,7 +417,7 @@ Partitions sources via the cyclades algorithm. Finds the batch size which return
 """
 function partition_cyclades_dynamic_auto_batchsize(target_sources, neighbor_map, ea_vec)
     n_threads = nthreads()
-    
+
     # Sample batch sizes at intervals
     n_to_sample = 100
     stepsize = max(1, trunc(Int, length(target_sources) / n_to_sample))
@@ -434,7 +434,7 @@ function partition_cyclades_dynamic_auto_batchsize(target_sources, neighbor_map,
             # Find average load imbalance within the batch as a percentage
 	    times = [sum([estimate_time(ea_vec[source_index].patches) for source_index in component]) for component in batch]
             times = load_balance_across_threads(n_threads, times)
-            estimated_imbalance = mean(maximum(times) - times) 
+            estimated_imbalance = mean(maximum(times) - times)
 	    score += estimated_imbalance
         end
         if score <= best_score
@@ -793,7 +793,7 @@ function process_sources_kernel!(ea_vec::Vector{ElboArgs},
         if within_batch_shuffling
             shuffle!(source_assignment)
         end
-	
+
 	#tic()
         for i in source_assignment
             maximize!(ea_vec[i], vp_vec[i], cfg_vec[i])
@@ -828,4 +828,3 @@ function show_pixels_processed()
     n_active, n_inactive = get_pixels_processed()
     Log.message("$(Time(now())): (active,inactive) pixels processed: \($n_active,$n_inactive\)")
 end
-

--- a/src/mcmc/mcmc_misc.jl
+++ b/src/mcmc/mcmc_misc.jl
@@ -48,8 +48,8 @@ end
 
 
 """
-Given a function (lnpdf), that takes in a num_color_components dimensional vector (th),
-this function fixes num_color_components-1 of the dimensions of th, and returns a function
+Given a function (lnpdf), that takes in a NUM_COLOR_COMPONENTS dimensional vector (th),
+this function fixes NUM_COLOR_COMPONENTS-1 of the dimensions of th, and returns a function
 handle that only varies with respect to dimension d.
 """
 function curry_dim(lnpdf::Function, th0::Vector{Float64}, dim::Int)
@@ -247,8 +247,8 @@ following website:
 http://blog.stata.com/2016/05/26/gelman-rubin-convergence-diagnostic-using-multiple-chains/
 """
 function potential_scale_reduction_factor(chains)
-    # each chain has to be size N x num_color_components, we have M chains
-    N, num_color_components  = size(chains[1])
+    # each chain has to be size N x NUM_COLOR_COMPONENTS, we have M chains
+    N, NUM_COLOR_COMPONENTS  = size(chains[1])
     M     = length(chains)
 
     # mean and variance of each chain
@@ -259,13 +259,13 @@ function potential_scale_reduction_factor(chains)
     gmu   = mean(means, 1)
 
     # between chain variance:w
-    num_bands = float(N)/(float(M)-1)*sum( broadcast(-, means, gmu).^2, 1)
+    NUM_BANDS = float(N)/(float(M)-1)*sum( broadcast(-, means, gmu).^2, 1)
 
     # average within chain variance
     W = mean(vars, 1)
 
     # compute PRSF ratio
-    Vhat = (float(N)-1.)/float(N) * W + (float(M)+1)/float(N*M) * num_bands
+    Vhat = (float(N)-1.)/float(N) * W + (float(M)+1)/float(N*M) * NUM_BANDS
     psrf = Vhat ./ W
     return psrf
 end

--- a/src/mcmc/mcmc_misc.jl
+++ b/src/mcmc/mcmc_misc.jl
@@ -48,8 +48,8 @@ end
 
 
 """
-Given a function (lnpdf), that takes in a D dimensional vector (th),
-this function fixes D-1 of the dimensions of th, and returns a function
+Given a function (lnpdf), that takes in a num_color_components dimensional vector (th),
+this function fixes num_color_components-1 of the dimensions of th, and returns a function
 handle that only varies with respect to dimension d.
 """
 function curry_dim(lnpdf::Function, th0::Vector{Float64}, dim::Int)
@@ -179,7 +179,7 @@ end
 function write_star_unit_flux(img0::Image,
                               pos::Array{Float64, 1},
                               pixels::Matrix{Float64})
-    iota = median(img0.iota_vec)
+    iota = median(img0.nelec_per_nmgy)
     for k in 1:length(img0.psf)
         the_mean = SVector{2}(WCS.world_to_pix(img0.wcs, pos)) + img0.psf[k].xiBar
         the_cov = img0.psf[k].tauBar
@@ -195,8 +195,8 @@ function write_galaxy_unit_flux(img0::Image,
                                 gal_angle::Float64,
                                 gal_scale::Float64,
                                 pixels::Matrix{Float64})
-    iota = median(img0.iota_vec)
-    e_devs = [gal_frac_dev, 1 - gal_frac_dev]
+    iota = median(img0.nelec_per_nmgy)
+    gal_fracdevs = [gal_frac_dev, 1 - gal_frac_dev]
     #XiXi = DeterministicVI.get_bvn_cov(ce.gal_ab, ce.gal_angle, ce.gal_scale)
     XiXi = Model.get_bvn_cov(gal_ab, gal_angle, gal_scale)
 
@@ -206,7 +206,7 @@ function write_galaxy_unit_flux(img0::Image,
                 the_mean = SVector{2}(WCS.world_to_pix(img0.wcs, pos)) +
                            img0.psf[k].xiBar
                 the_cov = img0.psf[k].tauBar + gproto.nuBar * XiXi
-                intensity = iota * img0.psf[k].alphaBar * e_devs[i] *
+                intensity = iota * img0.psf[k].alphaBar * gal_fracdevs[i] *
                     gproto.etaBar
                 write_gaussian(the_mean, the_cov, intensity, pixels)
             end
@@ -247,8 +247,8 @@ following website:
 http://blog.stata.com/2016/05/26/gelman-rubin-convergence-diagnostic-using-multiple-chains/
 """
 function potential_scale_reduction_factor(chains)
-    # each chain has to be size N x D, we have M chains
-    N, D  = size(chains[1])
+    # each chain has to be size N x num_color_components, we have M chains
+    N, num_color_components  = size(chains[1])
     M     = length(chains)
 
     # mean and variance of each chain
@@ -259,13 +259,13 @@ function potential_scale_reduction_factor(chains)
     gmu   = mean(means, 1)
 
     # between chain variance:w
-    B = float(N)/(float(M)-1)*sum( broadcast(-, means, gmu).^2, 1)
+    num_bands = float(N)/(float(M)-1)*sum( broadcast(-, means, gmu).^2, 1)
 
     # average within chain variance
     W = mean(vars, 1)
 
     # compute PRSF ratio
-    Vhat = (float(N)-1.)/float(N) * W + (float(M)+1)/float(N*M) * B
+    Vhat = (float(N)-1.)/float(N) * W + (float(M)+1)/float(N*M) * num_bands
     psrf = Vhat ./ W
     return psrf
 end

--- a/src/mcmc/slicesample.jl
+++ b/src/mcmc/slicesample.jl
@@ -177,8 +177,8 @@ end
 Helper that draws N samples using slice sampling
 """
 function slicesample_chain(lnpdf, th, N; print_skip=50)
-    D = length(th)
-    samps = zeros(N, D)
+    num_color_components = length(th)
+    samps = zeros(N, num_color_components)
     lls   = zeros(N)
     tic()
     @printf "  iter : \t loglike \n"

--- a/src/mcmc/slicesample.jl
+++ b/src/mcmc/slicesample.jl
@@ -177,8 +177,8 @@ end
 Helper that draws N samples using slice sampling
 """
 function slicesample_chain(lnpdf, th, N; print_skip=50)
-    num_color_components = length(th)
-    samps = zeros(N, num_color_components)
+    NUM_COLOR_COMPONENTS = length(th)
+    samps = zeros(N, NUM_COLOR_COMPONENTS)
     lls   = zeros(N)
     tic()
     @printf "  iter : \t loglike \n"

--- a/src/model/image_model.jl
+++ b/src/model/image_model.jl
@@ -1,5 +1,5 @@
 # See https://github.com/jeff-regier/Celeste.jl/wiki/About-SDSS-and-Stripe-82
-immutable SkyIntensity
+struct SkyIntensity
     sky_small::Matrix{Float32} # background flux per pixel, in DNs
     sky_x::Vector{Float32} # interpolation coordinates
     sky_y::Vector{Float32}
@@ -61,7 +61,7 @@ end
 
 
 """An image, taken though a particular filter band"""
-type Image
+mutable struct Image
     # The image height.
     H::Int
 

--- a/src/model/image_model.jl
+++ b/src/model/image_model.jl
@@ -91,7 +91,7 @@ type Image
 
     # The expected number of photons contributed to this image
     # by a source 1 nanomaggie in brightness. (varies by row)
-    iota_vec::Array{Float32, 1}
+    nelec_per_nmgy::Array{Float32, 1}
 
     # storing a RawPSF here isn't ideal, because it's an SDSS type
     # not a Celeste type

--- a/src/model/imaged_sources.jl
+++ b/src/model/imaged_sources.jl
@@ -15,7 +15,7 @@ Attributes:
                   sky for each band
   - pixel_center: The pixel location of center in each band.
 """
-immutable SkyPatch
+struct SkyPatch
     center::Vector{Float64}
     radius_pix::Float64
 

--- a/src/model/light_source_model.jl
+++ b/src/model/light_source_model.jl
@@ -2,10 +2,10 @@ import JLD
 
 
 # The number of components in the color prior.
-const num_color_components = 8
+const NUM_COLOR_COMPONENTS = 8
 
 # The number of types of celestial objects (here, stars and galaxies).
-const num_source_types = 2
+const NUM_SOURCE_TYPES = 2
 
 
 mutable struct CatalogEntry
@@ -95,9 +95,9 @@ function load_prior()
     # due to the greater flexibility of the galaxy model
     #is_star = [0.28, 0.72]
     is_star = [0.099, 0.001]
-    k = Matrix{Float64}(num_color_components, num_source_types)
-    color_mean = Array{Float64}(num_bands - 1, num_color_components, num_source_types)
-    color_cov = Array{Float64}(num_bands - 1, num_bands - 1, num_color_components, num_source_types)
+    k = Matrix{Float64}(NUM_COLOR_COMPONENTS, NUM_SOURCE_TYPES)
+    color_mean = Array{Float64}(NUM_BANDS - 1, NUM_COLOR_COMPONENTS, NUM_SOURCE_TYPES)
+    color_cov = Array{Float64}(NUM_BANDS - 1, NUM_BANDS - 1, NUM_COLOR_COMPONENTS, NUM_SOURCE_TYPES)
 
     prior_params = [JLD.load(joinpath(cfgdir, "star_prior.jld")),
                     JLD.load(joinpath(cfgdir, "gal_prior.jld"))]

--- a/src/model/light_source_model.jl
+++ b/src/model/light_source_model.jl
@@ -8,7 +8,7 @@ const num_color_components = 8
 const num_source_types = 2
 
 
-type CatalogEntry
+mutable struct CatalogEntry
     pos::Vector{Float64}
     is_star::Bool
     star_fluxes::Vector{Float64}
@@ -29,13 +29,13 @@ Attributes:
   etaBar: The weight of the galaxy component
   nuBar: The scale of the galaxy component
 """
-immutable GalaxyComponent
+struct GalaxyComponent
     etaBar::Float64
     nuBar::Float64
 end
 
 
-@compat const GalaxyPrototype = Vector{GalaxyComponent}
+const GalaxyPrototype = Vector{GalaxyComponent}
 
 
 """
@@ -78,7 +78,7 @@ end
 const galaxy_prototypes = get_galaxy_prototypes()
 
 
-immutable PriorParams
+struct PriorParams
     is_star::Vector{Float64}
     flux_mean::Vector{Float64}
     flux_var::Vector{Float64}

--- a/src/model/log_prob.jl
+++ b/src/model/log_prob.jl
@@ -263,12 +263,12 @@ function construct_prior()
     star_prior = StarPrior(
         LogNormal(pp.flux_mean[1], sqrt(pp.flux_var[1])),
         Categorical(pp.k[:,1]),
-        [MvNormal(pp.color_mean[:,k,1], pp.color_cov[:,:,k,1]) for k in 1:num_color_components])
+        [MvNormal(pp.color_mean[:,k,1], pp.color_cov[:,:,k,1]) for k in 1:NUM_COLOR_COMPONENTS])
 
     gal_prior = GalaxyPrior(
         LogNormal(pp.flux_mean[2], sqrt(pp.flux_var[2])),
         Categorical(pp.k[:,2]),
-        [MvNormal(pp.color_mean[:,k,2], pp.color_cov[:,:,k,2]) for k in 1:num_color_components],
+        [MvNormal(pp.color_mean[:,k,2], pp.color_cov[:,:,k,2]) for k in 1:NUM_COLOR_COMPONENTS],
         LogNormal(0, 10),
         Beta(1, 1),
         Beta(1, 1))
@@ -287,7 +287,7 @@ function color_logprior(brightness::Float64,
                         is_star::Bool)
     subprior      = is_star ? prior.star : prior.galaxy
     ll_brightness = logpdf(subprior.brightness, exp(brightness))
-    ll_component  = [logpdf(subprior.colors[k], colors) for k in 1:num_color_components]
+    ll_component  = [logpdf(subprior.colors[k], colors) for k in 1:NUM_COLOR_COMPONENTS]
     ll_color      = logsumexp(ll_component + log.(subprior.color_component.p))
     return ll_brightness + ll_color
 end

--- a/src/model/log_prob.jl
+++ b/src/model/log_prob.jl
@@ -231,14 +231,14 @@ end
 ###########################################################################
 
 
-type StarPrior
+struct StarPrior
     brightness::LogNormal
     color_component::Categorical
     colors::Vector{MvNormal}
 end
 
 
-type GalaxyPrior
+struct GalaxyPrior
     brightness::LogNormal
     color_component::Categorical
     colors::Vector{MvNormal}
@@ -248,7 +248,7 @@ type GalaxyPrior
 end
 
 
-type Prior
+struct Prior
     is_star::Bernoulli
     star::StarPrior
     galaxy::GalaxyPrior

--- a/src/model/log_prob.jl
+++ b/src/model/log_prob.jl
@@ -36,7 +36,7 @@ function make_star_logpdf(images::Vector{Image},
     subprior = prior.star
 
     function star_logprior(state::Vector{Float64})
-        brightness, colors, u = state[1], state[2:5], state[6:end]
+        brightness, colors, pos = state[1], state[2:5], state[6:end]
         return color_logprior(brightness, colors, prior, true)
     end
 
@@ -86,7 +86,7 @@ function make_galaxy_logpdf(images::Vector{Image},
     subprior = prior.galaxy
 
     function galaxy_logprior(state::Vector{Float64})
-        brightness, colors, u, gal_shape =
+        brightness, colors, pos, gal_shape =
             state[1], state[2:5], state[6:7], state[8:end]
 
         # brightness prior
@@ -152,11 +152,11 @@ function state_log_likelihood(is_star::Bool,                # source is star
 
     # load star/gal mixture components (make sure these reflect
     gdev, gaxis, gangle, gscale = gal_shape
-    source_params[1][lidx.u]       = position
-    source_params[1][lidx.e_dev]   = gdev
-    source_params[1][lidx.e_axis]  = gaxis
-    source_params[1][lidx.e_angle] = gangle
-    source_params[1][lidx.e_scale] = gscale
+    source_params[1][lidx.pos]       = position
+    source_params[1][lidx.gal_fracdev]   = gdev
+    source_params[1][lidx.gal_ab]  = gaxis
+    source_params[1][lidx.gal_angle] = gangle
+    source_params[1][lidx.gal_scale] = gscale
 
     # iterate over the pixels, summing pixel-specific poisson rates
     ll = 0.
@@ -190,10 +190,10 @@ function state_log_likelihood(is_star::Bool,                # source is star
             for s in 2:S  # excludes source #1
                 # determine if background source is star/gal; get fluxes
                 params_s  = source_params[s]
-                s_is_star = params_s[lidx.a[1,1]] > .5
+                s_is_star = params_s[lidx.is_star[1,1]] > .5
                 type_idx  = s_is_star ? 1 : 2
-                flux_s    = colors_to_fluxes(params_s[lidx.r[type_idx]],
-                                             params_s[lidx.c[:,type_idx]])
+                flux_s    = colors_to_fluxes(params_s[lidx.flux[type_idx]],
+                                             params_s[lidx.color[:,type_idx]])
                 populate_fsm!(bvn_derivs,
                               fs0m, fs1m,
                               s, hw,
@@ -216,7 +216,7 @@ function state_log_likelihood(is_star::Bool,                # source is star
             pixel_rate = fluxes[img.b] * this_rate + background_rate
 
             # multiply by image's gain for this pixel
-            rate     = pixel_rate * img.iota_vec[h]
+            rate     = pixel_rate * img.nelec_per_nmgy[h]
             pixel_ll = logpdf(Poisson(rate[1]), round(Int, img.pixels[h, w]))
             ll += pixel_ll
         end
@@ -261,14 +261,14 @@ Construct a `Prior` object, contains StarPrior and GalaxyPrior objects
 function construct_prior()
     pp = load_prior()
     star_prior = StarPrior(
-        LogNormal(pp.r_μ[1], sqrt(pp.r_σ²[1])),
+        LogNormal(pp.flux_mean[1], sqrt(pp.flux_var[1])),
         Categorical(pp.k[:,1]),
-        [MvNormal(pp.c_mean[:,k,1], pp.c_cov[:,:,k,1]) for k in 1:D])
+        [MvNormal(pp.color_mean[:,k,1], pp.color_cov[:,:,k,1]) for k in 1:num_color_components])
 
     gal_prior = GalaxyPrior(
-        LogNormal(pp.r_μ[2], sqrt(pp.r_σ²[2])),
+        LogNormal(pp.flux_mean[2], sqrt(pp.flux_var[2])),
         Categorical(pp.k[:,2]),
-        [MvNormal(pp.c_mean[:,k,2], pp.c_cov[:,:,k,2]) for k in 1:D],
+        [MvNormal(pp.color_mean[:,k,2], pp.color_cov[:,:,k,2]) for k in 1:num_color_components],
         LogNormal(0, 10),
         Beta(1, 1),
         Beta(1, 1))
@@ -287,7 +287,7 @@ function color_logprior(brightness::Float64,
                         is_star::Bool)
     subprior      = is_star ? prior.star : prior.galaxy
     ll_brightness = logpdf(subprior.brightness, exp(brightness))
-    ll_component  = [logpdf(subprior.colors[k], colors) for k in 1:D]
+    ll_component  = [logpdf(subprior.colors[k], colors) for k in 1:num_color_components]
     ll_color      = logsumexp(ll_component + log.(subprior.color_component.p))
     return ll_brightness + ll_color
 end
@@ -335,8 +335,8 @@ function colors_to_fluxes(brightness::Float64, colors::Vector{Float64})
     ret[3] = lnr     # r flux
     ret[4] = lnr + colors[3]        # ln(i/r) = c3 => lni = lnr - c3
     ret[5] = ret[4] + colors[4]     # ln(z/i) = c4 => lnz = lni - c4
-    ret[2] = -colors[2] + lnr       # ln(r/g) = c2 => lng = c2 + lnr
-    ret[1] = -colors[1] + ret[2]    # ln(g/u) = c1 => lnu = c1 + lng
+    ret[2] = -colors[2] + lnr       # ln(r/g) = color_var => lng = color_var + lnr
+    ret[1] = -colors[1] + ret[2]    # ln(g/u) = color_mean => lnu = color_mean + lng
     return exp.(ret)
 end
 
@@ -398,35 +398,35 @@ function catalog_entry_to_latent_state_params(ce::CatalogEntry)
     ret = Vector{Float64}(length(lidx))
 
     # galaxy shape params
-    ret[lidx.u]       = ce.pos
-    ret[lidx.e_dev]   = ce.gal_frac_dev
-    ret[lidx.e_axis]  = ce.gal_ab
-    ret[lidx.e_scale] = ce.gal_scale
-    ret[lidx.e_angle] = ce.gal_angle
+    ret[lidx.pos]       = ce.pos
+    ret[lidx.gal_fracdev]   = ce.gal_frac_dev
+    ret[lidx.gal_ab]  = ce.gal_ab
+    ret[lidx.gal_scale] = ce.gal_scale
+    ret[lidx.gal_angle] = ce.gal_angle
 
     # star, gal r flux
     star_lnr, star_cols = fluxes_to_colors(ce.star_fluxes)
     gal_lnr, gal_cols   = fluxes_to_colors(ce.gal_fluxes)
-    ret[lidx.r]         = [star_lnr, gal_lnr]
-    ret[lidx.c]         = hcat([star_cols, gal_cols]...)
+    ret[lidx.flux]         = [star_lnr, gal_lnr]
+    ret[lidx.color]         = hcat([star_cols, gal_cols]...)
 
     # set the prob star/prob gal
-    ret[lidx.a] = clamp(ce.is_star, eps_prob_a, 1-eps_prob_a)
+    ret[lidx.is_star] = clamp(ce.is_star, eps_prob_a, 1-eps_prob_a)
     ret
 end
 
 
 function extract_star_state(ls::Array{Float64, 1})
-    return [[ls[lidx.r[1]]]; ls[lidx.c[:, 1]]; ls[lidx.u]]
+    return [[ls[lidx.flux[1]]]; ls[lidx.color[:, 1]]; ls[lidx.pos]]
 end
 
 
 function extract_galaxy_state(ls::Array{Float64, 1})
-    gal_shape = [ls[lidx.e_dev]  ,
-                 ls[lidx.e_axis] ,
-                 ls[lidx.e_angle],
-                 ls[lidx.e_scale]]
-    return [[ls[lidx.r[2]]]; ls[lidx.c[:, 2]]; ls[lidx.u];
+    gal_shape = [ls[lidx.gal_fracdev]  ,
+                 ls[lidx.gal_ab] ,
+                 ls[lidx.gal_angle],
+                 ls[lidx.gal_scale]]
+    return [[ls[lidx.flux[2]]]; ls[lidx.color[:, 2]]; ls[lidx.pos];
             unconstrain_gal_shape(gal_shape)]
 end
 

--- a/src/model/param_set.jl
+++ b/src/model/param_set.jl
@@ -12,9 +12,9 @@
 # gal_scale = Galaxy scale (sigma). gal_scale times sqrt(gal_ab) gives the half-light radius in pixel
 #           coords.
 # For flux_loc, flux_scale, color_mean and color_var, the first row is stars, and the second is galaxies.
-# flux_loc      = num_source_typesx1 lognormal mean parameter for r_s, the brightness/total flux of the object, in nMgy.
+# flux_loc      = NUM_SOURCE_TYPESx1 lognormal mean parameter for r_s, the brightness/total flux of the object, in nMgy.
 #           For example, flux_loc[1] gives the lognormal mean brightness for a star.
-# flux_scale      = num_source_typesx1 lognormal variance parameter for r_s.
+# flux_scale      = NUM_SOURCE_TYPESx1 lognormal variance parameter for r_s.
 # color_mean      = C_s means (formerly beta), the log ratios of brightness from each color band to the
 #           previous one. For example color_mean[1,2] gives the mean log brightness ratio of band 3 over
 #           band 2.
@@ -22,10 +22,10 @@
 # is_star       = probability of being a star or galaxy.  is_star[1, 1] is the
 #           probability of being a star and is_star[2, 1] of being a galaxy.
 #           (formerly chi)
-# k       = {num_color_components|num_color_components-1}xnum_source_types matrix of color prior component indicators.
+# k       = {NUM_COLOR_COMPONENTS|NUM_COLOR_COMPONENTS-1}xNUM_SOURCE_TYPES matrix of color prior component indicators.
 #           (formerly kappa)
 #
-# Note num_source_types denotes the number of types of astronomical objects (e.g., 2 for stars and galaxies).
+# Note NUM_SOURCE_TYPES denotes the number of types of astronomical objects (e.g., 2 for stars and galaxies).
 
 abstract type ParamSet end
 
@@ -66,12 +66,12 @@ struct BrightnessParams <: ParamSet
     color_mean::Vector{Int}
     color_var::Vector{Int}
     BrightnessParams() = new(1, 2,
-                             collect(3:(3+(num_bands-1)-1)),
-                             collect((3+num_bands-1):(3+2*(num_bands-1)-1)))
+                             collect(3:(3+(NUM_BANDS-1)-1)),
+                             collect((3+NUM_BANDS-1):(3+2*(NUM_BANDS-1)-1)))
 end
 const bids = BrightnessParams()
 getids(::Type{BrightnessParams}) = bids
-length(::Type{BrightnessParams}) = 2 + 2 * (num_bands-1)
+length(::Type{BrightnessParams}) = 2 + 2 * (NUM_BANDS-1)
 
 struct CanonicalParams <: ParamSet
     pos::Vector{Int}
@@ -91,12 +91,12 @@ struct CanonicalParams <: ParamSet
             4, # gal_ab
             5, # gal_angle
             6, # gal_scale
-            collect(7:(7+num_source_types-1)),  # flux_loc
-            collect((7+num_source_types):(7+2num_source_types-1)), # flux_scale
-            reshape((7+2num_source_types):(7+2num_source_types+(num_bands-1)*num_source_types-1), (num_bands-1, num_source_types)),  # color_mean
-            reshape((7+2num_source_types+(num_bands-1)*num_source_types):(7+2num_source_types+2*(num_bands-1)*num_source_types-1), (num_bands-1, num_source_types)),  # color_var
-            collect((7+2num_source_types+2*(num_bands-1)*num_source_types):(7+3num_source_types+2*(num_bands-1)*num_source_types-1)),  # is_star
-            reshape((7+3num_source_types+2*(num_bands-1)*num_source_types):(7+3num_source_types+2*(num_bands-1)*num_source_types+num_color_components*num_source_types-1), (num_color_components, num_source_types))) # k
+            collect(7:(7+NUM_SOURCE_TYPES-1)),  # flux_loc
+            collect((7+NUM_SOURCE_TYPES):(7+2NUM_SOURCE_TYPES-1)), # flux_scale
+            reshape((7+2NUM_SOURCE_TYPES):(7+2NUM_SOURCE_TYPES+(NUM_BANDS-1)*NUM_SOURCE_TYPES-1), (NUM_BANDS-1, NUM_SOURCE_TYPES)),  # color_mean
+            reshape((7+2NUM_SOURCE_TYPES+(NUM_BANDS-1)*NUM_SOURCE_TYPES):(7+2NUM_SOURCE_TYPES+2*(NUM_BANDS-1)*NUM_SOURCE_TYPES-1), (NUM_BANDS-1, NUM_SOURCE_TYPES)),  # color_var
+            collect((7+2NUM_SOURCE_TYPES+2*(NUM_BANDS-1)*NUM_SOURCE_TYPES):(7+3NUM_SOURCE_TYPES+2*(NUM_BANDS-1)*NUM_SOURCE_TYPES-1)),  # is_star
+            reshape((7+3NUM_SOURCE_TYPES+2*(NUM_BANDS-1)*NUM_SOURCE_TYPES):(7+3NUM_SOURCE_TYPES+2*(NUM_BANDS-1)*NUM_SOURCE_TYPES+NUM_COLOR_COMPONENTS*NUM_SOURCE_TYPES-1), (NUM_COLOR_COMPONENTS, NUM_SOURCE_TYPES))) # k
     end
 end
 
@@ -104,7 +104,7 @@ const ids = CanonicalParams()
 
 getids(::Type{CanonicalParams}) = ids
 
-length(::Type{CanonicalParams}) = 6 + 3*num_source_types + 2*(num_bands-1)*num_source_types + num_color_components*num_source_types
+length(::Type{CanonicalParams}) = 6 + 3*NUM_SOURCE_TYPES + 2*(NUM_BANDS-1)*NUM_SOURCE_TYPES + NUM_COLOR_COMPONENTS*NUM_SOURCE_TYPES
 
 
 struct LatentStateIndexes <: ParamSet
@@ -120,15 +120,15 @@ struct LatentStateIndexes <: ParamSet
 
     LatentStateIndexes() =
         new([1, 2], 3, 4, 5, 6,
-            collect(7:(7+num_source_types-1)),  # r
-            reshape((7+num_source_types):(7+num_source_types+(num_bands-1)*num_source_types-1), (num_bands-1, num_source_types)),  # c
-            reshape((7+num_source_types+(num_bands-1)*num_source_types):(7+2num_source_types+(num_bands-1)*num_source_types-1), (num_source_types, 1)),  # is_star
-            reshape((7+2num_source_types+(num_bands-1)*num_source_types):(7+2num_source_types+(num_bands-1)*num_source_types+num_color_components*num_source_types-1), (num_color_components, num_source_types))) # k
+            collect(7:(7+NUM_SOURCE_TYPES-1)),  # r
+            reshape((7+NUM_SOURCE_TYPES):(7+NUM_SOURCE_TYPES+(NUM_BANDS-1)*NUM_SOURCE_TYPES-1), (NUM_BANDS-1, NUM_SOURCE_TYPES)),  # c
+            reshape((7+NUM_SOURCE_TYPES+(NUM_BANDS-1)*NUM_SOURCE_TYPES):(7+2NUM_SOURCE_TYPES+(NUM_BANDS-1)*NUM_SOURCE_TYPES-1), (NUM_SOURCE_TYPES, 1)),  # is_star
+            reshape((7+2NUM_SOURCE_TYPES+(NUM_BANDS-1)*NUM_SOURCE_TYPES):(7+2NUM_SOURCE_TYPES+(NUM_BANDS-1)*NUM_SOURCE_TYPES+NUM_COLOR_COMPONENTS*NUM_SOURCE_TYPES-1), (NUM_COLOR_COMPONENTS, NUM_SOURCE_TYPES))) # k
 end
 
 const lidx = LatentStateIndexes()
 getlidx(::Type{LatentStateIndexes}) = lidx
-length(::Type{LatentStateIndexes}) = 22 #6 + 3*num_source_types + 2*(num_bands-1)*num_source_types + num_color_components*num_source_types
+length(::Type{LatentStateIndexes}) = 22 #6 + 3*NUM_SOURCE_TYPES + 2*(NUM_BANDS-1)*NUM_SOURCE_TYPES + NUM_COLOR_COMPONENTS*NUM_SOURCE_TYPES
 
 # Parameters for a representation of the PSF
 struct PsfParams <: ParamSet

--- a/src/model/param_set.jl
+++ b/src/model/param_set.jl
@@ -27,9 +27,9 @@
 #
 # Note num_source_types denotes the number of types of astronomical objects (e.g., 2 for stars and galaxies).
 
-@compat abstract type ParamSet end
+abstract type ParamSet end
 
-type StarPosParams <: ParamSet
+struct StarPosParams <: ParamSet
     pos::Vector{Int}
     StarPosParams() = new([1, 2])
 end
@@ -37,7 +37,7 @@ const star_ids = StarPosParams()
 getids(::Type{StarPosParams}) = star_ids
 length(::Type{StarPosParams}) = 2
 
-type GalaxyShapeParams <: ParamSet
+struct GalaxyShapeParams <: ParamSet
     gal_ab::Int
     gal_angle::Int
     gal_scale::Int
@@ -47,7 +47,7 @@ const gal_shape_ids = GalaxyShapeParams()
 getids(::Type{GalaxyShapeParams}) = gal_shape_ids
 length(::Type{GalaxyShapeParams}) = 3
 
-type GalaxyPosParams <: ParamSet
+struct GalaxyPosParams <: ParamSet
     pos::Vector{Int}
     gal_fracdev::Int
     gal_ab::Int
@@ -60,7 +60,7 @@ getids(::Type{GalaxyPosParams}) = gal_ids
 length(::Type{GalaxyPosParams}) = 6
 
 
-type BrightnessParams <: ParamSet
+struct BrightnessParams <: ParamSet
     flux_loc::Int
     flux_scale::Int
     color_mean::Vector{Int}
@@ -73,7 +73,7 @@ const bids = BrightnessParams()
 getids(::Type{BrightnessParams}) = bids
 length(::Type{BrightnessParams}) = 2 + 2 * (num_bands-1)
 
-immutable CanonicalParams <: ParamSet
+struct CanonicalParams <: ParamSet
     pos::Vector{Int}
     gal_fracdev::Int
     gal_ab::Int
@@ -107,7 +107,7 @@ getids(::Type{CanonicalParams}) = ids
 length(::Type{CanonicalParams}) = 6 + 3*num_source_types + 2*(num_bands-1)*num_source_types + num_color_components*num_source_types
 
 
-type LatentStateIndexes <: ParamSet
+struct LatentStateIndexes <: ParamSet
     pos::Vector{Int}
     gal_fracdev::Int
     gal_ab::Int
@@ -131,7 +131,7 @@ getlidx(::Type{LatentStateIndexes}) = lidx
 length(::Type{LatentStateIndexes}) = 22 #6 + 3*num_source_types + 2*(num_bands-1)*num_source_types + num_color_components*num_source_types
 
 # Parameters for a representation of the PSF
-immutable PsfParams <: ParamSet
+struct PsfParams <: ParamSet
     mu::UnitRange{Int}
     gal_ab::Int
     gal_angle::Int

--- a/src/model/psf_model.jl
+++ b/src/model/psf_model.jl
@@ -14,7 +14,7 @@ Attributes:
   tauBarInv: The 2x2 precision
   tauBarLd: The log determinant of the covariance
 """
-immutable PsfComponent
+struct PsfComponent
     alphaBar::Float64  # TODO: use underscore
     xiBar::SVector{2,Float64}
     tauBar::SMatrix{2,2,Float64,4}
@@ -40,7 +40,7 @@ weight[k](x, y) = sum_{i,j} cmat[i, j, k] * (rcs * x)^i (rcs * y)^j
 
 where `rcs` is a coordinate transformation and `x` and `y` are zero-indexed.
 """
-immutable RawPSF
+struct RawPSF
     rrows::Array{Float64,2}  # A matrix of flattened eigenimages.
     rnrow::Int  # The number of rows in an eigenimage.
     rncol::Int  # The number of columns in an eigenimage.

--- a/src/multinode_run.jl
+++ b/src/multinode_run.jl
@@ -51,7 +51,7 @@ end
 # of sources.
 # ----------------
 
-type CentSRBarrier
+struct CentSRBarrier
     thread_counter::Atomic{Int}
     num_threads::Int
     sense::Int
@@ -81,7 +81,7 @@ end
 # ----------------
 # container for multiprocessing/multithreading-specific information
 # ----------------
-type MultiInfo
+struct MultiInfo
     dt::Dtree
     ni::Int
     ci::Int
@@ -95,7 +95,7 @@ end
 # ----------------
 # container for bounding boxes and associated data
 # ----------------
-type BoxInfo
+struct BoxInfo
     state::Atomic{Int}
     box_idx::Int
     catalog::Vector{CatalogEntry}

--- a/test/SampleData.jl
+++ b/test/SampleData.jl
@@ -79,17 +79,17 @@ end
 # for testing away from the truth, where derivatives != 0
 function perturb_params(vp)
     for vs in vp
-        vs[ids.a] = [ 0.4, 0.6 ]
-        vs[ids.u[1]] += .8
-        vs[ids.u[2]] -= .7
-        vs[ids.r1] -= log(10)
-        vs[ids.r2] *= 25.
-        vs[ids.e_dev] += 0.05
-        vs[ids.e_axis] += 0.05
-        vs[ids.e_angle] += pi/10
-        vs[ids.e_scale] *= 1.2
-        vs[ids.c1] += 0.5
-        vs[ids.c2] =  1e-1
+        vs[ids.is_star] = [ 0.4, 0.6 ]
+        vs[ids.pos[1]] += .8
+        vs[ids.pos[2]] -= .7
+        vs[ids.flux_loc] -= log(10)
+        vs[ids.flux_scale] *= 25.
+        vs[ids.gal_fracdev] += 0.05
+        vs[ids.gal_ab] += 0.05
+        vs[ids.gal_angle] += pi/10
+        vs[ids.gal_scale] *= 1.2
+        vs[ids.color_mean] += 0.5
+        vs[ids.color_var] =  1e-1
     end
 end
 
@@ -213,7 +213,7 @@ function gen_n_body_dataset(
 
     # Make non-constant background.
     for b=1:5
-        images[b].iota_vec = fill(images[b].iota_vec[1], images[b].H)
+        images[b].nelec_per_nmgy = fill(images[b].nelec_per_nmgy[1], images[b].H)
         images[b].sky = SkyIntensity(fill(images[b].sky[1,1], images[b].H, images[b].W),
                                      collect(1:images[b].H), collect(1:images[b].W),
                                      ones(images[b].H))
@@ -234,10 +234,10 @@ end
 function true_star_init()
     ea, vp, catalog = gen_sample_star_dataset(perturb=false)
 
-    vp[1][ids.a] = [ 1.0 - 1e-4, 1e-4 ]
-    vp[1][ids.r2] = 1e-4
-    vp[1][ids.r1] = log(sample_star_fluxes[3]) - 0.5 * vp[1][ids.r2]
-    vp[1][ids.c2] = 1e-4
+    vp[1][ids.is_star] = [ 1.0 - 1e-4, 1e-4 ]
+    vp[1][ids.flux_scale] = 1e-4
+    vp[1][ids.flux_loc] = log(sample_star_fluxes[3]) - 0.5 * vp[1][ids.flux_scale]
+    vp[1][ids.color_var] = 1e-4
 
     ea, vp, catalog
 end

--- a/test/test_accuracy_benchmarks.jl
+++ b/test/test_accuracy_benchmarks.jl
@@ -38,12 +38,12 @@ end
 
 @testset "variational params -> data frame -> catalog entry conversion" begin
     variational_params = DeterministicVI.generic_init_source([1.0, 2.0])
-    variational_params[Model.ids.e_axis] = 0.5
-    variational_params[Model.ids.e_scale] = 10.0
-    variational_params[Model.ids.e_angle] = -pi / 4
-    variational_params[Model.ids.r1[2]] = log(20.0)
-    variational_params[Model.ids.a[1]] = 0.01
-    variational_params[Model.ids.a[2]] = 0.99
+    variational_params[Model.ids.gal_ab] = 0.5
+    variational_params[Model.ids.gal_scale] = 10.0
+    variational_params[Model.ids.gal_angle] = -pi / 4
+    variational_params[Model.ids.flux_loc[2]] = log(20.0)
+    variational_params[Model.ids.is_star[1]] = 0.01
+    variational_params[Model.ids.is_star[2]] = 0.99
 
     data = AccuracyBenchmark.variational_parameters_to_data_frame_row("12345", variational_params)
     # we'll just check a few particularly troublesome parameters :)

--- a/test/test_constraints.jl
+++ b/test/test_constraints.jl
@@ -1,6 +1,6 @@
 module ConstraintTransformsTests
 
-using Celeste.Model: CanonicalParams, ids, D
+using Celeste.Model: CanonicalParams, ids, num_color_components
 
 using Celeste.DeterministicVI.ElboMaximize: elbo_constraints
 
@@ -373,7 +373,7 @@ constraints = elbo_constraints(bound, loc_width, loc_scale)
 for src in 1:n_sources
     u1_box = constraints.boxes[src][1].constraint
     u2_box = constraints.boxes[src][2].constraint
-    u1, u2 = bound[src][ids.u[1]], bound[src][ids.u[2]]
+    u1, u2 = bound[src][ids.pos[1]], bound[src][ids.pos[2]]
     @test u1_box === BoxConstraint(u1 - loc_width, u1 + loc_width, loc_scale)
     @test u2_box === BoxConstraint(u2 - loc_width, u2 + loc_width, loc_scale)
 end
@@ -417,18 +417,18 @@ function star_constraints(bound; loc_width = 1.5e-3, loc_scale = 1.0)
     boxes = Vector{Vector{ParameterConstraint{BoxConstraint}}}(n_sources)
     simplexes = Vector{Vector{ParameterConstraint{SimplexConstraint}}}(n_sources)
     for src in 1:n_sources
-        i1, i2 = ids.u[1], ids.u[2]
+        i1, i2 = ids.pos[1], ids.pos[2]
         u1, u2 = bound[src][i1], bound[src][i2]
         boxes[src] = [
             ParameterConstraint(BoxConstraint(u1 - loc_width, u1 + loc_width, loc_scale), i1),
             ParameterConstraint(BoxConstraint(u2 - loc_width, u2 + loc_width, loc_scale), i2),
-            ParameterConstraint(BoxConstraint(-1.0, 10.0, 1.0), ids.r1[1]),
-            ParameterConstraint(BoxConstraint(-10.0, 10.0, 1.0), ids.c1[:, 1]),
-            ParameterConstraint(BoxConstraint(1e-4, 1.0, 1.0), ids.c2[:, 1])
+            ParameterConstraint(BoxConstraint(-1.0, 10.0, 1.0), ids.flux_loc[1]),
+            ParameterConstraint(BoxConstraint(-10.0, 10.0, 1.0), ids.color_mean[:, 1]),
+            ParameterConstraint(BoxConstraint(1e-4, 1.0, 1.0), ids.color_var[:, 1])
         ]
         simplexes[src] = [
-            ParameterConstraint(SimplexConstraint(0.005, 1.0, 2), ids.a)
-            ParameterConstraint(SimplexConstraint(0.01/D, 1.0, D), ids.k[:, 1])
+            ParameterConstraint(SimplexConstraint(0.005, 1.0, 2), ids.is_star)
+            ParameterConstraint(SimplexConstraint(0.01/num_color_components, 1.0, num_color_components), ids.k[:, 1])
         ]
     end
     return ConstraintBatch(boxes, simplexes)

--- a/test/test_constraints.jl
+++ b/test/test_constraints.jl
@@ -1,6 +1,6 @@
 module ConstraintTransformsTests
 
-using Celeste.Model: CanonicalParams, ids, num_color_components
+using Celeste.Model: CanonicalParams, ids, NUM_COLOR_COMPONENTS
 
 using Celeste.DeterministicVI.ElboMaximize: elbo_constraints
 
@@ -428,7 +428,7 @@ function star_constraints(bound; loc_width = 1.5e-3, loc_scale = 1.0)
         ]
         simplexes[src] = [
             ParameterConstraint(SimplexConstraint(0.005, 1.0, 2), ids.is_star)
-            ParameterConstraint(SimplexConstraint(0.01/num_color_components, 1.0, num_color_components), ids.k[:, 1])
+            ParameterConstraint(SimplexConstraint(0.01/NUM_COLOR_COMPONENTS, 1.0, NUM_COLOR_COMPONENTS), ids.k[:, 1])
         ]
     end
     return ConstraintBatch(boxes, simplexes)

--- a/test/test_images.jl
+++ b/test/test_images.jl
@@ -64,7 +64,7 @@ function test_images()
         PSF.fit_raw_psf_for_celeste(original_psf_val, ea.psf_K)[1]
     fit_original_psf_val = PSF.get_psf_at_point(original_psf_celeste)
 
-    obj_psf = get_source_psf(vs_obj[ids.u], img, ea.psf_K)[1]
+    obj_psf = get_source_psf(vs_obj[ids.pos], img, ea.psf_K)[1]
     obj_psf_val = PSF.get_psf_at_point(obj_psf)
 
     # The fits should match exactly.

--- a/test/test_joint_infer.jl
+++ b/test/test_joint_infer.jl
@@ -75,14 +75,14 @@ result of joint inference are the same.
 
 Return true if vp params are the same, false otherwise
 """
-function compare_vp_params(r1, r2)
+function compare_vp_params(flux_loc, flux_scale)
 
-    length(r1) == length(r2) || return false
+    length(flux_loc) == length(flux_scale) || return false
 
-    # Check the existence and equivalence of each source's vp in r2
-    for i in eachindex(r1)
-        a = r1[i].vs
-        b = r2[i].vs
+    # Check the existence and equivalence of each source's vp in flux_scale
+    for i in eachindex(flux_loc)
+        a = flux_loc[i].vs
+        b = flux_scale[i].vs
         if !(isapprox(a, b))
             println("compare_vp_params: Mismatch - $(a) vs $(b)")
             print("norm(a - b): ", norm(a - b))

--- a/test/test_log_prob.jl
+++ b/test/test_log_prob.jl
@@ -87,7 +87,7 @@ function test_that_gal_truth_is_most_likely_log_prob()
     println("Best ll ", best_ll)
 
     # unpack true gal parameters
-    lnr, col, u, shape = gal_state[1], gal_state[2:5],
+    lnr, col, pos, shape = gal_state[1], gal_state[2:5],
                          gal_state[6:7], gal_state[8:11]
 
     # perterb lnr
@@ -98,7 +98,7 @@ function test_that_gal_truth_is_most_likely_log_prob()
     end
 
     # perturb location
-    ra, dec = u[1], u[2]
+    ra, dec = pos[1], pos[2]
     for bad_ra in [.5*ra, .8*ra, 1.1*ra, 1.5*ra]
         bad_state = deepcopy(gal_state)
         bad_state[6] = bad_ra
@@ -117,11 +117,11 @@ function test_that_gal_truth_is_most_likely_log_prob()
 
     # perturb galaxy shape parameters
     gdev, gab, gangle, gscale = shape
-    for bad_shape_scale in [.5, .8, 1.2, 1.3]
+    for bad_shapgal_scale in [.5, .8, 1.2, 1.3]
         # generate a random direction in param space
         r = randn(length(shape))
         r = r / sqrt(sum(r.*r))
-        bad_shape = shape + bad_shape_scale * r
+        bad_shape = shape + bad_shapgal_scale * r
 
         bad_state = deepcopy(gal_state)
         bad_state[8:11] = bad_shape

--- a/test/test_mcmc.jl
+++ b/test/test_mcmc.jl
@@ -63,7 +63,7 @@ function test_star_loglike()
     th = vcat([lnfluxes, lu]...)
 
     # create loglike
-    init_pos = deepcopy(vp[1][ids.u])
+    init_pos = deepcopy(vp[1][ids.pos])
     star_loglike, constrain_pos, unconstrain_pos =
         MCMC.make_star_loglike(dat_images, init_pos)
 

--- a/test/test_optimization.jl
+++ b/test/test_optimization.jl
@@ -8,43 +8,43 @@ using Celeste.DeterministicVI.ElboMaximize: Config, maximize!, elbo_optim_option
 using Optim
 
 function verify_sample_star(vs, pos)
-    @test vs[ids.a[2]] <= 0.01
+    @test vs[ids.is_star[2]] <= 0.01
 
-    @test isapprox(vs[ids.u[1]], pos[1], atol=0.1)
-    @test isapprox(vs[ids.u[2]], pos[2], atol=0.1)
+    @test isapprox(vs[ids.pos[1]], pos[1], atol=0.1)
+    @test isapprox(vs[ids.pos[2]], pos[2], atol=0.1)
 
-    brightness_hat = exp(vs[ids.r1[1]] + 0.5 * vs[ids.r2[1]])
+    brightness_hat = exp(vs[ids.flux_loc[1]] + 0.5 * vs[ids.flux_scale[1]])
     @test isapprox(brightness_hat / sample_star_fluxes[3], 1.0, atol=0.01)
 
     true_colors = log.(sample_star_fluxes[2:5] ./ sample_star_fluxes[1:4])
     for b in 1:4
-        @test isapprox(vs[ids.c1[b, 1]], true_colors[b], atol=0.2)
+        @test isapprox(vs[ids.color_mean[b, 1]], true_colors[b], atol=0.2)
     end
 end
 
 function verify_sample_galaxy(vs, pos)
-    @test vs[ids.a[2]] >= 0.99
+    @test vs[ids.is_star[2]] >= 0.99
 
-    @test isapprox(vs[ids.u[1]], pos[1], atol=0.1)
-    @test isapprox(vs[ids.u[2]], pos[2], atol=0.1)
+    @test isapprox(vs[ids.pos[1]], pos[1], atol=0.1)
+    @test isapprox(vs[ids.pos[2]], pos[2], atol=0.1)
 
-    @test isapprox(vs[ids.e_axis] , 0.7, atol=0.05)
-    @test isapprox(vs[ids.e_dev]  , 0.1, atol=0.08)
-    @test isapprox(vs[ids.e_scale], 4.0, atol=0.2)
+    @test isapprox(vs[ids.gal_ab] , 0.7, atol=0.05)
+    @test isapprox(vs[ids.gal_fracdev]  , 0.1, atol=0.08)
+    @test isapprox(vs[ids.gal_scale], 4.0, atol=0.2)
 
-    phi_hat = vs[ids.e_angle]
+    phi_hat = vs[ids.gal_angle]
     phi_hat -= floor(phi_hat / pi) * pi
     five_deg = 5 * pi/180
     @test isapprox(phi_hat, pi/4, atol=five_deg)
 
-    brightness_hat = exp(vs[ids.r1[2]] + 0.5 * vs[ids.r2[2]])
+    brightness_hat = exp(vs[ids.flux_loc[2]] + 0.5 * vs[ids.flux_scale[2]])
     @show brightness_hat
     @show sample_galaxy_fluxes[3]
     @test isapprox(brightness_hat / sample_galaxy_fluxes[3], 1.0, atol=0.05)
 
     true_colors = log.(sample_galaxy_fluxes[2:5] ./ sample_galaxy_fluxes[1:4])
     for b in 1:4
-        @test isapprox(vs[ids.c1[b, 2]], true_colors[b], atol=0.2)
+        @test isapprox(vs[ids.color_mean[b, 2]], true_colors[b], atol=0.2)
     end
 end
 
@@ -56,7 +56,7 @@ function test_star_optimization()
 
     # Newton's method converges on a small galaxy unless we start with
     # a high star probability.
-    vp[1][ids.a] = [0.8, 0.2]
+    vp[1][ids.is_star] = [0.8, 0.2]
 
     cfg = Config(ea, vp; loc_width=1.0)
     maximize!(ea, vp, cfg)

--- a/test/test_psf.jl
+++ b/test/test_psf.jl
@@ -109,13 +109,13 @@ function test_psf_fit()
     # sig_sf_vec = Vector{GalaxySigmaDerivs{NumType}}(K)
     #
     # for k = 1:K
-    #   sigma_vec[k] = PSF.get_bvn_cov(psf_params[k][psf_ids.e_axis],
-    #                                   psf_params[k][psf_ids.e_angle],
-    #                                   psf_params[k][psf_ids.e_scale])
+    #   sigma_vec[k] = PSF.get_bvn_cov(psf_params[k][psf_ids.gal_ab],
+    #                                   psf_params[k][psf_ids.gal_angle],
+    #                                   psf_params[k][psf_ids.gal_scale])
     #   sig_sf_vec[k] = GalaxySigmaDerivs(
-    #     psf_params[k][psf_ids.e_angle],
-    #     psf_params[k][psf_ids.e_axis],
-    #     psf_params[k][psf_ids.e_scale], sigma_vec[k], calculate_gradient)
+    #     psf_params[k][psf_ids.gal_angle],
+    #     psf_params[k][psf_ids.gal_ab],
+    #     psf_params[k][psf_ids.gal_scale], sigma_vec[k], calculate_gradient)
     #
     # end
 
@@ -135,9 +135,9 @@ function test_psf_fit()
 
   sigma_vec = Vector{Matrix{Float64}}(K)
   for k = 1:K
-    sigma_vec[k] = PSF.get_bvn_cov(psf_params[k][psf_ids.e_axis],
-                                    psf_params[k][psf_ids.e_angle],
-                                    psf_params[k][psf_ids.e_scale])
+    sigma_vec[k] = PSF.get_bvn_cov(psf_params[k][psf_ids.gal_ab],
+                                    psf_params[k][psf_ids.gal_angle],
+                                    psf_params[k][psf_ids.gal_scale])
   end
 
   println("Testing single pixel value")

--- a/test/test_psf.jl
+++ b/test/test_psf.jl
@@ -56,7 +56,7 @@ function load_raw_psf(; x::Float64=500., y::Float64=500.)
         datadir, run_num, camcol_num, field_num,
                  run_num, camcol_num, field_num)
   psf_fits = FITSIO.FITS(psf_filename)
-  raw_psf_comp = SDSSIO.read_psf(psf_fits, band_letters[b])
+  raw_psf_comp = SDSSIO.read_psf(psf_fits, BAND_LETTERS[b])
   close(psf_fits)
 
   eval_psf(raw_psf_comp, x, y)

--- a/test/test_wcs.jl
+++ b/test/test_wcs.jl
@@ -3,9 +3,6 @@ import FITSIO
 import WCS
 using Celeste.SDSSIO
 
-const band_letters = ['u', 'g', 'r', 'i', 'z']
-
-
 @testset "the identity WCSTransform works as expected" begin
     rand_coord = rand(2, 10)
     @test WCS.pix_to_world(SampleData.wcs_id, rand_coord) == rand_coord


### PR DESCRIPTION
This PR closes #330 by renaming many variables that are frequently used throughout Celeste. Originally, these variables' names matched the mathematical notation. Now it makes more sense to use descriptive variable names.

@andymiller Please rebase once this is committed--could be a lot of merge conflicts otherwise.