### PR TITLE
RawPSF -> AbstractPSFMap in Image

### DIFF
--- a/src/Model.jl
+++ b/src/Model.jl
@@ -9,7 +9,7 @@ export Image, SkyPatch, PsfComponent,
        GalaxyComponent, GalaxyPrototype,
        PriorParams, CanonicalParams, BrightnessParams, StarPosParams,
        GalaxyPosParams, GalaxyShapeParams,
-       PsfParams, RawPSF, CatalogEntry,
+       PsfParams, CatalogEntry,
        ParamSet, SkyIntensity
 
 # functions

--- a/src/ParallelRun.jl
+++ b/src/ParallelRun.jl
@@ -56,7 +56,7 @@ Arguments:
 """
 function find_neighbors(target_sources::Vector{Int64},
                         catalog::Vector{CatalogEntry},
-                        images::Vector{Image})
+                        images::Vector{<:Image})
     psf_width_ub = zeros(NUM_BANDS)
     for img in images
         psf_width = Model.get_psf_width(img.psf)
@@ -111,7 +111,7 @@ Non-standard arguments:
   noise_fraction: The proportion of the noise below which we will remove pixels.
 """
 function load_active_pixels!(config::Config,
-                             images::Vector{Image},
+                             images::Vector{<:Image},
                              patches::Matrix{SkyPatch};
                              exclude_nan=true,
                              noise_fraction=0.5)
