### PR TITLE
Remove objid and thing_id / thingid

### DIFF
--- a/benchmark/accuracy/jld_catalog_to_csv.jl
+++ b/benchmark/accuracy/jld_catalog_to_csv.jl
@@ -13,10 +13,10 @@ for jld_path in ARGS
     sources = JLD.load(jld_path)["results"]
     Log.info("Found $(length(sources)) sources")
     for source in sources
-        push!(
-            data_rows,
-            AccuracyBenchmark.variational_parameters_to_data_frame_row(source.objid, source.vs),
-        )
+        push!(data_rows,
+              AccuracyBenchmark.variational_parameters_to_data_frame_row(
+                  source.vs)
+              )
     end
 end
 data = vcat(data_rows...)

--- a/benchmark/accuracy/score_predictions.jl
+++ b/benchmark/accuracy/score_predictions.jl
@@ -46,18 +46,20 @@ if haskey(parsed_args, "write-prediction-csv")
             end
         end
     end
+    matched_truth[:index] = collect(1:nrow(matched_truth))
     matched_truth[:source] = fill("truth", size(matched_truth, 1))
-    for (index, prediction_df) in enumerate(matched_prediction_dfs)
-        prediction_df[:source] = fill("prediction $index", size(prediction_df, 1))
+    for (i, prediction_df) in enumerate(matched_prediction_dfs)
+        prediction_df[:index] = collect(1:nrow(prediction_df))
+        prediction_df[:source] = fill("prediction $i", size(prediction_df, 1))
     end
     all_predictions = vcat(matched_truth, matched_prediction_dfs...)
-    long_df = melt(all_predictions, [:objid, :source])
-    long_df[:objid_var] = [
-        join([objid, variable], " ")
-        for (objid, variable) in zip(long_df[:objid], long_df[:variable])
+    long_df = melt(all_predictions, [:index, :source])
+    long_df[:index_var] = [
+        join([idx, variable], " ")
+        for (idx, variable) in zip(long_df[:index], long_df[:variable])
     ]
-    delete!(long_df, :objid)
+    delete!(long_df, :index)
     delete!(long_df, :variable)
-    final_df = unstack(long_df, :objid_var, :source, :value)
+    final_df = unstack(long_df, :index_var, :source, :value)
     writetable(parsed_args["write-prediction-csv"], final_df)
 end

--- a/src/AccuracyBenchmark.jl
+++ b/src/AccuracyBenchmark.jl
@@ -572,7 +572,6 @@ function make_catalog_entry(
         pi / 4, # gal_angle
         4., # gal_scale
         objid, # objid
-        0, # thing_id
     )
 end
 
@@ -599,8 +598,7 @@ function make_catalog_entry(row::DataFrameRow)
         minor_major_axis_ratio,
         na_to_default(row[:angle_deg], 0.) / 180.0 * pi,
         na_to_default(row[:half_light_radius_px] / sqrt(minor_major_axis_ratio), 2.),
-        row[:objid],
-        0, # thing_id
+        row[:objid]
     )
 end
 

--- a/src/DeterministicVI.jl
+++ b/src/DeterministicVI.jl
@@ -126,7 +126,7 @@ function infer_source(config::Config,
                       neighbors::Vector{CatalogEntry},
                       entry::CatalogEntry)
     if length(neighbors) > 100
-        msg = string("objid $(entry.objid) [ra: $(entry.pos)] has an excessive",
+        msg = string("object at RA, Dec = $(entry.pos) has an excessive",
                      "number ($(length(neighbors))) of neighbors")
         Log.warn(msg)
     end

--- a/src/GalsimBenchmark.jl
+++ b/src/GalsimBenchmark.jl
@@ -55,11 +55,21 @@ end
 function truth_comparison_df(truth_df::DataFrame, prediction_df::DataFrame)
     @assert size(truth_df, 1) == size(prediction_df, 1)
     parameter_columns = names(truth_df)
+
+    # remove objid if present
     deleteat!(parameter_columns, findin(parameter_columns, [:objid]))
+
+    # add an object index to truth and prediction, for when we reshape
+    idx = collect(1:nrow(truth_df))
+    truth_df = hcat(DataFrame(index=idx), truth_df)
+    prediction_df = hcat(DataFrame(index=idx), prediction_df)
+
     long_truth_df = stack(truth_df, parameter_columns)
-    sort!(long_truth_df, cols=[:objid, :variable])
+    sort!(long_truth_df, cols=[:index, :variable])
+
     long_prediction_df = stack(prediction_df, parameter_columns)
-    sort!(long_prediction_df, cols=[:objid, :variable])
+    sort!(long_prediction_df, cols=[:index, :variable])
+
     rename!(long_truth_df, :value, :truth)
     long_truth_df[:estimate] = long_prediction_df[:value]
     long_truth_df[:error] = long_truth_df[:estimate] .- long_truth_df[:truth]

--- a/src/ParallelRun.jl
+++ b/src/ParallelRun.jl
@@ -232,8 +232,7 @@ function detect_sources(images::Vector{SDSSIO.RawImage})
                                          gal_ab,
                                          gal_angle,
                                          gal_scale,
-                                         "",  # objid
-                                         0)  # thing_id
+                                         "")  # objid
 
             # get object extent in degrees from bounding box in pixels
             xmin = sep_catalog.xmin[i]
