### PR TITLE
Organization: moduleize bivariate normals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,10 @@ notifications:
   email: false
 git:
   depth: 99999999
-
+addons:
+  apt:
+    packages:
+    - hdf5-tools
 after_success:
   - julia -e 'cd(Pkg.dir("Celeste")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,7 +2,7 @@ julia 0.6
 BinDeps
 Compat 0.18.0
 DataFrames
-DataStructures 0.5.2
+DataStructures 0.7.0
 Distributions
 FITSIO 0.8.4
 DiffBase 0.0.3

--- a/src/BivariateNormals.jl
+++ b/src/BivariateNormals.jl
@@ -106,7 +106,7 @@ struct BivariateNormalDerivatives{NumType <: Number}
   end
 end
 
-function clear!{T}(bvn_derivs::BivariateNormalDerivatives{T})
+function zero!(bvn_derivs::BivariateNormalDerivatives{T}) where {T}
     x = zero(T)
     fill!(bvn_derivs.py1, x)
     fill!(bvn_derivs.py2, x)

--- a/src/Celeste.jl
+++ b/src/Celeste.jl
@@ -13,6 +13,7 @@ include("config.jl")
 include("Log.jl")
 
 include("SensitiveFloats.jl")
+include("BivariateNormals.jl")
 
 include("Coordinates.jl")
 

--- a/src/DeterministicVI.jl
+++ b/src/DeterministicVI.jl
@@ -6,11 +6,11 @@ module DeterministicVI
 using Base.Threads: threadid, nthreads
 
 import ..Config
+using ..BivariateNormals: BivariateNormalDerivatives, BvnComponent,
+                          GalaxySigmaDerivs, get_bvn_cov, eval_bvn_pdf!,
+                          get_bvn_derivs!, transform_bvn_derivs!
 using ..Model
-import ..Model: BivariateNormalDerivatives, BvnComponent, GalaxyCacheComponent,
-                BvnBundle, GalaxySigmaDerivs, SkyPatch,
-                get_bvn_cov, eval_bvn_pdf!, get_bvn_derivs!,
-                transform_bvn_derivs!, populate_fsm!
+using ..Model: SkyPatch, BvnBundle, populate_fsm!
 import ..Celeste: Const, @aliasscope, @unroll_loop
 import ..Infer
 using ..SensitiveFloats

--- a/src/DeterministicVI.jl
+++ b/src/DeterministicVI.jl
@@ -14,14 +14,13 @@ using ..Model: SkyPatch, BvnBundle, populate_fsm!
 import ..Celeste: Const, @aliasscope, @unroll_loop
 import ..Infer
 using ..SensitiveFloats
-import ..SensitiveFloats.clear!
 import ..Log
 using ..Transform
 import DataFrames
 import Optim
 import ForwardDiff.Dual
 using StaticArrays
-import Base.convert
+import Base: convert
 
 export ElboArgs, generic_init_source, catalog_init_source, init_sources,
        VariationalParams, elbo, ElboIntermediateVariables

--- a/src/Model.jl
+++ b/src/Model.jl
@@ -25,16 +25,16 @@ export NUM_COLOR_COMPONENTS, NUM_SOURCE_TYPES, NUM_BANDS,
        ids, star_ids, gal_ids, gal_shape_ids, psf_ids, bids
 
 
-import Base.convert
-import Base.+
+import Base: convert, length, +
 import Distributions
 import FITSIO, WCS
 import WCS.WCSTransform
 import ..Log
 import ..Celeste: Const, @aliasscope, @unroll_loop
 import ..SensitiveFloats: SensitiveFloat, clear!
-
-import Base.length
+using ..BivariateNormals: BivariateNormalDerivatives, BvnComponent,
+                          GalaxySigmaDerivs, get_bvn_cov, eval_bvn_pdf!,
+                          get_bvn_derivs!, transform_bvn_derivs!
 
 const cfgdir = joinpath(Pkg.dir("Celeste"), "cfg")
 
@@ -50,7 +50,6 @@ include("model/image_model.jl")
 include("model/param_set.jl")
 include("model/imaged_sources.jl")
 include("model/wcs_utils.jl")
-include("model/bivariate_normals.jl")
 include("model/fsm_util.jl")
 include("model/log_prob.jl")
 

--- a/src/Model.jl
+++ b/src/Model.jl
@@ -31,10 +31,13 @@ import FITSIO, WCS
 import WCS.WCSTransform
 import ..Log
 import ..Celeste: Const, @aliasscope, @unroll_loop
-import ..SensitiveFloats: SensitiveFloat, clear!
+import ..SensitiveFloats
+import ..SensitiveFloats: SensitiveFloat
+import ..BivariateNormals
 using ..BivariateNormals: BivariateNormalDerivatives, BvnComponent,
                           GalaxySigmaDerivs, get_bvn_cov, eval_bvn_pdf!,
-                          get_bvn_derivs!, transform_bvn_derivs!
+                          get_bvn_derivs!, transform_bvn_derivs!,
+                          transform_bvn_ux_derivs!
 
 const cfgdir = joinpath(Pkg.dir("Celeste"), "cfg")
 

