### PR TITLE
require FITSIO v0.11.0 (fixes depwarns)

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -4,7 +4,7 @@ Compat 0.18.0
 DataFrames
 DataStructures 0.7.0
 Distributions
-FITSIO 0.8.4
+FITSIO 0.11.0
 DiffBase 0.0.3
 ForwardDiff 0.3.4 0.5
 ReverseDiff 0.1.1 0.1.3


### PR DESCRIPTION
Merge after JuliaLang/METADATA.jl#11389 is closed.

Closes #698.