### PR TITLE
move Config to top level

### DIFF
--- a/benchmark/accuracy/run_celeste_on_field.jl
+++ b/benchmark/accuracy/run_celeste_on_field.jl
@@ -4,7 +4,7 @@ using DataFrames
 
 import Celeste.AccuracyBenchmark
 import Celeste.ArgumentParse
-import Celeste.Configs
+import Celeste: Config
 import Celeste.Infer
 import Celeste.ParallelRun
 import Celeste.SDSSIO
@@ -101,7 +101,7 @@ else
 end
 neighbor_map = Infer.find_neighbors(target_sources, catalog_entries, images)
 
-config = Configs.Config()
+config = Config()
 if haskey(parsed_args, "min-radius-px")
     config.min_radius_pix = parsed_args["min-radius-px"]
 end

--- a/src/AccuracyBenchmark.jl
+++ b/src/AccuracyBenchmark.jl
@@ -6,12 +6,12 @@ import FITSIO
 import StaticArrays
 import WCS
 
-import Celeste.Configs
-import Celeste.DeterministicVI
-import Celeste.Infer
-import Celeste.Model
-import Celeste.ParallelRun
-import Celeste.SDSSIO
+import ..Config
+import ..DeterministicVI
+import ..Infer
+import ..Model
+import ..ParallelRun
+import ..SDSSIO
 
 const ARCSEC_PER_DEGREE = 3600
 const SDSS_ARCSEC_PER_PIXEL = 0.396
@@ -1018,7 +1018,7 @@ end
 
 # Run Celeste with any combination of single/joint inference
 function run_celeste(
-    config::Configs.Config, catalog_entries, target_sources, images;
+    config::Config, catalog_entries, target_sources, images;
     use_joint_inference=false,
 )
     neighbor_map = Infer.find_neighbors(target_sources, catalog_entries, images)

--- a/src/Celeste.jl
+++ b/src/Celeste.jl
@@ -6,11 +6,10 @@ module Celeste
 # workaround a bug
 import ForwardDiff
 
-# alias scopes
 include("aliasscopes.jl")
+include("config.jl")
 
 # submodules
-include("Configs.jl")
 include("Log.jl")
 
 include("SensitiveFloats.jl")

--- a/src/DeterministicVI.jl
+++ b/src/DeterministicVI.jl
@@ -5,7 +5,7 @@ module DeterministicVI
 
 using Base.Threads: threadid, nthreads
 
-import ..Configs
+import ..Config
 using ..Model
 import ..Model: BivariateNormalDerivatives, BvnComponent, GalaxyCacheComponent,
                 BvnBundle, GalaxySigmaDerivs, SkyPatch,
@@ -122,7 +122,7 @@ Arguments:
     neighbors: the other light sources near `entry`
     entry: the source to infer
 """
-function infer_source(config::Configs.Config,
+function infer_source(config::Config,
                       images::Vector{Image},
                       neighbors::Vector{CatalogEntry},
                       entry::CatalogEntry)
@@ -149,7 +149,7 @@ end
 function infer_source(images::Vector{Image},
                       neighbors::Vector{CatalogEntry},
                       entry::CatalogEntry)
-    infer_source(Configs.Config(), images, neighbors, entry)
+    infer_source(Config(), images, neighbors, entry)
 end
 
 end

--- a/src/GalsimBenchmark.jl
+++ b/src/GalsimBenchmark.jl
@@ -5,9 +5,9 @@ module GalsimBenchmark
 using DataFrames
 import FITSIO
 
-import Celeste.AccuracyBenchmark
-import Celeste.Configs
-import Celeste.Infer
+import ..AccuracyBenchmark
+import ..Config
+import ..Infer
 
 const GALSIM_BENCHMARK_DIR = joinpath(Pkg.dir("Celeste"), "benchmark", "galsim")
 const LATEST_FITS_FILENAME_DIR = joinpath(GALSIM_BENCHMARK_DIR, "latest_filenames")
@@ -86,7 +86,7 @@ function run_benchmarks(; test_case_names=String[], joint_inference=false)
         truth_catalog_df = extract_catalog_from_header(header)
         catalog_entries = AccuracyBenchmark.make_initialization_catalog(truth_catalog_df, false)
         target_sources = collect(1:num_sources)
-        config = Configs.Config()
+        config = Config()
         config.min_radius_pix = ACTIVE_PIXELS_MIN_RADIUS_PX
         results = AccuracyBenchmark.run_celeste(
             config,

--- a/src/Infer.jl
+++ b/src/Infer.jl
@@ -12,7 +12,7 @@ module Infer
 import WCS
 using StaticArrays
 
-import ..Configs
+import ..Config
 using ..Model
 import ..Log
 
@@ -129,7 +129,7 @@ objective function.
 Non-standard arguments:
   noise_fraction: The proportion of the noise below which we will remove pixels.
 """