@@ -154,7 +154,7 @@ function load_active_pixels!(config::Config,
 end
 
 # legacy wrapper
-function load_active_pixels!(images::Vector{Image},
+function load_active_pixels!(images::Vector{<:Image},
                              patches::Matrix{SkyPatch};
                              exclude_nan=true,
                              noise_fraction=0.5)
@@ -516,7 +516,7 @@ function process_source(config::Config,
                         catalog::Vector{CatalogEntry},
                         target_sources::Vector{Int},
                         neighbor_map::Vector{Vector{Int}},
-                        images::Vector{Image})
+                        images::Vector{<:Image})
     neighbors = catalog[neighbor_map[ts]]
     if length(neighbors) > 100
         msg = string("object at RA, Dec = $(entry.pos) has an excessive",
@@ -551,7 +551,7 @@ callback and write the results to a file.
 function one_node_single_infer(catalog::Vector{CatalogEntry},
                                target_sources::Vector{Int},
                                neighbor_map::Vector{Vector{Int}},
-                               images::Vector{Image};
+                               images::Vector{<:Image};
                                config=Config())
     curr_source = 1
     last_source = length(target_sources)

--- a/src/Synthetic.jl
+++ b/src/Synthetic.jl
@@ -72,7 +72,7 @@ end
 Generate a synthetic images based on a vector of catalog entries using
 identity world coordinates.
 """
-function gen_images!(images::Vector{Image}, n_bodies::Vector{CatalogEntry}; expectation=false)
+function gen_images!(images::Vector{<:Image}, n_bodies::Vector{CatalogEntry}; expectation=false)
     for img in images
         gen_image!(img, n_bodies; expectation=expectation)
     end

--- a/src/deterministic_vi/elbo_args.jl
+++ b/src/deterministic_vi/elbo_args.jl
@@ -175,7 +175,7 @@ struct ElboArgs
 
     # The number of components in the point spread function.
     psf_K::Int64
-    images::Vector{Image}
+    images::Vector{<:Image}
 
     # subimages is a better name for patches: regions of an image
     # around a particular light source
@@ -190,7 +190,7 @@ end
 
 
 function ElboArgs(
-            images::Vector{Image},
+            images::Vector{<:Image},
             patches::Matrix{SkyPatch},
             active_sources::Vector{Int};
             psf_K::Int=2,

--- a/src/joint_infer.jl
+++ b/src/joint_infer.jl
@@ -493,7 +493,7 @@ function init_elboargs(config::Config,
                        catalog::Vector{CatalogEntry},
                        target_sources::Vector{Int},
                        neighbor_map::Vector{Vector{Int}},
-                       images::Vector{Image},
+                       images::Vector{<:Image},
                        ea_vec::Vector{ElboArgs},
                        vp_vec::Vector{VariationalParams{Float64}},
                        cfg_vec::Vector{ElboConfig{DEFAULT_CHUNK,Float64}},
@@ -531,7 +531,7 @@ function init_elboargs(config::Config,
 end
 
 
-function process_sources!(images::Vector{Model.Image},
+function process_sources!(images::Vector{<:Model.Image},
                           ea_vec::Vector{ElboArgs},
                           vp_vec::Vector{VariationalParams{Float64}},
                           cfg_vec::Vector{ElboConfig{DEFAULT_CHUNK,Float64}},
@@ -564,7 +564,7 @@ function process_sources!(images::Vector{Model.Image},
     end
 end
 
-function process_sources_dynamic!(images::Vector{Model.Image},
+function process_sources_dynamic!(images::Vector{<:Model.Image},
                                   ea_vec::Vector{ElboArgs},
                                   vp_vec::Vector{VariationalParams{Float64}},
                                   cfg_vec::Vector{ElboConfig{DEFAULT_CHUNK,Float64}},

--- a/src/model/image_model.jl
+++ b/src/model/image_model.jl
@@ -61,7 +61,7 @@ end
 
 
 """An image, taken though a particular filter band"""
-mutable struct Image
+mutable struct Image{T <: AbstractPSFMap}
     # The image height.
     H::Int
 
@@ -82,9 +82,9 @@ mutable struct Image
 
     # SDSS-specific identifiers. A field is a particular region of the sky.
     # A Camcol is the output of one camera column as part of a Run.
-    run_num::Int
-    camcol_num::Int
-    field_num::Int
+    run_num::Int16
+    camcol_num::UInt8
+    field_num::Int16
 
     # The background noise in nanomaggies. (varies by position)
     sky::SkyIntensity
@@ -93,9 +93,10 @@ mutable struct Image
     # by a source 1 nanomaggie in brightness. (varies by row)
     nelec_per_nmgy::Array{Float32, 1}
 
-    # storing a RawPSF here isn't ideal, because it's an SDSS type
-    # not a Celeste type
-    raw_psf_comp::RawPSF
+    # The image PSF map: a callable f(x, y) -> Matrix that takes a pixel
+    # coordinate and returns the rasterized PSF image at that coordinate,
+    # with the PSF centered in the image.
+    psfmap::T
 end
 
 

--- a/src/model/imaged_sources.jl
+++ b/src/model/imaged_sources.jl
@@ -54,7 +54,7 @@ function SkyPatch(img::Image, ce::CatalogEntry; radius_override_pix=NaN)
     # all pixels are active by default
     active_pixel_bitmap = trues(H2, W2)
 
-    grid_psf = Model.eval_psf(img.raw_psf_comp, pixel_center[1], pixel_center[2])
+    grid_psf = img.psfmap(pixel_center[1], pixel_center[2])
     grid_psf[:, :] = max.(grid_psf, 0.0)
     grid_psf += 1e-6
     grid_psf /= sum(grid_psf)
@@ -77,7 +77,7 @@ function SkyPatch(img::Image, ce::CatalogEntry; radius_override_pix=NaN)
 end
 
 
-function get_sky_patches(images::Vector{Image},
+function get_sky_patches(images::Vector{<:Image},
                          catalog::Vector{CatalogEntry};
                          radius_override_pix=NaN)
     N = length(images)

--- a/src/model/log_prob.jl
+++ b/src/model/log_prob.jl
@@ -25,7 +25,7 @@ Returns:
   - star_logprior: star param log prior function handle that takes in same
                    flat, unconstrained array as parameter
 """
-function make_star_logpdf(images::Vector{Image},
+function make_star_logpdf(images::Vector{<:Image},
                           S::Int64,
                           N::Int64,
                           source_params::Vector{Vector{Float64}},
@@ -75,7 +75,7 @@ Returns:
   - gal_logprior: star param log prior function handle that takes in same
                  flat, unconstrained array as parameter
 """
-function make_galaxy_logpdf(images::Vector{Image},
+function make_galaxy_logpdf(images::Vector{<:Image},
                             S::Int64,
                             N::Int64,
                             source_params::Vector{Vector{Float64}},
@@ -134,7 +134,7 @@ function state_log_likelihood(is_star::Bool,                # source is star
                               colors::Vector{Float64},      # source vector of colors
                               position::Vector{Float64},    # source position
                               gal_shape::Vector{Float64},   # source gal shape
-                              images::Vector{Image},   # list of images with source pixel data
+                              images::Vector{<:Image},   # list of images with source pixel data
                               patches::Matrix{SkyPatch},    # formerly of ElboArgs
                               active_sources::Vector{Int},  # formerly of ElboArgs
                               psf_K::Int64,                 # number of PSF Comps

--- a/src/model/psf_model.jl
+++ b/src/model/psf_model.jl
@@ -29,38 +29,6 @@ struct PsfComponent
 end
 
 
-"""
-SDSS representation of a spatially variable PSF. The PSF is represented as
-a weighted combination of eigenimages (stored in `rrows`), where the weights
-vary smoothly across the image as a polynomial of the form
-
-```
-weight[k](x, y) = sum_{i,j} cmat[i, j, k] * (rcs * x)^i (rcs * y)^j
-```
-
-where `rcs` is a coordinate transformation and `x` and `y` are zero-indexed.
-"""
-struct RawPSF
-    rrows::Array{Float64,2}  # A matrix of flattened eigenimages.
-    rnrow::Int  # The number of rows in an eigenimage.
-    rncol::Int  # The number of columns in an eigenimage.
-    cmat::Array{Float64,3}  # The coefficients of the weight polynomial
-
-    function RawPSF(rrows::Array{Float64, 2}, rnrow::Integer, rncol::Integer,
-                     cmat::Array{Float64, 3})
-        # rrows contains eigen images. Each eigen image is along the first
-        # dimension in a flattened form. Check that dimensions match up.
-        @assert size(rrows, 1) == rnrow * rncol
-
-        # The second dimension is the number of eigen images, which should
-        # match the number of coefficient arrays.
-        @assert size(rrows, 2) == size(cmat, 3)
-
-        return new(rrows, Int(rnrow), Int(rncol), cmat)
-    end
-end
-
-
 function get_psf_width(psf::Array{PsfComponent}; width_scale=1.0)
     # A heuristic measure of the PSF width based on an anology
     # with it being a mixture of normals.    Note that it is not an actual
@@ -85,40 +53,43 @@ end
 
 
 """
-psf(x, y)
+    render_psf(psf, dims)
 
-Evaluate the PSF at the given image coordinates. The size of the result is
-will be `(psf.rnrow, psf.rncol)`, with the PSF (presumably) centered in the
-stamp.
-
-This function was originally based on the function sdss_psf_at_points
-in astrometry.net:
-https://github.com/dstndstn/astrometry.net/blob/master/util/sdss_psf.py
+Render a Celeste PSF on a grid of size `dims`. The PSF is centered in the
+grid, with center coordinates `(dims[1]+1) / 2, (dims[2]+1) / 2`.
 """
-function eval_psf(psf::RawPSF, x::Real, y::Real)
-    const RCS = 0.001  # A coordinate transform to keep polynomial
-                       # coefficients to a reasonable size.
-    nk = size(psf.rrows, 2)  # number of eigen images.
-
-    # initialize output stamp
-    stamp = zeros(psf.rnrow, psf.rncol)
-
-    # Loop over eigen images
-    for k=1:nk
-        # calculate the weight for the k-th eigen image from psf.cmat.
-        # Note that the image coordinates and coefficients are intended
-        # to be zero-indexed.
-        w = 0.0
-        for j=1:size(psf.cmat, 2), i=1:size(psf.cmat, 1)
-            w += (psf.cmat[i, j, k] *
-                  (RCS * (x - 1.0))^(i-1) * (RCS * (y - 1.0))^(j-1))
-        end
-
-        # add the weighted k-th eigen image to the output stamp
-        for i=1:length(stamp)
-            stamp[i] += w * psf.rrows[i, k]
+function render_psf(psf::Array{PsfComponent}, dims::Tuple{Int, Int})
+    center = ((dims[1]+1) / 2, (dims[2]+1) / 2)
+    stamp = zeros(dims)
+    x = zeros(2)
+    for pc in psf
+        bvn = MultivariateNormal(convert(Array, pc.xiBar),
+                                 convert(Array, pc.tauBar))
+        for j in 1:dims[2], i in 1:dims[1]
+            x[1] = i - center[1]
+            x[2] = j - center[2]
+            stamp[i, j] += pc.alphaBar * pdf(bvn, x)
         end
     end
-
     return stamp
 end
+
+
+"""
+    AbstractPSFMap
+
+Subtypes are callables that return a PSF stamp given pixel position.
+"""
+abstract type AbstractPSFMap end
+
+
+"""
+    ConstantPSFMap <: AbstractPSFMap
+
+A non-variable PSF map: calling an instance returns the same PSF stamp
+regardless of arguments.
+"""
+struct ConstantPSFMap <: AbstractPSFMap
+    stamp::Matrix{Float64}
+end
+(psfmap::ConstantPSFMap)(x, y) = copy(psfmap.stamp)

--- a/test/SampleData.jl
+++ b/test/SampleData.jl
@@ -45,7 +45,7 @@ const sample_images = load_field_images(PlainFITSStrategy(datadir), sample_rcf)
 Turn a images and vector of catalog entries into elbo arguments
 that can be used with Celeste.
 """
-function make_elbo_args(images::Vector{Image},
+function make_elbo_args(images::Vector{<:Image},
                         catalog::Vector{CatalogEntry};
                         active_source=-1,
                         patch_radius_pix::Float64=NaN,


### PR DESCRIPTION
This is a step in making the core of Celeste independent of the SDSS data model.

It Makes the `Image` type parametric in the last attribute (formerly called a `RawPSF`) which represents the rasterized PSF as a function of position in the image.  `Image` can now contain any type of `AbstractPSFMap`, which has one job: to return a rasterized PSF model, given a pixel position. This allows for different implementations, such as `SDSSPSFMap`, or `ConstantPSFMap` (a non-varying PSF), or any other survey's PSF representation, without any of the rest of Celeste knowing the type or the implementation.

The alternative to this would be fitting a spatially variable version of Celeste's PSF model (`Vector{PsfComponent}`) and storing that in `Image`. (That would be cleaner in some ways and can of course still be done in the future.)

Note: most of the big blocks of changes here are simply moving code around: the SDSS specific PSF has moved to SDSSIO.jl for example.