### PR TITLE
Remove multiple includes of bivariate_normals code

### DIFF
--- a/src/Model.jl
+++ b/src/Model.jl
@@ -32,6 +32,7 @@ import FITSIO, WCS
 import WCS.WCSTransform
 import ..Log
 import ..Celeste: Const, @aliasscope, @unroll_loop
+import ..SensitiveFloats: SensitiveFloat, clear!
 
 import Base.length
 
@@ -49,9 +50,7 @@ include("model/image_model.jl")
 include("model/param_set.jl")
 include("model/imaged_sources.jl")
 include("model/wcs_utils.jl")
-
-import ..SensitiveFloats: SensitiveFloat, clear!
-include("bivariate_normals.jl")
+include("model/bivariate_normals.jl")
 include("model/fsm_util.jl")
 include("model/log_prob.jl")
 

--- a/src/PSF.jl
+++ b/src/PSF.jl
@@ -9,6 +9,8 @@ module PSF
 using Celeste
 using Celeste: Const, @aliasscope, @unroll_loop
 using ..Model
+using ..Model: GalaxySigmaDerivs, BivariateNormalDerivatives, get_bvn_derivs!,
+               eval_bvn_pdf!, transform_bvn_derivs!, BvnComponent, get_bvn_cov
 using ..Transform
 using ..SensitiveFloats.SensitiveFloat
 import ..SensitiveFloats.clear!
@@ -19,8 +21,6 @@ import WCS
 
 using ForwardDiff
 using StaticArrays
-
-include("bivariate_normals.jl")
 
 
 const ID_MAT_2D = eye(Float64, 2)

--- a/src/Synthetic.jl
+++ b/src/Synthetic.jl
@@ -2,15 +2,14 @@ module Synthetic
 
 export gen_blob
 
-using Celeste, Celeste.Model
-import Celeste: Infer, DeterministicVI
+using Celeste
+using Celeste.Model
 
 import WCS
 import Distributions
 using ForwardDiff
 using StaticArrays
 
-include("bivariate_normals.jl")
 
 # Generate synthetic data.
 
@@ -66,7 +65,7 @@ function write_galaxy(img0::Image, ce::CatalogEntry, pixels::Matrix{Float64};
                       expectation=false)
     iota = median(img0.nelec_per_nmgy)
     gal_fracdevs = [ce.gal_frac_dev, 1 - ce.gal_frac_dev]
-    XiXi = DeterministicVI.get_bvn_cov(ce.gal_ab, ce.gal_angle, ce.gal_scale)
+    XiXi = Model.get_bvn_cov(ce.gal_ab, ce.gal_angle, ce.gal_scale)
 
     for i in 1:2
         for gproto in galaxy_prototypes[i]

--- a/src/model/bivariate_normals.jl
+++ b/src/model/bivariate_normals.jl
@@ -1,7 +1,10 @@
-# Defining gal_shape_ids_len might not be needed but it is critical that this is compile time constant
-const gal_shape_ids_len = 3
+# Bivarate normals -- 2-d gaussians and their derivatives, as well as
+# derivatives of model components.
 
-using Celeste: Const, @aliasscope, @unroll_loop
+# Hardcoding this might not be needed but it is critical that this is
+# compile time constant.
+const GAL_SHAPE_IDS_LENGTH = 3
+@assert GAL_SHAPE_IDS_LENGTH == length(gal_shape_ids)
 
 """
 Unpack a rotation-parameterized BVN covariance matrix.
@@ -302,7 +305,6 @@ function get_bvn_derivs!{NumType <: Number}(
   end
 end
 
-##############################
 
 """
 The derivatives of sigma with respect to the galaxy shape parameters.  In
@@ -314,8 +316,8 @@ parameters are indexed by GalaxyShapeParams.
       derivatives d2 Sigma / d GalaxyShapeParams d GalaxyShapeParams.
 """
 struct GalaxySigmaDerivs{NumType <: Number}
-    j::SMatrix{3,gal_shape_ids_len,NumType,9}
-    t::SArray{Tuple{3,gal_shape_ids_len,gal_shape_ids_len},NumType,3,27}
+    j::SMatrix{3,GAL_SHAPE_IDS_LENGTH,NumType,9}
+    t::SArray{Tuple{3,GAL_SHAPE_IDS_LENGTH,GAL_SHAPE_IDS_LENGTH},NumType,3,27}
 end
 
 
@@ -359,6 +361,13 @@ function GalaxySigmaDerivs{NumType <: Number}(
 
   GalaxySigmaDerivs(j*nuBar, t*nuBar)
 end
+
+
+GalaxySigmaDerivs{NumType}(::Type{NumType}) = GalaxySigmaDerivs(
+                                                     @SMatrix(zeros(NumType,3,GAL_SHAPE_IDS_LENGTH)),
+                                                     @SArray( zeros(NumType,3,GAL_SHAPE_IDS_LENGTH,GAL_SHAPE_IDS_LENGTH)))
+
+
 
 
 """
@@ -421,9 +430,6 @@ function GalaxyCacheComponent{NumType <: Number}(
   GalaxyCacheComponent(gal_fracdev_dir, gal_fracdev_i, bmc, sig_sf)
 end
 
-GalaxySigmaDerivs{NumType}(::Type{NumType}) = GalaxySigmaDerivs(
-                                                     @SMatrix(zeros(NumType,3,gal_shape_ids_len)),
-                                                     @SArray( zeros(NumType,3,gal_shape_ids_len,gal_shape_ids_len)))
 
 ###################################################
 # Transform derivatives into the model parameterization.


### PR DESCRIPTION
This is simply code organization, removing the multiple `include`s of `bivariate_normals.jl`. Instead, the code now lives solely in the `Model` submodule and is imported into other submodules as needed (`PSF` and `Synthetic`.

~I also split the `bivariate_normals.jl` file into two files:~
- ~`model/bivariate_normals.jl` model independent stuff about bivariate normals. Could live outside `Model` if desired.~
- ~`model/derivatives.jl`: stuff specific to the Galaxy or PSF model, using bivariate normals. Mostly about derivatives.~