@@ -458,17 +457,14 @@ end
 # optimization result container
 
 struct OptimizedSource
-    thingid::Int64
     objid::String
     init_ra::Float64
     init_dec::Float64
     vs::Vector{Float64}
 end
-const OptimizedSourceLen = 465
 
 function serialize(s::Base.AbstractSerializer, os::OptimizedSource)
     Base.serialize_type(s, typeof(os))
-    write(s.io, os.thingid)
     @assert length(os.objid) == 19
     for i = 1:19
         write(s.io, os.objid.data[i])
@@ -481,7 +477,6 @@ function serialize(s::Base.AbstractSerializer, os::OptimizedSource)
 end
 
 function deserialize(s::Base.AbstractSerializer, ::Type{OptimizedSource})
-    thingid = read(s.io, Int64)::Int64
     objid_data = zeros(UInt8, 19)
     for i = 1:19
         objid_data[i] = read(s.io, UInt8)::UInt8
@@ -492,7 +487,7 @@ function deserialize(s::Base.AbstractSerializer, ::Type{OptimizedSource})
     for i = 1:length(Celeste.Model.ids)
         vs[i] = read(s.io, Float64)
     end
-    OptimizedSource(thingid, String(objid_data), init_ra, init_dec, vs)
+    OptimizedSource(String(objid_data), init_ra, init_dec, vs)
 end
 
 
@@ -515,8 +510,7 @@ function process_source(config::Config,
     tic()
     vs_opt = infer_source(config, images, neighbors, entry)
     Log.info("$(entry.objid): $(toq()) secs")
-    return OptimizedSource(entry.thing_id,
-                           entry.objid,
+    return OptimizedSource(entry.objid,
                            entry.pos[1],
                            entry.pos[2],
                            vs_opt)

--- a/src/SDSSIO.jl
+++ b/src/SDSSIO.jl
@@ -519,8 +519,8 @@ function convert(::Type{Vector{CatalogEntry}}, catalog::Dict)
         celeste_phi_rad = fits_phi * (pi / 180)
 
         entry = CatalogEntry(worldcoords, catalog["is_star"][i], star_fluxes,
-                             gal_fluxes, frac_dev, fits_ab, celeste_phi_rad, re_pixel,
-                             catalog["objid"][i], Int(catalog["thing_id"][i]))
+                             gal_fluxes, frac_dev, fits_ab, celeste_phi_rad,
+                             re_pixel, catalog["objid"][i])
         push!(out, entry)
     end
 

--- a/src/SDSSIO.jl
+++ b/src/SDSSIO.jl
@@ -399,7 +399,6 @@ function read_photoobj(f::FITSIO.FITS, band::Char='r', close_file=true)
 
     # nopeak, DEBLEND_DEGENERATE, or saturated center
     bad_flags2 = objc_flags2 .& UInt32(2^14 + 2^18 + 2^11) .!= 0
-    i = findfirst(objid, "1237680069097291856")
 
     has_child = read(hdu, "nchild")::Vector{Int16} .> 0
 
@@ -520,7 +519,7 @@ function convert(::Type{Vector{CatalogEntry}}, catalog::Dict)
 
         entry = CatalogEntry(worldcoords, catalog["is_star"][i], star_fluxes,
                              gal_fluxes, frac_dev, fits_ab, celeste_phi_rad,
-                             re_pixel, catalog["objid"][i])
+                             re_pixel)
         push!(out, entry)
     end
 
