### PR TITLE
make infer_init() consistent with usage

### DIFF
--- a/test/test_joint_infer.jl
+++ b/test/test_joint_infer.jl
@@ -156,9 +156,7 @@ function test_detect_sources()
     # Get raw images
     strategy = SDSSIO.PlainFITSStrategy(datadir)
     raw_images = SDSSIO.load_raw_images(strategy, [rcf])
-    catalog, source_rcfs, source_idxs, source_radii = detect_sources(raw_images)
-
-    @test all(source_rcfs .== rcf)
+    catalog, source_radii = detect_sources(raw_images)
 
     ra = [ce.pos[1] for ce in catalog]
     dec = [ce.pos[2] for ce in catalog]


### PR DESCRIPTION
The use of `infer_init()` in `ParallelRun.jl` requires it to return a length-4 tuple. It was returning a length-6 tuple. This PR removes the two extra return values. (These had been added for multinode_run.jl, which no longer exists).