--- a/src/PSF.jl
+++ b/src/PSF.jl
@@ -13,7 +13,6 @@ using ..Model: GalaxySigmaDerivs, BivariateNormalDerivatives, get_bvn_derivs!,
                eval_bvn_pdf!, transform_bvn_derivs!, BvnComponent, get_bvn_cov
 using ..Transform
 using ..SensitiveFloats.SensitiveFloat
-import ..SensitiveFloats.clear!
 import ..SensitiveFloats
 
 import Optim
@@ -404,7 +403,7 @@ function evaluate_psf_pixel_fit!{NumType <: Number}(
         pdf::SensitiveFloat{NumType},
         pixel_value::SensitiveFloat{NumType},
         calculate_gradient::Bool)
-    clear!(pixel_value)
+    SensitiveFloats.zero!(pixel_value)
 
     K = length(psf_params)
     sigma_ids = (psf_ids.gal_ab, psf_ids.gal_angle, psf_ids.gal_scale)
@@ -416,8 +415,8 @@ function evaluate_psf_pixel_fit!{NumType <: Number}(
         get_bvn_derivs!(bvn_derivs, bvn, true, true)
         transform_bvn_derivs!(bvn_derivs, sig_sf_vec[k], I, true)
 
-        clear!(log_pdf)
-        clear!(pdf)
+        SensitiveFloats.zero!(log_pdf)
+        SensitiveFloats.zero!(pdf)
 
         # This is redundant, but it's what eval_bvn_pdf returns.
         log_pdf.v[] = log(bvn_derivs.f_pre[1])
@@ -519,10 +518,10 @@ function evaluate_psf_fit!{NumType <: Number}(
         calculate_gradient::Bool)
     K = length(psf_params)
     sigma_vec, sig_sf_vec, bvn_vec = get_sigma_from_params(psf_params)
-    clear!(squared_error)
+    SensitiveFloats.zero!(squared_error)
 
     @inbounds for x_ind in 1:length(x_mat)
-        clear!(pixel_value)
+        SensitiveFloats.zero!(pixel_value)
         evaluate_psf_pixel_fit!(
                 x_mat[x_ind], psf_params, sig_sf_vec, bvn_vec,
                 bvn_derivs, log_pdf, pdf, pixel_value, calculate_gradient)

--- a/src/SensitiveFloats.jl
+++ b/src/SensitiveFloats.jl
@@ -1,7 +1,6 @@
 module SensitiveFloats
 
 export SensitiveFloat,
-       clear!,
        multiply_sfs!,
        add_scaled_sfs!,
        combine_sfs!,
@@ -82,8 +81,8 @@ function zero!{T}(m::Array{T})
     end
 end
 
-function clear!{NumType <: Number}(sf::SensitiveFloat{NumType})
-    sf.v[] = zero(NumType)
+function zero!(sf::SensitiveFloat{T}) where {T<:Number}
+    sf.v[] = zero(T)
 
     if sf.has_gradient
         zero!(sf.d)

--- a/src/deterministic_vi/elbo_args.jl
+++ b/src/deterministic_vi/elbo_args.jl
@@ -112,28 +112,28 @@ function ElboIntermediateVariables(NumType::DataType,
         elbo_log_term, elbo, 0, 0)
 end
 
-function clear!{NumType <: Number}(elbo_vars::ElboIntermediateVariables{NumType})
-    clear!(elbo_vars.fs0m)
-    clear!(elbo_vars.fs1m)
-    clear!(elbo_vars.E_G_s)
-    clear!(elbo_vars.E_G2_s)
-    clear!(elbo_vars.var_G_s)
+function zero!(elbo_vars::ElboIntermediateVariables{T}) where {T<:Number}
+    SensitiveFloats.zero!(elbo_vars.fs0m)
+    SensitiveFloats.zero!(elbo_vars.fs1m)
+    SensitiveFloats.zero!(elbo_vars.E_G_s)
+    SensitiveFloats.zero!(elbo_vars.E_G2_s)
+    SensitiveFloats.zero!(elbo_vars.var_G_s)
 
     for i in 1:NUM_SOURCE_TYPES
-        fill!(elbo_vars.E_G_s_hsub_vec[i].u_u, zero(NumType))
-        fill!(elbo_vars.E_G_s_hsub_vec[i].shape_shape, zero(NumType))
-        fill!(elbo_vars.E_G2_s_hsub_vec[i].u_u, zero(NumType))
-        fill!(elbo_vars.E_G2_s_hsub_vec[i].shape_shape, zero(NumType))
+        fill!(elbo_vars.E_G_s_hsub_vec[i].u_u, zero(T))
+        fill!(elbo_vars.E_G_s_hsub_vec[i].shape_shape, zero(T))
+        fill!(elbo_vars.E_G2_s_hsub_vec[i].u_u, zero(T))
+        fill!(elbo_vars.E_G2_s_hsub_vec[i].shape_shape, zero(T))
     end
 
-    clear!(elbo_vars.E_G)
-    clear!(elbo_vars.var_G)
+    SensitiveFloats.zero!(elbo_vars.E_G)
+    SensitiveFloats.zero!(elbo_vars.var_G)
 
-    fill!(elbo_vars.combine_grad, zero(NumType))
-    fill!(elbo_vars.combine_hess, zero(NumType))
+    fill!(elbo_vars.combine_grad, zero(T))
+    fill!(elbo_vars.combine_hess, zero(T))
 
-    clear!(elbo_vars.elbo_log_term)
-    clear!(elbo_vars.elbo)
+    SensitiveFloats.zero!(elbo_vars.elbo_log_term)
+    SensitiveFloats.zero!(elbo_vars.elbo)
 end
 
 

--- a/src/deterministic_vi/elbo_objective.jl
+++ b/src/deterministic_vi/elbo_objective.jl
@@ -32,9 +32,9 @@ function calculate_G_s!{NumType <: Number}(
 
     # we'd like to get rid of these calls to `fill!`
     if is_active_source
-        clear!(E_G_s)
-        clear!(E_G2_s)
-        clear!(var_G_s)
+        SensitiveFloats.zero!(E_G_s)
+        SensitiveFloats.zero!(E_G2_s)
+        SensitiveFloats.zero!(var_G_s)
     else
         E_G_s.v[] = 0.0
         E_G2_s.v[] = 0.0
@@ -337,8 +337,8 @@ function add_pixel_term!{NumType <: Number}(
                     elbo_vars::ElboIntermediateVariables = ElboIntermediateVariables(NumType, ea.Sa))
     img = ea.images[n]
 
-    clear!(elbo_vars.E_G)
-    clear!(elbo_vars.var_G)
+    SensitiveFloats.zero!(elbo_vars.E_G)
+    SensitiveFloats.zero!(elbo_vars.var_G)
 
     for s in 1:ea.S
         p = ea.patches[s,n]
@@ -404,8 +404,8 @@ function elbo_likelihood{T}(ea::ElboArgs,
                             vp::VariationalParams{T},
                             elbo_vars::ElboIntermediateVariables = ElboIntermediateVariables(T, ea.Sa),
                             bvn_bundle::BvnBundle{T} = BvnBundle{T}(ea.psf_K, ea.S))
-    clear!(elbo_vars)
-    clear!(bvn_bundle)
+    zero!(elbo_vars)
+    Model.zero!(bvn_bundle)
 
     # this call loops over light sources (but not images)
     sbs = load_source_brightnesses(ea, vp)

--- a/src/joint_infer.jl
+++ b/src/joint_infer.jl
@@ -232,9 +232,7 @@ function partition_cyclades(n_threads, target_sources, neighbor_map; batch_size=
     # Load balance the connected components within each batch into thread_sources_assignment.
     for (cur_batch, cur_batch_component) in enumerate(components)
         # Priority queue for load balancing.
-        pqueue = PriorityQueue([i for i=1:n_threads],
-                               [0 for i=1:n_threads],
-                               Base.Order.Forward)
+        pqueue = PriorityQueue(Base.Order.Forward, (i, 0) for i=1:n_threads)
 
         # Assign non-conflicting group of sources to different threads
         for (component_group_id, sources_of_component) in cur_batch_component

--- a/src/model/log_prob.jl
+++ b/src/model/log_prob.jl
@@ -1,7 +1,7 @@
 # Functions to compute the log probability of star parameters and galaxy
 # parameters given pixel data
 using Distributions
-import ..SensitiveFloats: SensitiveFloat, clear!
+import ..SensitiveFloats: SensitiveFloat
 
 const eps_prob_a = 1e-6
 

--- a/test/test_psf.jl
+++ b/test/test_psf.jl
@@ -119,7 +119,7 @@ function test_psf_fit()
     #
     # end
 
-    clear!(pixel_value)
+    SensitiveFloats.zero!(pixel_value)
     PSF.evaluate_psf_pixel_fit!(
         x, psf_params, sig_sf_vec, bvn_vec,
         bvn_derivs, log_pdf, pdf, pixel_value, calculate_gradient)


### PR DESCRIPTION
This moves the part of `model/bivariate_normals.jl` that is model-independent (just about 2-d gaussians, not galaxies) to its own submodule `BivariateNormals`. This is the entire file, with the exception of `GalaxyCacheComponent` and `BvnBundle`. This will hopefully make things a little easier to understand, or make it easier to do so in the future.

I ran into a bit of a problem with the `clear!` function and I ended up renaming `clear!` to `zero!` as the former could be confused with the `clear!` in Base that has a completely different meaning. Several submodules now have their own `zero!` function that acts on their own types: `SensitiveFloats.zero!`, `Model.zero!`, `BivariateNormals.zero!` and `DeterministicVI.zero!`. We could make these methods of a single function `Celeste.zero!`, but that isn't done in this PR.

Finally, I updated a bit of code to the new `where` syntax while I was poking around.