@@ -608,10 +607,6 @@ function read_photoobj_files(strategy, fts::Vector{RunCamcolField};
     if drop_quickly
         return CatalogEntry[]
     end
-
-    #for i in eachindex(fts)
-    #    Log.info("field $(fts[i]): $(length(rawcatalogs[i]["objid"])) entries")
-    #end
 
     return assemble_catalog(rawcatalogs; duplicate_policy=duplicate_policy)
 end

--- a/src/joint_infer.jl
+++ b/src/joint_infer.jl
@@ -552,8 +552,7 @@ function one_node_joint_infer(config::Config, catalog, target_sources, neighbor_
     else
         for i = 1:n_sources
             entry = catalog[target_sources[i]]
-            result = OptimizedSource(entry.thing_id,
-                                     entry.objid,
+            result = OptimizedSource(entry.objid,
                                      entry.pos[1],
                                      entry.pos[2],
                                      vp_vec[i][1])

--- a/src/joint_infer.jl
+++ b/src/joint_infer.jl
@@ -552,8 +552,7 @@ function one_node_joint_infer(config::Config, catalog, target_sources, neighbor_
     else
         for i = 1:n_sources
             entry = catalog[target_sources[i]]
-            result = OptimizedSource(entry.objid,
-                                     entry.pos[1],
+            result = OptimizedSource(entry.pos[1],
                                      entry.pos[2],
                                      vp_vec[i][1])
             push!(results, result)

--- a/src/model/light_source_model.jl
+++ b/src/model/light_source_model.jl
@@ -18,7 +18,6 @@ mutable struct CatalogEntry
     gal_angle::Float64
     gal_scale::Float64
     objid::String
-    thing_id::Int
 end
 
 

--- a/src/model/light_source_model.jl
+++ b/src/model/light_source_model.jl
@@ -17,7 +17,6 @@ mutable struct CatalogEntry
     gal_ab::Float64
     gal_angle::Float64
     gal_scale::Float64
-    objid::String
 end
 
 

--- a/test/SampleData.jl
+++ b/test/SampleData.jl
@@ -72,7 +72,7 @@ end
 
 function sample_ce(pos, is_star::Bool)
     CatalogEntry(pos, is_star, sample_star_fluxes, sample_galaxy_fluxes,
-        0.1, .7, pi/4, 4., "sample", 0)
+        0.1, .7, pi/4, 4., "sample")
 end
 
 
@@ -207,7 +207,7 @@ function gen_n_body_dataset(
     world_locations = WCS.pix_to_world(images0[3].wcs, locations)
 
     catalog = CatalogEntry[CatalogEntry(world_locations[:, s], true,
-            fluxes, fluxes, 0.1, .7, pi/4, 4., string(s), s) for s in 1:S];
+            fluxes, fluxes, 0.1, .7, pi/4, 4., string(s)) for s in 1:S];
 
     images = Synthetic.gen_blob(images0, catalog);
 

--- a/test/SampleData.jl
+++ b/test/SampleData.jl
@@ -72,7 +72,7 @@ end
 
 function sample_ce(pos, is_star::Bool)
     CatalogEntry(pos, is_star, sample_star_fluxes, sample_galaxy_fluxes,
-        0.1, .7, pi/4, 4., "sample")
+        0.1, 0.7, pi/4, 4.0)
 end
 
 
@@ -207,7 +207,7 @@ function gen_n_body_dataset(
     world_locations = WCS.pix_to_world(images0[3].wcs, locations)
 
     catalog = CatalogEntry[CatalogEntry(world_locations[:, s], true,
-            fluxes, fluxes, 0.1, .7, pi/4, 4., string(s)) for s in 1:S];
+            fluxes, fluxes, 0.1, 0.7, pi/4, 4.0) for s in 1:S];
 
     images = Synthetic.gen_blob(images0, catalog);
 

--- a/test/test_accuracy_benchmarks.jl
+++ b/test/test_accuracy_benchmarks.jl
@@ -45,7 +45,8 @@ end
     variational_params[Model.ids.is_star[1]] = 0.01
     variational_params[Model.ids.is_star[2]] = 0.99
 
-    data = AccuracyBenchmark.variational_parameters_to_data_frame_row("12345", variational_params)
+    data = AccuracyBenchmark.variational_parameters_to_data_frame_row(
+        variational_params)
     # we'll just check a few particularly troublesome parameters :)
     @test isapprox(data[1, :half_light_radius_px], 10 * sqrt(0.5))
     @test isapprox(data[1, :angle_deg], 135.0)

--- a/test/test_infer.jl
+++ b/test/test_infer.jl
@@ -132,8 +132,8 @@ end
     strategy = PlainFITSStrategy(datadir)
     images = SDSSIO.load_field_images(strategy, rcfs)
     catalog = SDSSIO.read_photoobj_files(strategy, rcfs)
-    entry_id = findfirst((ce)->ce.objid == "1237663143711147274", catalog)
-    entry = catalog[entry_id]
+
+    entry_id = 429  # star at RA, Dec = (309.49754066435867, 45.54976572870953)
 
     neighbors = Infer.find_neighbors([entry_id,], catalog, images)[1]
 


### PR DESCRIPTION
This removes the SDSS-specific `objid` and `thing_id` fields from the core of Celeste (primarily `CatalogEntry`). Mostly these were not used for anything, so this doesn't have much of an effect.

In the benchmarks, `objid` was sometimes used as an object index. It was necessary to have an object index when reshaping (`melt`ing or `stack`ing) DataFrames. However, it wasn't necessary for the index to be globally unique or meaningful. So here, I've replaced it with a simple running index (`1:length(catalog)`) within the catalog.

References to `objid`/`thing_id` still exist in the `SDSSIO` module which is totally fine. The code there has the ability to read tables with those fields, they're just not used by any of the rest of the code.