-function load_active_pixels!(config::Configs.Config,
+function load_active_pixels!(config::Config,
                              images::Vector{Image},
                              patches::Matrix{SkyPatch};
                              exclude_nan=true,
@@ -178,7 +178,7 @@ function load_active_pixels!(images::Vector{Image},
                              exclude_nan=true,
                              noise_fraction=0.5)
     load_active_pixels!(
-        Configs.Config(),
+        Config(),
         images,
         patches,
         exclude_nan=exclude_nan,

--- a/src/ParallelRun.jl
+++ b/src/ParallelRun.jl
@@ -7,7 +7,7 @@ import FITSIO
 import JLD
 import WCS
 
-import ..Configs
+import ..Config
 import ..Log
 using ..Model
 import ..SDSSIO
@@ -525,7 +525,7 @@ end
 """
 Optimize the `ts`th element of `target_sources`.
 """
-function process_source(config::Configs.Config,
+function process_source(config::Config,
                         ts::Int,
                         catalog::Vector{CatalogEntry},
                         target_sources::Vector{Int},
@@ -550,7 +550,7 @@ end
 Use multiple threads to process each target source with the specified
 callback and write the results to a file.
 """
-function one_node_single_infer(config::Configs.Config,
+function one_node_single_infer(config::Config,
                                catalog::Vector{CatalogEntry},
                                target_sources::Vector{Int},
                                neighbor_map::Vector{Vector{Int}},
@@ -614,7 +614,7 @@ function one_node_single_infer(catalog::Vector{CatalogEntry},
                                infer_source_callback=infer_source,
                                timing=InferTiming())
     one_node_single_infer(
-        Configs.Config(),
+        Config(),
         catalog,
         target_sources,
         neighbor_map,

--- a/src/config.jl
+++ b/src/config.jl
@@ -1,4 +1,4 @@
-module Configs
+# Configuration parameters
 
 mutable struct Config
     # A minimum pixel radius to be included around each source.
@@ -9,6 +9,4 @@ mutable struct Config
         config.min_radius_pix = 8.0
         config
     end
-end
-
 end

--- a/src/joint_infer.jl
+++ b/src/joint_infer.jl
@@ -11,7 +11,7 @@ import ..PSF
 
 using ..DeterministicVI
 using ..DeterministicVI.ConstraintTransforms: ConstraintBatch, DEFAULT_CHUNK
-using ..DeterministicVI.ElboMaximize: Config, maximize!
+using ..DeterministicVI.ElboMaximize: ElboConfig, maximize!
 
 const PeakFlops = false
 gdlog = nothing
@@ -464,7 +464,7 @@ function setup_vecs(n_sources::Int, target_sources::Vector{Int},
 
     ea_vec = Vector{ElboArgs}(n_sources)
     vp_vec = Vector{VariationalParams{Float64}}(n_sources)
-    cfg_vec = Vector{Config{DEFAULT_CHUNK,Float64}}(n_sources)
+    cfg_vec = Vector{ElboConfig{DEFAULT_CHUNK,Float64}}(n_sources)
 
     return ea_vec, vp_vec, cfg_vec, ts_vp
 end
@@ -489,7 +489,7 @@ Returns:
 
 - Vector of OptimizedSource results
 """
-function one_node_joint_infer(config::Configs.Config, catalog, target_sources, neighbor_map, images;
+function one_node_joint_infer(config::Config, catalog, target_sources, neighbor_map, images;
                               cyclades_partition::Bool=true,
                               batch_size::Int=7000,
                               within_batch_shuffling::Bool=true,
@@ -576,7 +576,7 @@ function one_node_joint_infer(catalog, target_sources, neighbor_map, images;
                               n_iters::Int=3,
                               timing=InferTiming())
     one_node_joint_infer(
-        Configs.Config(),
+        Config(),
         catalog,
         target_sources,
         neighbor_map,
@@ -589,7 +589,7 @@ function one_node_joint_infer(catalog, target_sources, neighbor_map, images;
     )
 end
 
-function initialize_elboargs_sources!(config::Configs.Config, ea_vec, vp_vec, cfg_vec,
+function initialize_elboargs_sources!(config::Config, ea_vec, vp_vec, cfg_vec,
                                       thread_initialize_sources_assignment,
                                       catalog, target_sources, neighbor_map, images,
                                       target_source_variational_params;
@@ -615,7 +615,7 @@ end
 """
 Initialize elbo args for the specified target source.
 """
-function init_elboargs(config::Configs.Config,
+function init_elboargs(config::Config,
                        ts::Int,
                        catalog::Vector{CatalogEntry},
                        target_sources::Vector{Int},
@@ -623,7 +623,7 @@ function init_elboargs(config::Configs.Config,
                        images::Vector{Image},
                        ea_vec::Vector{ElboArgs},
                        vp_vec::Vector{VariationalParams{Float64}},
-                       cfg_vec::Vector{Config{DEFAULT_CHUNK,Float64}},
+                       cfg_vec::Vector{ElboConfig{DEFAULT_CHUNK,Float64}},
                        ts_vp::Dict{Int64,Array{Float64}};
                        termination_callback=nothing)
     try
@@ -646,7 +646,7 @@ function init_elboargs(config::Configs.Config,
 
         ea_vec[ts] = ea
         vp_vec[ts] = vp
-        cfg_vec[ts] = Config(ea, vp;
+        cfg_vec[ts] = ElboConfig(ea, vp;
                 termination_callback=termination_callback)
     catch exc
         if is_production_run || nthreads() > 1
@@ -661,7 +661,7 @@ end
 function process_sources!(images::Vector{Model.Image},
                           ea_vec::Vector{ElboArgs},
                           vp_vec::Vector{VariationalParams{Float64}},
-                          cfg_vec::Vector{Config{DEFAULT_CHUNK,Float64}},
+                          cfg_vec::Vector{ElboConfig{DEFAULT_CHUNK,Float64}},
                           thread_sources_assignment::Vector{Vector{Vector{Int64}}},
                           n_iters::Int,
                           within_batch_shuffling::Bool)
@@ -694,7 +694,7 @@ end
 function process_sources_dynamic!(images::Vector{Model.Image},
                                   ea_vec::Vector{ElboArgs},
                                   vp_vec::Vector{VariationalParams{Float64}},
-                                  cfg_vec::Vector{Config{DEFAULT_CHUNK,Float64}},
+                                  cfg_vec::Vector{ElboConfig{DEFAULT_CHUNK,Float64}},
                                   thread_sources_assignment::Vector{Vector{Vector{Int64}}},
                                   n_iters::Int,
                                   within_batch_shuffling::Bool;
@@ -783,7 +783,7 @@ end
 # Process partition of sources. Multiple threads call this function in parallel.
 function process_sources_kernel!(ea_vec::Vector{ElboArgs},
                                  vp_vec::Vector{VariationalParams{Float64}},
-                                 cfg_vec::Vector{Config{DEFAULT_CHUNK,Float64}},
+                                 cfg_vec::Vector{ElboConfig{DEFAULT_CHUNK,Float64}},
                                  source_assignment::Vector{Int64},
                                  within_batch_shuffling::Bool)
     try

--- a/src/multinode_run.jl
+++ b/src/multinode_run.jl
@@ -5,13 +5,12 @@ using Base.Dates
 using Base.Threads
 
 using Celeste
-import Celeste: SDSSIO, ParallelRun, Infer
+import Celeste: SDSSIO, ParallelRun, Infer, Config
 using Celeste.Model
 using Celeste.ParallelRun: InferTiming, BoxKillSwitch, FieldExtent, OptimizedSourceLen, get_overlapping_fields, infer_init, is_production_run, setup_vecs, partition_box, get_pixels_processed, add_timing!
 using Celeste.DeterministicVI
 using Celeste.DeterministicVI.ConstraintTransforms: ConstraintBatch, DEFAULT_CHUNK
 using Celeste.DeterministicVI.ElboMaximize: Config, maximize!
-using Celeste.Configs
 using Celeste.Log
 using Gasp
 using JLD
@@ -474,7 +473,7 @@ end
 """
 To be called by a thread dedicated to preloading boxes into `conc_boxes`.
 """
-function preload_boxes(config::Configs.Config,
+function preload_boxes(config::Config,
                        boxes::Vector{BoundingBox},
                        rcf_map::Dict{RunCamcolField,Int32},
                        field_extents::Vector{FieldExtent},
@@ -533,7 +532,7 @@ end
 Thread function for running joint inference on the light sources in
 the specified bounding boxes.
 """
-function joint_infer_boxes(config::Configs.Config,
+function joint_infer_boxes(config::Config,
                            boxes::Vector{BoundingBox},
                            rcf_map::Dict{RunCamcolField,Int32},
                            field_extents::Vector{FieldExtent},
@@ -712,7 +711,7 @@ function Celeste.ParallelRun.do_infer_boxes(
                     "  $tot_srcs sources in these RCFs")
 
     # inference configuration
-    config = Configs.Config()
+    config = Config()
 
     prev_results = nothing
     for i = 1:length(all_boxes)

--- a/test/test_infer.jl
+++ b/test/test_infer.jl
@@ -1,7 +1,7 @@
 ## test the main entry point in Celeste: the `infer` function
 import JLD
 
-import Celeste.Configs
+import Celeste: Config
 using Celeste.SDSSIO
 
 """
@@ -24,7 +24,7 @@ function test_load_active_pixels()
     # the star is bright but it doesn't cover the whole image.
     # it's hard to say exactly how many pixels should be active,
     # but not all of them, and not none of them.
-    config = Configs.Config()
+    config = Config()
     config.min_radius_pix = 0
     Infer.load_active_pixels!(config, ea.images, ea.patches)
 
@@ -67,7 +67,7 @@ function test_load_active_pixels()
 
     # only 2 pixels per image are within 0.6 pixels of the
     # source's center (10.9, 11.5)
-    config = Configs.Config()
+    config = Config()
     config.min_radius_pix = 0.6
     Infer.load_active_pixels!(config, ea.images, ea.patches)
 
@@ -81,7 +81,7 @@ end
 function test_patch_pixel_selection()
     ea, vp, catalog = gen_two_body_dataset();
     patches = Infer.get_sky_patches(ea.images, catalog; radius_override_pix=5);
-    config = Configs.Config()
+    config = Config()
     config.min_radius_pix = 5
     Infer.load_active_pixels!(config, ea.images, patches, noise_fraction=Inf)
 

--- a/test/test_optimization.jl
+++ b/test/test_optimization.jl
@@ -4,7 +4,7 @@ using Celeste: Model, SensitiveFloats
 using Celeste.DeterministicVI.ConstraintTransforms: ParameterConstraint,
                         ConstraintBatch, BoxConstraint, SimplexConstraint
 using Celeste.DeterministicVI: ElboArgs
-using Celeste.DeterministicVI.ElboMaximize: Config, maximize!, elbo_optim_options
+using Celeste.DeterministicVI.ElboMaximize: ElboConfig, maximize!, elbo_optim_options
 using Optim
 
 function verify_sample_star(vs, pos)
@@ -58,7 +58,7 @@ function test_star_optimization()
     # a high star probability.
     vp[1][ids.is_star] = [0.8, 0.2]
 
-    cfg = Config(ea, vp; loc_width=1.0)
+    cfg = ElboConfig(ea, vp; loc_width=1.0)
     maximize!(ea, vp, cfg)
 
     verify_sample_star(vp[1], [10.1, 12.2])
@@ -72,7 +72,7 @@ function test_single_source_optimization()
     ea = make_elbo_args(ea.images, catalog, active_source=s, include_kl=false);
     vp_original = deepcopy(vp);
 
-    cfg = Config(ea, vp; loc_width=1.0)
+    cfg = ElboConfig(ea, vp; loc_width=1.0)
     maximize!(ea, vp, cfg)
 
     # Test that it only optimized source s
@@ -85,7 +85,7 @@ end
 
 function test_galaxy_optimization()
     ea, vp, catalog = gen_sample_galaxy_dataset(; include_kl = false);
-    cfg = Config(ea, vp; loc_width=3.0)
+    cfg = ElboConfig(ea, vp; loc_width=3.0)
     maximize!(ea, vp, cfg)
     verify_sample_galaxy(vp[1], [8.5, 9.6])
 end
@@ -93,7 +93,7 @@ end
 
 function test_full_elbo_optimization()
     ea, vp, catalog = gen_sample_galaxy_dataset(perturb=true);
-    cfg = Config(ea, vp; loc_width=1.0,
+    cfg = ElboConfig(ea, vp; loc_width=1.0,
                  optim_options=elbo_optim_options(xtol_abs=0.0))
     maximize!(ea, vp, cfg)
     verify_sample_galaxy(vp[1], [8.5, 9.6]);
@@ -104,7 +104,7 @@ function test_termination_callback()
     ea, vp, catalog = gen_sample_galaxy_dataset(; include_kl = false);
     terminated = false
     callback = x -> (terminated = x.iteration >= 3; return terminated)
-    cfg = Config(ea, vp; termination_callback = callback)
+    cfg = ElboConfig(ea, vp; termination_callback = callback)
     _, _, _, result = maximize!(ea, vp, cfg)
     return terminated && Optim.iterations(result) == 3
 end


### PR DESCRIPTION
It seemed like the `Config` type doesn't need to live in it's own submodule `Configs`, of which it was the only occupant.

I also changed the name of `DeterministicVI.ElboMaximize.Config` to `ElboConfig` to avoid name conflicts or confusion.