### PR TITLE
RawPSF with bicubic interpolation for stars

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -17,3 +17,4 @@ TranscodingStreams
 CodecBzip2
 CodecZlib
 NearestNeighbors
+Interpolations

--- a/src/DeterministicVI.jl
+++ b/src/DeterministicVI.jl
@@ -10,7 +10,7 @@ using ..BivariateNormals: BivariateNormalDerivatives, BvnComponent,
                           GalaxySigmaDerivs, get_bvn_cov, eval_bvn_pdf!,
                           get_bvn_derivs!, transform_bvn_derivs!
 using ..Model
-using ..Model: SkyPatch, BvnBundle, populate_fsm!
+using ..Model: SkyPatch, BvnBundle
 import ..Celeste: Const, @aliasscope, @unroll_loop
 using ..SensitiveFloats
 import ..Log

--- a/src/deterministic_vi/elbo_objective.jl
+++ b/src/deterministic_vi/elbo_objective.jl
@@ -357,15 +357,13 @@ function add_pixel_term!{NumType <: Number}(
                 elbo_vars.inactive_pixel_counter[] += 1
             end
 
-            populate_fsm!(bvn_bundle.bvn_derivs,
-                          elbo_vars.fs0m,
-                          elbo_vars.fs1m,
-                          s,
-                          SVector{2,Float64}(h, w),
-                          is_active_source,
-                          p.wcs_jacobian,
-                          bvn_bundle.gal_mcs,
-                          bvn_bundle.star_mcs)
+            Model.star_light_density!(elbo_vars.fs0m, p, h, w, vp[s][ids.pos], is_active_source)
+            Model.populate_gal_fsm!(elbo_vars.fs1m,
+                                    bvn_bundle.bvn_derivs,
+                                    s, h, w,
+                                    is_active_source,
+                                    p.wcs_jacobian,
+                                    bvn_bundle.gal_mcs)
 
             accumulate_source_pixel_brightness!(ea, vp, elbo_vars,
                 sbs[s], ea.images[n].b, s, is_active_source)

--- a/src/model/imaged_sources.jl
+++ b/src/model/imaged_sources.jl
@@ -1,3 +1,5 @@
+using Interpolations
+
 # Routines for observations of light sources in particular images,
 # rather than for sources in the abstract, in physical units,
 # and rather than for images alone (that's image_model.jl).
@@ -20,7 +22,7 @@ struct SkyPatch
     radius_pix::Float64
 
     psf::Vector{PsfComponent}
-    grid_psf::Matrix{Float32}
+    itp_psf::AbstractInterpolation
     wcs_jacobian::Matrix{Float64}
     pixel_center::Vector{Float64}
 
@@ -53,11 +55,12 @@ function SkyPatch(img::Image, ce::CatalogEntry; radius_override_pix=NaN)
     active_pixel_bitmap = trues(H2, W2)
 
     grid_psf = Model.eval_psf(img.raw_psf_comp, pixel_center[1], pixel_center[2])
+    itp_psf = interpolate(grid_psf, BSpline(Cubic(Line())), OnGrid())
 
     SkyPatch(world_center,
              radius_pix,
              img.psf,
-             grid_psf,
+             itp_psf,
              wcs_jacobian,
              pixel_center,
              SVector(hmin, wmin),

--- a/src/model/light_source_model.jl
+++ b/src/model/light_source_model.jl
@@ -1,6 +1,5 @@
 import JLD
 
-
 # The number of components in the color prior.
 const NUM_COLOR_COMPONENTS = 8
 

--- a/src/model/psf_model.jl
+++ b/src/model/psf_model.jl
@@ -122,5 +122,3 @@ function eval_psf(psf::RawPSF, x::Real, y::Real)
 
     return stamp
 end
-
-

--- a/test/SampleData.jl
+++ b/test/SampleData.jl
@@ -38,7 +38,7 @@ cd(wd)
 
 
 const sample_rcf = RunCamcolField(3900, 6, 269)
-const sample_images = load_field_images(PlainFITSStrategy(datadir),sample_rcf)
+const sample_images = load_field_images(PlainFITSStrategy(datadir), sample_rcf)
 
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,6 @@ using Celeste: Model, DeterministicVI
 
 import Celeste: DeterministicVI, ParallelRun
 import Celeste: PSF, SDSSIO, SensitiveFloats, Transform
-import Celeste.SensitiveFloats.clear!
 import Celeste.SDSSIO: RunCamcolField
 
 include(joinpath(Pkg.dir("Celeste"), "test", "SampleData.jl"))

--- a/test/test_optimization.jl
+++ b/test/test_optimization.jl
@@ -7,21 +7,6 @@ using Celeste.DeterministicVI: ElboArgs
 using Celeste.DeterministicVI.ElboMaximize: ElboConfig, maximize!, elbo_optim_options
 using Optim
 
-function verify_sample_star(vs, pos)
-    @test vs[ids.is_star[2]] <= 0.01
-
-    @test isapprox(vs[ids.pos[1]], pos[1], atol=0.1)
-    @test isapprox(vs[ids.pos[2]], pos[2], atol=0.1)
-
-    brightness_hat = exp(vs[ids.flux_loc[1]] + 0.5 * vs[ids.flux_scale[1]])
-    @test isapprox(brightness_hat / sample_star_fluxes[3], 1.0, atol=0.01)
-
-    true_colors = log.(sample_star_fluxes[2:5] ./ sample_star_fluxes[1:4])
-    for b in 1:4
-        @test isapprox(vs[ids.color_mean[b, 1]], true_colors[b], atol=0.2)
-    end
-end
-
 function verify_sample_galaxy(vs, pos)
     @test vs[ids.is_star[2]] >= 0.99
 
@@ -48,22 +33,7 @@ function verify_sample_galaxy(vs, pos)
     end
 end
 
-
 #########################################################
-
-function test_star_optimization()
-    ea, vp, catalog = gen_sample_star_dataset();
-
-    # Newton's method converges on a small galaxy unless we start with
-    # a high star probability.
-    vp[1][ids.is_star] = [0.8, 0.2]
-
-    cfg = ElboConfig(ea, vp; loc_width=1.0)
-    maximize!(ea, vp, cfg)
-
-    verify_sample_star(vp[1], [10.1, 12.2])
-end
-
 
 function test_single_source_optimization()
     ea, vp, catalog = gen_three_body_dataset();
@@ -100,18 +70,6 @@ function test_full_elbo_optimization()
 end
 
 
-function test_termination_callback()
-    ea, vp, catalog = gen_sample_galaxy_dataset(; include_kl = false);
-    terminated = false
-    callback = x -> (terminated = x.iteration >= 3; return terminated)
-    cfg = ElboConfig(ea, vp; termination_callback = callback)
-    _, _, _, result = maximize!(ea, vp, cfg)
-    return terminated && Optim.iterations(result) == 3
-end
-
-
-test_star_optimization()
 test_single_source_optimization()
 test_full_elbo_optimization()
 test_galaxy_optimization()
-test_termination_callback()


### PR DESCRIPTION
This PR brings the percent of stars misclassified as galaxies (`missed_stars`) down from ~31% to ~8% -- right in line with Photo. Apparently our Mixture of Gaussians PSF really was very bad. It's still in use for galaxies, but I can get rid of that in later work. 

From `master`:
```
│ Row │ N   │ first     │ second    │ diff       │ diff_sd    │ field                         │
├─────┼─────┼───────────┼───────────┼────────────┼────────────┼───────────────────────────────┤
│ 1   │ 481 │ 0.0       │ 0.0       │ 0.0        │ 0.0        │ is_saturated                  │
│ 2   │ 128 │ 0.078125  │ 0.3125    │ -0.234375  │ 0.0405416  │ missed_stars                  │
│ 3   │ 353 │ 0.0396601 │ 0.0396601 │ 0.0        │ 0.00965877 │ missed_galaxies               │
│ 4   │ 481 │ 0.267953  │ 0.26437   │ 0.00358313 │ 0.00623836 │ position                      │
│ 5   │ 481 │ 0.179437  │ 0.177197  │ 0.00224041 │ 0.0100144  │ reference_band_flux_mag       │
│ 6   │ 481 │ 1.11384   │ 1.72663   │ -0.612792  │ 0.338765   │ reference_band_flux_nmgy      │
│ 7   │ 105 │ 16.9819   │ 14.979    │ 2.00284    │ 1.44225    │ angle_deg                     │
│ 8   │ 211 │ 0.260781  │ 0.187767  │ 0.0730141  │ 0.0210781  │ de_vaucouleurs_mixture_weight │
│ 9   │ 211 │ 0.199889  │ 0.144968  │ 0.0549212  │ 0.0103371  │ minor_major_axis_ratio        │
│ 10  │ 211 │ 1.29034   │ 0.614865  │ 0.675474   │ 0.331621   │ half_light_radius_px          │
│ 11  │ 370 │ 1.03077   │ 0.56432   │ 0.466447   │ 0.0499466  │ color_log_ratio_ug            │
│ 12  │ 472 │ 0.338688  │ 0.17356   │ 0.165128   │ 0.0203928  │ color_log_ratio_gr            │
│ 13  │ 480 │ 0.201699  │ 0.118033  │ 0.0836664  │ 0.00985499 │ color_log_ratio_ri            │
│ 14  │ 476 │ 0.387063  │ 0.180376  │ 0.206687   │ 0.0221786  │ color_log_ratio_iz            │
```

From `jcr/interpolations` (this PR):
```
14×6 DataFrames.DataFrame
│ Row │ N   │ first     │ second    │ diff        │ diff_sd    │ field                         │
├─────┼─────┼───────────┼───────────┼─────────────┼────────────┼───────────────────────────────┤
│ 1   │ 482 │ 0.0       │ 0.0       │ 0.0         │ 0.0        │ is_saturated                  │
│ 2   │ 129 │ 0.0775194 │ 0.0775194 │ 0.0         │ 0.0213178  │ missed_stars                  │
│ 3   │ 353 │ 0.0396601 │ 0.0509915 │ -0.0113314  │ 0.010402   │ missed_galaxies               │
│ 4   │ 482 │ 0.267632  │ 0.265964  │ 0.00166788  │ 0.00634124 │ position                      │
│ 5   │ 482 │ 0.179185  │ 0.187796  │ -0.00861089 │ 0.013311   │ reference_band_flux_mag       │
│ 6   │ 482 │ 1.13222   │ 2.14602   │ -1.01381    │ 0.483521   │ reference_band_flux_nmgy      │
│ 7   │ 105 │ 16.9819   │ 15.5799   │ 1.40192     │ 1.31291    │ angle_deg                     │
│ 8   │ 211 │ 0.260781  │ 0.187022  │ 0.0737584   │ 0.0215299  │ de_vaucouleurs_mixture_weight │
│ 9   │ 211 │ 0.199889  │ 0.145787  │ 0.0541026   │ 0.0103492  │ minor_major_axis_ratio        │
│ 10  │ 211 │ 1.29034   │ 0.612578  │ 0.677761    │ 0.331698   │ half_light_radius_px          │
│ 11  │ 371 │ 1.0283    │ 0.575659  │ 0.452643    │ 0.0498698  │ color_log_ratio_ug            │
│ 12  │ 473 │ 0.338041  │ 0.175434  │ 0.162607    │ 0.0204756  │ color_log_ratio_gr            │
│ 13  │ 481 │ 0.201293  │ 0.126392  │ 0.0749017   │ 0.0124566  │ color_log_ratio_ri            │
│ 14  │ 477 │ 0.386288  │ 0.189743  │ 0.196545    │ 0.0235967  │ color_log_ratio_iz            │
```