### PR TITLE
ais inference

### DIFF
--- a/src/MCMC.jl
+++ b/src/MCMC.jl
@@ -1,7 +1,8 @@
 module MCMC
 
 using Celeste: Model, Transform, SensitiveFloats
-import Celeste.Model: SkyPatch, SDSSBackground, Image
+import Celeste.Model: SkyPatch, Image
+import Celeste.SDSSIO: SDSSBackground
 using Distributions, StatsBase, DataFrames, StaticArrays, WCS
 import Celeste: Config
 

--- a/src/MCMC.jl
+++ b/src/MCMC.jl
@@ -1,7 +1,7 @@
 module MCMC
 
 using Celeste: Model, Transform, SensitiveFloats
-import Celeste.Model: SkyPatch, SkyIntensity, Image
+import Celeste.Model: SkyPatch, SDSSBackground, Image
 using Distributions, StatsBase, DataFrames, StaticArrays, WCS
 import Celeste: Config
 

--- a/src/MCMC.jl
+++ b/src/MCMC.jl
@@ -1,7 +1,9 @@
 module MCMC
 
-using Celeste: Model, Transform, SensitiveFloats, MCMC
+using Celeste: Model, Transform, SensitiveFloats
+import Celeste.Model: SkyPatch, SkyIntensity, Image
 using Distributions, StatsBase, DataFrames, StaticArrays, WCS
+import Celeste: Config
 
 # TODO move these to model/log_prob.jl
 star_param_names = ["lnr", "cug", "cgr", "cri", "ciz", "ra", "dec"]
@@ -10,10 +12,14 @@ galaxy_param_names = [star_param_names; ["gdev", "gaxis", "gangle", "gscale"]]
 # functions to create star/gal log likelihoods
 include("mcmc/mcmc_functions.jl")
 
-# slice sampling function
+# slice sampling and annealed importance sampling implementations
 include("mcmc/slicesample.jl")
+include("mcmc/ais.jl")
 
 # misc MCMC functions
 include("mcmc/mcmc_misc.jl")
+
+# functions to run star/gal AIS, and combine inferences
+include("mcmc/mcmc_infer.jl")
 
 end

--- a/src/ParallelRun.jl
+++ b/src/ParallelRun.jl
@@ -580,7 +580,9 @@ function process_source_mcmc(config::Config,
 
     # run mcmc sampler on this image/patch/background initialized at entry
     if use_ais
-        mcmc_results = MCMC.run_ais(entry, patch_images, patches, background_images)
+        mcmc_results = MCMC.run_ais(entry, patch_images, patches, background_images;
+            num_temperatures=config.num_ais_temperatures,
+            num_samples=config.num_ais_samples)
     else
         mcmc_results = MCMC.run_mcmc(entry, patch_images, patches, background_images)
     end

--- a/src/config.jl
+++ b/src/config.jl
@@ -2,6 +2,13 @@
 struct Config
     # A minimum pixel radius to be included around each source.
     min_radius_pix::Float64
+
+    # number of temperatures (for annealed importance sampling)
+    num_ais_temperatures::Int64
+
+    # number of independent AIS samples
+    num_ais_samples::Int64
 end
 
-Config() = Config(8.0)
+Config() = Config(8.0, 50, 10)
+Config(min_radius_pix) = Config(min_radius_pix, 50, 10)

--- a/src/mcmc/ais.jl
+++ b/src/mcmc/ais.jl
@@ -1,0 +1,143 @@
+"""
+Annealed Importance Sampling. Estimate the partition function of lnpdf
+
+Args:
+    - lnpdf     : target distribution unnomralized log prob.  Potentially
+                  vectorized --- takes in z = D-dimensional tensor, outputs
+                  joint log prob
+    - lnpdf0    : initial distribution log likelihood --- same input and
+                  output as lnpdf
+    - z0        : D-dimensional initial sample
+    - step      : function that takes in a current state and an
+                  unnormalized log probability function, performs
+                  an MCMC transition (in place)
+    - init_logZ : (optional) initial log partition (unused for now)
+    - schedule  : temperature schedule, monotonically increasing from 0 to 1
+"""
+function ais(lnpdf, lnpdf0, step, z0;
+             init_logZ=nothing, schedule=nothing, verbose=false)
+    # set up initial log partition function for p(z) --- should be ln(1) = 0
+    D = length(z0)
+
+    # set up and check schedule
+    if schedule == nothing
+        schedule = collect(linspace(0, 1, 10))   # default to 10 steps ...
+    end
+    @assert(isapprox(schedule[1], 0.), "schedule must start with temp = 0.")
+    @assert(isapprox(schedule[end], 1.), "schedule must end with temp = 1.")
+
+    # set up function that returns intermediate distributions
+    function lnpdf_t(z, t)
+        # do this to catch the 0 * -Inf = NaN cases
+        if t==0.
+            return lnpdf0(z)
+        elseif t==1.
+            return lnpdf(z)
+        end
+        return t*lnpdf(z) + (1.-t)*lnpdf0(z)
+    end
+
+    # run AIS: track the ratio at each step, and current z
+    z = deepcopy(z0)
+    llratios = zeros(length(schedule) - 1)
+    accepted = 0.
+    for ti in 2:length(schedule)
+        # unpack previous and current temperatures
+        tprev, tcurr = schedule[ti-1], schedule[ti]
+        if ti % 25 == 0
+            @printf "  temp %2.3f (%d/%d): logpost = %2.4f  logprior = %2.4f\n" tcurr ti length(schedule) lnpdf(z) lnpdf0(z)
+        end
+
+        # generate zt | zt-1 using tcurr --- this leaves the distribution
+        #   lnp_t = tcurr*lnpdf(z) + (1-tcurr)*lnpdf0(0) invariant
+        z, _ = step(z, z -> lnpdf_t(z, tcurr))  # returns z, and aux info
+
+        # record log ratio of distributions
+        llprev = lnpdf_t(z, tprev)
+        llcurr = lnpdf_t(z, tcurr)
+        llratios[ti-1] = llcurr - llprev
+    end
+
+    # return z (final posterior sample) and weight
+    return z, sum(llratios), llratios, float(accepted)/(length(schedule))
+end
+
+
+"""broadcasting logsumexp"""
+function logsumexp(mat; dim=1)
+    max_score = maximum(mat, dim)
+    lse = log.(sum(exp.(broadcast(-, mat, max_score)), dim))
+    return broadcast(+, lse, max_score)
+end
+
+
+""" compute a bootstrap sample of the normalizing constant """
+function bootstrap_lnZ(lnZ_samps; num_bootstrap=100)
+    lnZ    = zeros(num_bootstrap)
+    nsamps = length(lnZ_samps)
+    for n in 1:num_bootstrap
+        boot_sample = [lnZ_samps[rand(1:nsamps)] for n in 1:nsamps]
+        lnZ[n]      = logsumexp(boot_sample)[1] - log(nsamps)
+    end
+    return lnZ
+end
+
+
+""" copy of sigmoid schedule from https://github.com/tonywu95/eval_gen/blob/master/algorithms/ais.py
+This is defined as:
+      gamma_t = sigma(rad * (2t/T - 1))
+      beta_t = (gamma_t - gamma_1) / (gamma_T - gamma_1),
+where sigma is the logistic sigmoid. This schedule allocates more distributions near
+the inverse temperature 0 and 1, since these are often the places where the distributon
+changes the fastest.
+"""
+function sigmoid_schedule(num_steps; rad=4)
+    if num_steps == 1
+        return collect(linspace(0, 1, 2))
+    end
+    t    = collect(linspace(-rad, rad, num_steps))
+    sigm = 1. ./ (1. .+ exp.(-t))
+    return (sigm - minimum(sigm)) / (maximum(sigm) - minimum(sigm))
+end
+
+
+""" Run AIS multiple times to get multiple posterior samples, and a tighter
+marginal likelihood estimate """
+function ais_slicesample(logposterior::Function,
+                         logprior::Function,
+                         prior_sample::Function;
+                         schedule::Array{Float64,1}=nothing,
+                         num_temps::Int=50,
+                         num_samps::Int=10,
+                         num_bootstrap::Int=5000,
+                         num_samples_per_step::Int=1)
+    if schedule == nothing
+        schedule = sigmoid_schedule(num_temps; rad=1)
+    end
+
+    function step(z, lnpdf)
+        for i in 1:num_samples_per_step
+            z, llh = MCMC.slicesample(z, lnpdf)
+        end
+        return z, 0.
+    end
+
+    D = length(prior_sample())
+    zsamps = zeros(D, num_samps)
+    wsamps = zeros(num_samps)
+    for n in 1:num_samps
+        @printf "ais samp %d / %d\n" n num_samps
+        z0   = prior_sample()
+        #step = (z, lnpdf) -> MCMC.slicesample(z, lnpdf)
+        z, w, llrats, _ = ais(logposterior, logprior, step, z0; schedule=schedule)
+        zsamps[:,n] = z
+        wsamps[n]   = w
+    end
+
+    # estimate the partition function and get a bootstrap confidence interval
+    lnZ  = logsumexp(wsamps, dim=1)[1] - log(num_samps)
+    lnZs = bootstrap_lnZ(wsamps; num_bootstrap=num_bootstrap)
+    res = Dict(:lnZ => lnZ, :lnZ_bootstrap => lnZs,
+               :zsamps => zsamps, :lnZsamps => wsamps)
+    return res
+end

--- a/src/mcmc/mcmc_functions.jl
+++ b/src/mcmc/mcmc_functions.jl
@@ -1,4 +1,98 @@
 """
+Make all star inference functiouns: prior, loglike, log (unnormalized) posterior.
+"""
+function make_star_inference_functions(imgs::Array{Image},
+          entry::CatalogEntry;
+          pos_delta::Array{Float64, 1}=[2., 2.],
+          patches::Array{SkyPatch, 1}=nothing,
+          background_images::Array{Array{Float64, 2}, 1}=nothing)
+    # position log prior --- same for both star and galaxy (constrains to a 
+    # small window around the existing catalog location.  Because the range
+    # of RA,DEC values is so small, numerical underflow becomes an issue in
+    # the slice sampler.  The generic parameter representation of the (ra,dec)
+    # position of the sampler will be on [0, 1]^2.  We transform this value
+    # before feeding it into the likelihood (but slice sampler machineary will
+    # be on the scale of [0, 1]).
+    pos_logprior, ra_lim, dec_lim, uniform_to_deg, deg_to_uniform =
+        make_location_prior(imgs[1], entry.pos; pos_pixel_delta=pos_delta)
+
+    # star parameters are [lnfluxes, upos]
+    loglike = make_star_loglike(imgs;
+                                patches=patches,
+                                background_images=background_images,
+                                pos_transform=uniform_to_deg)
+
+    function logprior(th)
+        lnfluxes, pos = th[1:5], uniform_to_deg(th[6:end])
+        return logflux_logprior(lnfluxes; is_star=true) +
+               pos_logprior(pos)
+    end
+
+    function sample_prior()
+        lnfluxes = sample_logfluxes(; is_star=true)
+        pos      = rand(2)
+        return [lnfluxes..., pos...]
+    end
+
+    function logpost(th)
+        llprior = logprior(th)
+        if llprior < -1e100
+            return llprior
+        end
+        return loglike(th) + llprior
+    end
+
+    # quick test
+    return loglike, logprior, logpost, sample_prior,
+           ra_lim, dec_lim, uniform_to_deg, deg_to_uniform
+end
+
+
+"""
+Make all star inference functiouns: prior, loglike, log (unnormalized) posterior.
+"""
+function make_gal_inference_functions(imgs::Array{Image},
+          entry::CatalogEntry;
+          pos_delta::Array{Float64, 1}=[2., 2.],
+          patches::Array{SkyPatch, 1}=nothing,
+          background_images::Array{Array{Float64, 2}, 1}=nothing)
+    # constrained location prior (same as above)
+    pos_logprior, ra_lim, dec_lim, uniform_to_deg, deg_to_uniform =
+        make_location_prior(imgs[1], entry.pos; pos_pixel_delta=pos_delta)
+
+    # gal parameters are [lnfluxes, upos, gal_shape]
+    loglike = make_gal_loglike(imgs;
+                               patches=patches,
+                               background_images=background_images,
+                               pos_transform=uniform_to_deg)
+    gal_logprior = make_gal_logprior()
+    function logprior(th)
+        _, pos, _ = th[1:5], uniform_to_deg(th[6:7]), th[8:end]
+        return gal_logprior(th) + pos_logprior(pos)
+    end
+
+    #th_cat = parameters_from_catalog(entry; is_star=false)
+    #cat_shape = th_cat[8:end]
+    function sample_prior()
+        lnfluxes = sample_logfluxes(; is_star=false)
+        pos = rand(2)
+        shape = sample_galaxy_shape()
+        return [lnfluxes..., pos..., shape...]
+    end
+
+    function logpost(th)
+        llprior = logprior(th)
+        if llprior < -1e100
+            return llprior
+        end
+        return loglike(th) + llprior
+    end
+    return loglike, logprior, logpost, sample_prior,
+           ra_lim, dec_lim, uniform_to_deg, deg_to_uniform
+end
+
+
+"""
 Star log likelihood maker.  Creates a star log prob function that is
 parameterized by a flat vector
 
@@ -6,52 +100,87 @@ parameterized by a flat vector
 
 Args:
   imgs: Array of observed data Images with the .pixel field
-  pos0: Initial location of the source in ra/dec
-  pos_delta: (optional) determines how much ra/dec we allow the sampler
-    to drift away from pos0
+  patches...
+  background_images...
+  pos_transform....
+  use_raw_psf: use patch provided raw psf that interpolates on a grid as 
+    appearance model, not the MOG approximation
 """
-function make_star_loglike(imgs::Array{Image},
-                           pos0::Array{Float64, 1};
-                           pos_delta::Array{Float64, 1}=[1., 1.])
-
-    # create a function that constrains the pixel location to be within
-    # pos0 +- [pos_delta]
-    constrain_pos, unconstrain_pos =
-        make_position_transformations(pos0, pos_delta)
-
-    function star_loglike(th::Array{Float64, 1})
-
-      # unpack location and log fluxes (smushed)
-      lnfluxes, unc_pos = th[1:5], th[6:end]
-      pos = constrain_pos(unc_pos)
-
-      ll = 0.
-      for img in imgs
-
-          # sky pixel intensity (sky image)
-          epsilon    = img.sky[1, 1]
-          iota       = img.nelec_per_nmgy[1]
-          sky_pixels = [epsilon * iota for h=1:img.H, w=1:img.W]
-
-          # create and cache unit flux src image
-          #src_pixels = [0. for h=1:img.H, w=1:img.W]
-          src_pixels = zeros(img.H, img.W)
-          write_star_unit_flux(img, pos, src_pixels)
-
-          # compute model image
-          rates = sky_pixels .+ (exp(lnfluxes[img.b])*src_pixels)
-
-          # sum per-pixel likelihood contribution
-          H, W = size(rates)
-          for h in 1:H, w in 1:W
-              ll += poisson_lnpdf(img.pixels[h,w], rates[h,w])
-          end
-
-      end
-    return ll
+function make_star_loglike(imgs::Array{Image};
+                           patches::Array{SkyPatch, 1}=nothing,
+                           background_images::Array{Array{Float64, 2}, 1}=nothing,
+                           pos_transform::Function=nothing,
+                           use_raw_psf=false)
+    # create background images --- sky noise and neighbors if there
+    if background_images == nothing
+        background_images = make_empty_background_images(imgs)
     end
 
-    return star_loglike, constrain_pos, unconstrain_pos
+    # patch offset (0 if no patches passed in)
+    if patches == nothing
+        offsets = zeros(2, length(imgs))
+        active_bitmaps = [BitArray(ones(img.H, img.W)) for img in imgs]
+    else
+        offsets = hcat([convert(Array{Float64, 1}, p.bitmap_offset) - 1.
+                        for p in patches]...)
+        active_bitmaps = [p.active_pixel_bitmap for p in patches]
+    end
+
+    # cache the log(data!) term (lgamma in poisson lnpdf) --- this call is
+    # a fixed constant wrt params, and only enters into the likelihood
+    # as a sum, so we can compute it here and cache it
+    lgamma_const = compute_lgamma_sum(imgs, active_bitmaps)
+
+    # create iota vecs --- number of elecs per nanomaggy fo reach image
+    nelec_per_nmgy_vec = [Float64(median(img.nelec_per_nmgy)) for img in imgs]
+
+    # create function to return
+    function star_loglike(th::Array{Float64, 1})
+
+        # unpack log fluxes and location (ra, dec)
+        lnfluxes, pos = th[1:5], th[6:end]
+        if pos_transform != nothing
+            pos = pos_transform(pos)
+        end
+
+        ll = 0.
+        for ii in 1:length(imgs)
+            img, active_bitmap = imgs[ii], active_bitmaps[ii]
+
+            # sky pixel intensity (sky image)
+            background = background_images[ii]
+
+            # create and cache unit flux src image
+            src_pixels = zeros(img.H, img.W)
+            iota = nelec_per_nmgy_vec[ii]
+            if use_raw_psf
+                write_star_unit_flux_raw(pos, patches[ii], iota, src_pixels)
+            else
+                write_star_unit_flux(pos, img.psf, img.wcs, iota, src_pixels,
+                                     offset=offsets[:,ii])
+            end
+
+            # band-specific flux --- do bounds check
+            bflux = exp(lnfluxes[img.b])
+            if isinf(bflux)  # if bflux overflows, then return -Inf logprob
+                return -Inf
+            end
+
+            # sum per-pixel likelihood contribution
+            for h in 1:img.H, w in 1:img.W
+                pixel_data = img.pixels[h,w]
+                is_active  = active_bitmap[h, w]
+                if !isnan(pixel_data) && is_active
+                    rate_hw = background[h,w] + bflux*src_pixels[h,w]
+                    #ll += poisson_lnpdf(pixel_data, rate_hw)
+                    ll += (pixel_data*log(rate_hw) - rate_hw)
+                end
+            end
+        end
+        return ll - lgamma_const
+    end
+
+    return star_loglike
 end
 
 
@@ -66,55 +195,243 @@ Args:
   pos0: Initial location of the source in ra/dec
   pos_delta: (optional) determines how much ra/dec we allow the sampler
     to drift away from pos0
+
+Note on Galaxy Shapes: the `gal_scale` parameter is in pixels.  The 
+  Celeste parameterization sigma^2_{cel} is slightly different from the
+  Photo and SDSS parameterization for :half_light_radius_px (sigma^2_{sdss}).
+  The two have the following relationship:
+
+      sigma^2_{cel}  = sigma^2_{sdss} / sqrt(gal_ab)
+   => sigma^2_{sdss} = sigma^2_{cel} * sqrt(gal_ab)
+
+  The function `write_galaxy_unit_flux` is defined for sigma^2_{cel}, that is
+  a scale parameter in pixels that indicates the length of the major axis
+  (as given by the bivariate_normals.jl#get_bvn_cov function).
+
+  Also note that the scale prior defined below is over sigma^2_{cel}.
 """
-function make_gal_loglike(imgs::Array{Image},
-                          pos0::Array{Float64, 1};
-                          pos_delta::Array{Float64, 1}=[1., 1.])
+function make_gal_loglike(imgs::Array{Image};
+                          patches::Array{SkyPatch, 1}=nothing,
+                          background_images::Array{Array{Float64, 2}, 1}=nothing,
+                          pos_transform::Function=nothing)
 
-    # create a function that constrains the pixel location to be within
-    # pos0 +- [pos_delta]
-    constrain_pos, unconstrain_pos =
-        make_position_transformations(pos0, pos_delta)
-
-    function gal_loglike(th::Array{Float64, 1})
-
-        # unpack location and log fluxes (smushed)
-        lnfluxes, unc_pos, ushape = th[1:5], th[6:7], th[8:end]
-        pos   = constrain_pos(unc_pos)
-        shape = Model.constrain_gal_shape(ushape)
-
-        gal_frac_dev, gal_axis_ratio, gal_angle, gal_radius_px =
-            Model.constrain_gal_shape(ushape)
-
-        ll = 0.
-        for img in imgs
-            # sky pixel intensity (sky image)
-            epsilon    = img.sky[1, 1]
-            iota       = img.nelec_per_nmgy[1]
-            sky_pixels = [epsilon * iota for h=1:img.H, w=1:img.W]
-
-            # create and cache unit flux src image
-            src_pixels = [0. for h=1:img.H, w=1:img.W]
-            write_galaxy_unit_flux(img, pos, gal_frac_dev,
-                               gal_axis_ratio, gal_angle, gal_radius_px, src_pixels)
-
-            # compute model image
-            rates = sky_pixels .+ exp(lnfluxes[img.b])*src_pixels
-
-            # sum per-pixel likelihood contribution
-            H, W = size(rates)
-            for h in 1:H, w in 1:W
-                ll += poisson_lnpdf(img.pixels[h,w], rates[h,w])
-            end
-        end
-
-    return ll
+    # create background images --- sky noise and neighbors if there
+    if background_images == nothing
+        background_images = make_empty_background_images(imgs)
     end
 
-    return gal_loglike, constrain_pos, unconstrain_pos
+    # patch offset (0 if no patches passed in)
+    if patches == nothing
+        offsets = zeros(2, length(imgs))
+        active_bitmaps = [BitArray(ones(img.H, img.W)) for img in imgs]
+    else
+        offsets = hcat([convert(Array{Float64, 1}, p.bitmap_offset) - 1.
+                        for p in patches]...)
+        active_bitmaps = [p.active_pixel_bitmap for p in patches]
+    end
+
+    # cache the log(data!) term (lgamma in poisson lnpdf) --- this call is
+    # a fixed constant wrt params, and only enters into the likelihood
+    # as a sum, so we can compute it here and cache it
+    lgamma_const = compute_lgamma_sum(imgs, active_bitmaps)
+
+    function pretty_print_galaxy_params(th)
+        lnfluxes, unc_pos, ushape = th[1:5], th[6:7], th[8:end]
+        pos   = constrain_pos(unc_pos)
+        gal_frac_dev, gal_ab, gal_angle, gal_scale = ushape
+        @printf "lnfluxes     = %s \n" string(lnfluxes)
+        @printf "pos (ra,dec) = %2.4f, %2.4f \n" pos[1] pos[2]
+        @printf "gal shape:\n"
+        @printf "  frac_dev   = %2.4f \n" gal_frac_dev
+        @printf "  ab ratio   = %2.4f \n" gal_ab
+        @printf "  angle      = %2.4f \n" gal_angle
+        @printf "  scale      = %2.4f \n" gal_scale
+    end
+
+    # make galaxy log like function
+    function gal_loglike(th::Array{Float64, 1}; print_params=false)
+
+        # unpack location and log fluxes (smushed)
+        lnfluxes, pos, ushape = th[1:5], th[6:7], th[8:end]
+        gal_frac_dev, gal_ab, gal_angle, gal_scale = ushape
+        if pos_transform != nothing
+            pos = pos_transform(pos)
+        end
+
+        if print_params
+          pretty_print_galaxy_params(th)
+        end
+
+        ll = 0.
+        for ii in 1:length(imgs)
+            img, active_bitmap = imgs[ii], active_bitmaps[ii]
+
+            # sky pixel intensity (sky image)
+            background = background_images[ii]
+
+            # create and cache unit flux src image
+            src_pixels = zeros(img.H, img.W)
+            px_pos     = WCS.world_to_pix(img.wcs, pos) - offsets[:,ii]
+            write_galaxy_unit_flux_pixel(px_pos, img.psf,
+                Float64(median(img.nelec_per_nmgy)),
+                gal_frac_dev, gal_ab, gal_angle, gal_scale, src_pixels)
+
+            # image specific flux
+            bflux = exp(lnfluxes[img.b])
+            if isinf(bflux)
+                return -Inf
+            end
+
+            # sum per-pixel likelihood contribution
+            for h in 1:img.H, w in 1:img.W
+                pixel_data = img.pixels[h,w]
+                is_active  = active_bitmap[h,w]
+                if !isnan(pixel_data) && is_active
+                    rate_hw = background[h,w] + bflux*src_pixels[h,w]
+                    #ll += poisson_lnpdf(pixel_data, rate_hw)
+                    ll += (pixel_data*log(rate_hw) - rate_hw)
+                end
+            end
+        end
+        return ll - lgamma_const
+    end
+
+    return gal_loglike
 end
 
 
+##########
+# priors #
+##########
+
+"""
+Create a uniform prior around a RA/DEC location --- specify size of box
+by number of pixels
+"""
+function make_location_prior(img::Image,
+                             pos0::Array{Float64, 1};
+                             pos_pixel_delta::Array{Float64, 1} = [1., 1.])
+
+    # figure out lower and upper bounds on RA, Dec
+    pos0_pix = WCS.world_to_pix(img.wcs, pos0)
+    pos0_pix_lower = pos0_pix - .5 * pos_pixel_delta
+    pos0_pix_upper = pos0_pix + .5 * pos_pixel_delta
+    pos0_world_lower = WCS.pix_to_world(img.wcs, pos0_pix_lower)
+    pos0_world_upper = WCS.pix_to_world(img.wcs, pos0_pix_upper)
+
+    # lower and upper bounds on the ra/dec
+    ra_lo, ra_hi   = sort([pos0_world_lower[1], pos0_world_upper[1]])
+    dec_lo, dec_hi = sort([pos0_world_lower[2], pos0_world_upper[2]])
+    @printf " ... limiting RA  to [%2.5f, %2.5f] \n" ra_lo ra_hi
+    @printf " ... limiting DEC to [%2.5f, %2.5f] \n" dec_lo dec_hi
+
+    # corresponding uniform log likelihoods
+    llra  = log(1./(ra_hi - ra_lo))
+    lldec = log(1./(dec_hi - dec_lo))
+
+    function pos_logprior(pos)
+        if !inrange(pos[1], ra_lo, ra_hi)
+            return -Inf
+        end
+        if !inrange(pos[2], dec_lo, dec_hi)
+            return -Inf
+        end
+        return llra + lldec
+    end
+
+    function uniform_to_deg(u)
+        ra  = (ra_hi  - ra_lo ) * u[1] + ra_lo
+        dec = (dec_hi - dec_lo) * u[2] + dec_lo
+        return [ra, dec]
+    end
+
+    function deg_to_uniform(radec)
+        u = [ (radec[1] - ra_lo)  / (ra_hi  - ra_lo),
+              (radec[2] - dec_lo) / (dec_hi - dec_lo) ]
+        return u
+    end
+
+    return pos_logprior, [ra_lo, ra_hi], [dec_lo, dec_hi],
+           uniform_to_deg, deg_to_uniform
+end
+
+
+function make_gal_logprior()
+    # distributions over galaxy parameters
+    prior = Model.construct_prior()
+
+    function gal_logprior(th)
+        lnfluxes, u, ushape = th[1:5], th[6:7], th[8:end]
+
+        # first compute prior --- make sure all in bounds
+        gal_frac_dev, gal_ab, gal_angle, gal_scale = ushape
+        if !inrange(gal_frac_dev, 0., 1.)
+            return -Inf
+        end
+        if !inrange(gal_ab, 0., 1.)
+            return -Inf
+        end
+        if !inrange(gal_angle, 0., pi)
+            return -Inf
+        end
+        if !inrange(gal_scale, 1e-5, Inf)
+            return -Inf
+        end
+
+        # uniform over angle, ll log normal over scale
+        llangle = -log(pi)
+        llscale = logpdf(prior.galaxy.gal_radius_px, gal_scale)
+        if isinf(llangle)
+          println(" angle bad!")
+        end
+        if isinf(llscale)
+          println(" scale bad!")
+        end
+        ll = MCMC.logflux_logprior(lnfluxes; is_star=false) + llangle + llscale
+        return ll
+    end
+    return gal_logprior
+end
+
+
+param_prior = Model.construct_prior()
+
+function sample_galaxy_shape()
+    gal_frac_dev = rand()
+    gal_ab       = rand()
+    gal_angle    = rand() * pi
+    gal_scale    = rand(param_prior.galaxy.gal_radius_px)
+    return [gal_frac_dev, gal_ab, gal_angle, gal_scale]
+end
+
+
+function make_empty_background_images(imgs::Array{Image})
+    background_images = []
+    for img in imgs
+        # sky pixel intensity (sky image)
+        epsilon    = img.sky[1, 1]
+        iota       = img.nelec_per_nmgy[1]
+        sky_pixels = [epsilon * iota for h=1:img.H, w=1:img.W]
+        push!(background_images, sky_pixels)
+    end
+    return background_images
+end
+
+
+function compute_lgamma_sum(imgs::Array{Image}, active_bitmaps)
+    lgamma_const = 0.
+    for ii in 1:length(imgs)
+        img, active_bitmap = imgs[ii], active_bitmaps[ii]
+        for h in 1:img.H, w in 1:img.W
+            pixel_data = img.pixels[h,w]
+            is_active  = active_bitmap[h,w]
+            if !isnan(pixel_data) && is_active
+                lgamma_const += lgamma(pixel_data+1.)
+            end
+        end
+    end
+    return lgamma_const
+end
 
 
 function make_position_transformations(pos0::Array{Float64, 1},
@@ -140,7 +457,6 @@ function make_position_transformations(pos0::Array{Float64, 1},
 
     return constrain_pos, unconstrain_pos
 end
-
 
 
 #####################################
@@ -249,7 +565,7 @@ function logflux_logprior(lnfluxes::Vector{Float64}; is_star::Bool=true)
     lnr, colors = logfluxes_to_colors(lnfluxes)
 
     # compute brightness distribution
-    llr = logpdf(Normal(pp.flux_mean[type_i], 2*pp.flux_var[type_i]), lnr)
+    llr = logpdf(Normal(pp.flux_mean[type_i], sqrt(pp.flux_var[type_i])), lnr)
 
     # compute color likelihoods (mixture model --- computes all component lls)
     nc, nk, ns = size(pp.color_mean)
@@ -286,7 +602,7 @@ function sample_logfluxes(; is_star=true, lnr=nothing)
 
     # sample log r
     if lnr == nothing
-        lnr = rand(Normal(pp.flux_mean[type_i], 2*pp.flux_var[type_i]))
+        lnr = rand(Normal(pp.flux_mean[type_i], sqrt(pp.flux_var[type_i])))
     end
 
     # sample colors
@@ -312,20 +628,25 @@ end
 
 function sample_logr(; is_star=true)
     type_i = is_star ? 1 : 2
-    lnr = rand(Normal(pp.flux_mean[type_i], 2*pp.flux_var[type_i]))
+    lnr = rand(Normal(pp.flux_mean[type_i], sqrt(pp.flux_var[type_i])))
     return lnr
 end
 
-
-function sample_fluxes(i::Int, r_s)
-    k_s = rand(Distributions.Categorical(pp.k[i]))
-    c_s = rand(Distributions.MvNormal(pp.color[i][:, k_s], pp.color[i][:, :, k_s]))
-
-    l_s = Vector{Float64}(5)
-    l_s[3] = r_s
-    l_s[4] = l_s[3] * exp(c_s[3])
-    l_s[5] = l_s[4] * exp(c_s[4])
-    l_s[2] = l_s[3] / exp(c_s[2])
-    l_s[1] = l_s[2] / exp(c_s[1])
-    l_s
+"""
+Convert catalog entry into unconstrained parameters for star or gal loglikes
+"""
+function parameters_from_catalog(entry::CatalogEntry;
+                                 unconstrain_pos::Function= x-> x,
+                                 is_star=true, epsilon=1e-5)
+    if is_star
+        return vcat([log.(entry.star_fluxes), unconstrain_pos(entry.pos)]...)
+    else
+        #ushape = Model.unconstrain_gal_shape([
+        #  entry.gal_frac_dev, entry.gal_ab, entry.gal_angle, entry.gal_scale])
+        ushape = [clamp(entry.gal_frac_dev, epsilon, 1-epsilon),
+                  clamp(entry.gal_axis_ratio, epsilon, 1-epsilon),
+                  clamp(entry.gal_angle, epsilon, pi-epsilon),
+                  clamp(entry.gal_radius_px, epsilon, Inf)]
+        return vcat([log.(entry.gal_fluxes), unconstrain_pos(entry.pos), ushape]...)
+    end
 end

--- a/src/mcmc/mcmc_functions.jl
+++ b/src/mcmc/mcmc_functions.jl
@@ -1,12 +1,12 @@
 """
 Make all star inference functiouns: prior, loglike, log (unnormalized) posterior.
 """
-function make_star_inference_functions(imgs::Array{Image},
+function make_star_inference_functions(imgs::Vector,
           entry::CatalogEntry;
           pos_delta::Array{Float64, 1}=[2., 2.],
           patches::Array{SkyPatch, 1}=nothing,
           background_images::Array{Array{Float64, 2}, 1}=nothing)
-    # position log prior --- same for both star and galaxy (constrains to a 
+    # position log prior --- same for both star and galaxy (constrains to a
     # small window around the existing catalog location.  Because the range
     # of RA,DEC values is so small, numerical underflow becomes an issue in
     # the slice sampler.  The generic parameter representation of the (ra,dec)
@@ -51,7 +51,7 @@ end
 """
 Make all star inference functiouns: prior, loglike, log (unnormalized) posterior.
 """
-function make_gal_inference_functions(imgs::Array{Image},
+function make_gal_inference_functions(imgs::Vector,
           entry::CatalogEntry;
           pos_delta::Array{Float64, 1}=[2., 2.],
           patches::Array{SkyPatch, 1}=nothing,
@@ -103,10 +103,10 @@ Args:
   patches...
   background_images...
   pos_transform....
-  use_raw_psf: use patch provided raw psf that interpolates on a grid as 
+  use_raw_psf: use patch provided raw psf that interpolates on a grid as
     appearance model, not the MOG approximation
 """
-function make_star_loglike(imgs::Array{Image};
+function make_star_loglike(imgs::Vector;
                            patches::Array{SkyPatch, 1}=nothing,
                            background_images::Array{Array{Float64, 2}, 1}=nothing,
                            pos_transform::Function=nothing,
@@ -196,7 +196,7 @@ Args:
   pos_delta: (optional) determines how much ra/dec we allow the sampler
     to drift away from pos0
 
-Note on Galaxy Shapes: the `gal_scale` parameter is in pixels.  The 
+Note on Galaxy Shapes: the `gal_scale` parameter is in pixels.  The
   Celeste parameterization sigma^2_{cel} is slightly different from the
   Photo and SDSS parameterization for :half_light_radius_px (sigma^2_{sdss}).
   The two have the following relationship:
@@ -210,7 +210,7 @@ Note on Galaxy Shapes: the `gal_scale` parameter is in pixels.  The
 
   Also note that the scale prior defined below is over sigma^2_{cel}.
 """
-function make_gal_loglike(imgs::Array{Image};
+function make_gal_loglike(imgs::Vector;
                           patches::Array{SkyPatch, 1}=nothing,
                           background_images::Array{Array{Float64, 2}, 1}=nothing,
                           pos_transform::Function=nothing)
@@ -405,7 +405,7 @@ function sample_galaxy_shape()
 end
 
 
-function make_empty_background_images(imgs::Array{Image})
+function make_empty_background_images(imgs::Vector)
     background_images = []
     for img in imgs
         # sky pixel intensity (sky image)
@@ -418,7 +418,7 @@ function make_empty_background_images(imgs::Array{Image})
 end
 
 
-function compute_lgamma_sum(imgs::Array{Image}, active_bitmaps)
+function compute_lgamma_sum(imgs::Vector, active_bitmaps)
     lgamma_const = 0.
     for ii in 1:length(imgs)
         img, active_bitmap = imgs[ii], active_bitmaps[ii]
@@ -511,7 +511,7 @@ end
 """
 create vectorized star log flux log like function with multiple images
 """
-function make_logflux_loglike(imgs::Array{Image},
+function make_logflux_loglike(imgs::Vector,
                               pos::Array{Float64, 1};
                               is_star = true,
                               gal_frac_dev::Float64 = .5,

--- a/src/mcmc/mcmc_infer.jl
+++ b/src/mcmc/mcmc_infer.jl
@@ -1,0 +1,285 @@
+# High level MCMC and AIS inference functions.  These functions
+# construct the star and galaxy log likelihood and prior functions, and
+# run either Slice-Sampling or Slice-Sampling-within-AIS
+
+"""
+Runs Annealed Importance Sampling on both the Star and Galaxy posteriors
+to estimate the marginal likelihood of each model and posterior samples
+simultaneously
+"""
+function run_ais(entry::CatalogEntry,
+                 imgs::Array{Image},
+                 patches::Array{SkyPatch, 2},
+                 background_images::Array{Array{Float64, 2}, 1},
+                 pos_delta::Array{Float64, 1}=[2., 2.];
+                 num_samples::Int=2,
+                 num_temperatures::Int=50,
+                 print_skip::Int=20)
+    println("\nRunning AIS on with patch size ", imgs[1].H, "x", imgs[1].W)
+    println("  catalog type: ", entry.is_star ? "star" : "galaxy")
+    println("  num images  : ", length(imgs))
+    n_active = sum([sum(p.active_pixel_bitmap) for p in patches[1, :]]) / length(patches[1,:])
+    println("  num active pixels per patch: ", n_active)
+    #imgs, pos_delta, num_samples, print_skip, num_temperatures = patch_images, [1., 1.], 3, 1, 10
+
+    ###################
+    # run star MCMC   #
+    ###################
+    star_loglike, star_logprior, star_logpost, sample_star_prior, ra_lim, dec_lim, uniform_to_deg, deg_to_uniform = 
+          MCMC.make_star_inference_functions(imgs, entry;
+                                        patches=patches[1, :],
+                                        background_images=background_images,
+                                        pos_delta=pos_delta)
+
+    th_cat = [log.(entry.star_fluxes)..., deg_to_uniform(entry.pos)...]
+    th_rand = sample_star_prior()
+    println("star loglike at CATALOG vs PRIOR : ", star_loglike(th_cat), ", ", star_loglike(th_rand))
+    println("star logprior at CATALOG vs PRIOR : ", star_logprior(th_cat), ", ", star_logprior(th_rand))
+    star_schedule = MCMC.sigmoid_schedule(num_temperatures; rad=4)
+    res_star = MCMC.ais_slicesample(star_logpost, star_logprior,
+                                    sample_star_prior;
+                                    schedule=star_schedule,
+                                    num_samps=num_samples,
+                                    num_samples_per_step=1)
+    lnZ = res_star[:lnZ]
+    lnZs = res_star[:lnZ_bootstrap]
+    lo, hi = percentile(lnZs, 2.5), percentile(lnZs, 97.5)
+    @printf "STAR AIS estimate : %2.4f [%2.3f, %2.3f]\n" lnZ lo hi
+    @printf "  CI width : %2.5f \n" (hi-lo)
+
+    ####################
+    # run galaxy AIS   #
+    ####################
+    gal_loglike, gal_logprior, gal_logpost, sample_gal_prior, ra_lim, dec_lim, uniform_to_deg, deg_to_uniform = 
+          MCMC.make_gal_inference_functions(imgs, entry;
+                                        patches=patches[1, :],
+                                        background_images=background_images,
+                                        pos_delta=pos_delta)
+
+    gal_schedule = MCMC.sigmoid_schedule(num_temperatures; rad=4)
+    res_gal = MCMC.ais_slicesample(gal_logpost, gal_logprior,
+                                   sample_gal_prior;
+                                   schedule=gal_schedule,
+                                   num_samps=num_samples,
+                                   num_samples_per_step=1)
+    lnZ = res_gal[:lnZ]
+    lnZs = res_gal[:lnZ_bootstrap]
+    lo, hi = percentile(lnZs, 2.5), percentile(lnZs, 97.5)
+    @printf "GAL AIS estimate : %2.4f [%2.3f, %2.3f]\n" lnZ lo hi
+    @printf "  CI width : %2.5f \n" (hi-lo)
+
+    #########################################################
+    # Compute prob star vs gal based on marginal likelihood #
+    #########################################################
+    type_chain  = zeros(length(res_gal[:lnZ_bootstrap]))
+    # is_star = [.28, .72] vs [.999, .001] vs [.5, .5]
+    lnprob_a    = log(.28)
+    lnprob_nota = log(.72)
+    for n in 1:length(res_gal[:lnZ_bootstrap])
+        # normalizing constant is ln p(data | star)
+        # so p(star | data) \propto p(data | star) p(star)
+        lnprob_star = res_star[:lnZ_bootstrap][n] + lnprob_a
+        lnprob_gal  = res_gal[:lnZ_bootstrap][n] + lnprob_nota
+        lnsum = Model.logsumexp([lnprob_star, lnprob_gal]) # normalize
+        type_chain[n] = lnprob_star - lnsum
+    end
+    ave_pstar = Model.logsumexp(type_chain) - log(length(type_chain))
+    println("  source p-star = ", exp(ave_pstar))
+
+    ####################################################################
+    # convert positions to RA/Dec and organize chains into dataframes  #
+    ####################################################################
+    for n in 1:size(res_gal[:zsamps], 2)
+        res_gal[:zsamps][6:7,n]  = uniform_to_deg(res_gal[:zsamps][6:7,n])
+        res_star[:zsamps][6:7,n] = uniform_to_deg(res_star[:zsamps][6:7,n])
+    end
+    star_chain = MCMC.samples_to_dataframe(transpose(res_star[:zsamps]), is_star=true)
+    gal_chain  = MCMC.samples_to_dataframe(transpose(res_gal[:zsamps]), is_star=false)
+
+    # store objid (for concatenation)
+    mcmc_results = Dict("star_samples" => star_chain,
+                        "star_lls"     => res_star[:lnZsamps],
+                        "star_bootstrap"=> res_star[:lnZ_bootstrap],
+                        "gal_samples"  => gal_chain,
+                        "gal_lls"      => res_gal[:lnZsamps],
+                        "gal_bootstrap" => res_gal[:lnZ_bootstrap],
+                        "type_samples" => type_chain,
+                        "ave_pstar"    => ave_pstar)
+    return mcmc_results
+end
+
+
+"""
+Run single source MCMC chain
+"""
+function run_mcmc(entry::CatalogEntry,
+                  imgs::Array{Image},
+                  patches::Array{SkyPatch, 2},
+                  background_images::Array{Array{Float64, 2}, 1},
+                  pos_delta::Array{Float64, 1}=[1., 1.];
+                  num_samples::Int=500,
+                  print_skip::Int=20)
+    println("\nRunning mcmc on entry with patch size ",
+            imgs[1].H, "x", imgs[1].W)
+    println("  catalog type: ", entry.is_star ? "star" : "galaxy")
+
+    # position log prior --- same for both star and galaxy (constrains to a 
+    # small window around the existing catalog location
+    #imgs, pos_delta, num_samples, print_skip = patch_images, [1., 1.], 200, 20
+    pos_logprior, ra_lim, dec_lim = MCMC.make_location_prior(
+        imgs[1], entry.pos; pos_pixel_delta=[2., 2.])
+
+    ###################
+    # run star MCMC   #
+    ###################
+    star_loglike, constrain_pos, unconstrain_pos =
+        MCMC.make_star_loglike(imgs, entry.pos;
+                               patches=patches[1,:],
+                               background_images=background_images,
+                               pos_delta=pos_delta)
+
+    function star_logprior(th)
+        lnfluxes, pos = th[1:5], th[6:end]
+        return MCMC.logflux_logprior(lnfluxes; is_star=true) + pos_logprior(pos)
+    end
+
+    function star_logpost(th)
+        return star_loglike(th) + star_logprior(th)
+    end
+
+    # log likelihood at data generating parameters, and random prior
+    th_cat = [log.(entry.star_fluxes)..., entry.pos...]
+    #th_cat = MCMC.parameters_from_catalog(entry, unconstrain_pos; is_star=true)
+    #th_rand = [th_cat[1:5]..., [.001, .001]...]
+    th_rand = th_cat + .0001*randn(length(th_cat))
+    println("loglike at true initial position: ", star_loglike(th_cat))
+    println("loglike at random prior position: ", star_loglike(th_rand))
+    println("logprior at true position:        ", star_logprior(th_cat))
+
+    # draw MCMC samples
+    star_chain, star_lls = MCMC.slicesample_chain(star_logpost, th_cat,
+        num_samples; print_skip=print_skip, verbose=false)
+    num_warmup = Int(round(.25 * num_samples))
+    star_chain = star_chain[num_warmup:end, :]
+    star_lls   = star_lls[num_warmup:end]
+
+    ####################
+    # run galaxy MCMC  #
+    ####################
+    gal_loglike, constrain_pos, unconstrain_pos =
+        MCMC.make_gal_loglike(imgs, entry.pos;
+                              patches=patches[1,:],
+                              background_images=background_images,
+                              pos_delta=pos_delta)
+    gal_logprior = MCMC.make_gal_logprior()
+
+    # test at catalog initialized position vs shifted --- eye test
+    th_cat = MCMC.parameters_from_catalog(entry; is_star=false)
+    th_rand = th_cat + .00001*randn(length(th_cat))
+    println("gal ll at Catalog vs Shifted : ",
+        gal_loglike(th_cat), " vs. ", gal_loglike(th_rand))
+    println("gal lnprior at true initial pos:  ", gal_logprior(th_cat))
+    th_cat[1:5] = th_rand[1:5]
+
+    function gal_logpost(th)
+        # catch illegal values in the prior
+        llprior = gal_logprior(th)
+        if llprior < -1e100
+            return llprior
+        end
+        return gal_loglike(th; print_params=false) + llprior
+    end
+
+    # draw MCMC samples
+    gal_chain, gal_lls = MCMC.slicesample_chain(
+        gal_logpost, th_cat, num_samples; print_skip=print_skip, verbose=false)
+    gal_chain = gal_chain[num_warmup:end, :]
+    gal_lls   = gal_lls[num_warmup:end]
+
+    #############################################
+    # Compute prob star vs gal based on samples #
+    #############################################
+    type_chain  = zeros(length(gal_lls))
+    lnprob_a    = log(.5)
+    lnprob_nota = log(1.-.5)
+    for n in 1:length(gal_lls)
+        # a == 1 full joint prob ln p(pixels | theta^star, a=star) p(theta^star) p(theta^gal) p(a)
+        lnjoint_star = star_lls[n] + gal_logprior(gal_chain[n, :]) + lnprob_a
+
+        # a == 0 (galaxy) full joint
+        lnjoint_gal = gal_lls[n] + star_logprior(star_chain[n, :]) + lnprob_nota
+
+        # compute log prob of type = star (1)
+        lnsum = Model.logsumexp([lnjoint_star, lnjoint_gal])
+        type_chain[n] = lnjoint_star - lnsum
+    end
+    ave_pstar = Model.logsumexp(type_chain) - log(length(gal_lls))
+    println("  source p-star = ", exp(ave_pstar))
+
+    ####################################################################
+    # convert positions to RA/Dec and organize chains into dataframes  #
+    ####################################################################
+    #for n in 1:size(star_chain)[1]
+    #    star_chain[n,6:7] = constrain_pos(star_chain[n,6:7])
+    #end
+    #for n in 1:size(gal_chain)[1]
+    #    gal_chain[n,6:7] = constrain_pos(gal_chain[n,6:7])
+    #end
+    star_chain = MCMC.samples_to_dataframe(star_chain; is_star=true)
+    gal_chain = MCMC.samples_to_dataframe(gal_chain; is_star=false)
+
+    # store objid (for concatenation)
+    mcmc_results = Dict("star_samples" => star_chain,
+                        "star_lls"     => star_lls,
+                        "gal_samples"  => gal_chain,
+                        "gal_lls"      => gal_lls,
+                        "type_samples" => type_chain)
+    return mcmc_results
+end
+
+
+"""
+Turn MCMC results into a single dataframe row that summarizes the
+posterior distribution
+"""
+function summarize_samples(results_dict)
+    stardf   = results_dict["star_samples"]
+    galdf    = results_dict["gal_samples"]
+    star_row = samples_to_dataframe_row(stardf; is_star=true)
+    gal_row  = samples_to_dataframe_row(galdf; is_star=false)
+    return star_row, gal_row
+end
+
+
+"""
+Consolidate samples into results dataframes (single entry per source)
+"""
+function consolidate_samples(reslist; objids=nothing)
+    # give each source a unique label
+    if objids==nothing
+        objids = ["samp_$(i)" for i in 1:length(reslist)]
+    end
+
+    # loop through each result sample list and summarize
+    joint_summary, star_summary, gal_summary = [], [], []
+    for i in 1:length(reslist)
+        r = reslist[i]
+
+        # compute star and gal summaries
+        star_row, gal_row = summarize_samples(r)
+        star_row[:objid], gal_row[:objid] = objids[i], objids[i]
+        push!(star_summary, star_row)
+        push!(gal_summary, gal_row)
+
+        # compute star average
+        pstar = exp(r["ave_pstar"])
+        srow  = (pstar > .5) ? star_row : gal_row
+        srow[:, :is_star] = [pstar]
+        push!(joint_summary, srow)
+    end
+    joint_summary = vcat(joint_summary...)
+    star_summary  = vcat(star_summary...)
+    gal_summary   = vcat(gal_summary...)
+    return star_summary, gal_summary, joint_summary
+end
+

--- a/src/mcmc/mcmc_infer.jl
+++ b/src/mcmc/mcmc_infer.jl
@@ -8,7 +8,7 @@ to estimate the marginal likelihood of each model and posterior samples
 simultaneously
 """
 function run_ais(entry::CatalogEntry,
-                 imgs::Array{Image},
+                 imgs::Vector,
                  patches::Array{SkyPatch, 2},
                  background_images::Array{Array{Float64, 2}, 1},
                  pos_delta::Array{Float64, 1}=[2., 2.];
@@ -25,7 +25,7 @@ function run_ais(entry::CatalogEntry,
     ###################
     # run star MCMC   #
     ###################
-    star_loglike, star_logprior, star_logpost, sample_star_prior, ra_lim, dec_lim, uniform_to_deg, deg_to_uniform = 
+    star_loglike, star_logprior, star_logpost, sample_star_prior, ra_lim, dec_lim, uniform_to_deg, deg_to_uniform =
           MCMC.make_star_inference_functions(imgs, entry;
                                         patches=patches[1, :],
                                         background_images=background_images,
@@ -50,7 +50,7 @@ function run_ais(entry::CatalogEntry,
     ####################
     # run galaxy AIS   #
     ####################
-    gal_loglike, gal_logprior, gal_logpost, sample_gal_prior, ra_lim, dec_lim, uniform_to_deg, deg_to_uniform = 
+    gal_loglike, gal_logprior, gal_logpost, sample_gal_prior, ra_lim, dec_lim, uniform_to_deg, deg_to_uniform =
           MCMC.make_gal_inference_functions(imgs, entry;
                                         patches=patches[1, :],
                                         background_images=background_images,
@@ -113,7 +113,7 @@ end
 Run single source MCMC chain
 """
 function run_mcmc(entry::CatalogEntry,
-                  imgs::Array{Image},
+                  imgs::Vector,
                   patches::Array{SkyPatch, 2},
                   background_images::Array{Array{Float64, 2}, 1},
                   pos_delta::Array{Float64, 1}=[1., 1.];
@@ -123,7 +123,7 @@ function run_mcmc(entry::CatalogEntry,
             imgs[1].H, "x", imgs[1].W)
     println("  catalog type: ", entry.is_star ? "star" : "galaxy")
 
-    # position log prior --- same for both star and galaxy (constrains to a 
+    # position log prior --- same for both star and galaxy (constrains to a
     # small window around the existing catalog location
     #imgs, pos_delta, num_samples, print_skip = patch_images, [1., 1.], 200, 20
     pos_logprior, ra_lim, dec_lim = MCMC.make_location_prior(
@@ -282,4 +282,3 @@ function consolidate_samples(reslist; objids=nothing)
     gal_summary   = vcat(gal_summary...)
     return star_summary, gal_summary, joint_summary
 end
-

--- a/src/mcmc/mcmc_misc.jl
+++ b/src/mcmc/mcmc_misc.jl
@@ -103,7 +103,7 @@ function catalog_to_data_frame_row(catalog_entry; objid="truth")
 end
 
 function samples_to_dataframe(chain; is_star=true)
-    """ Turns MCMC samples (star or galaxy chain) into a dataframe of samples 
+    """ Turns MCMC samples (star or galaxy chain) into a dataframe of samples
     with parameters we can compare to Photo and VB inferences
 
     Conversions performed:
@@ -249,7 +249,7 @@ function write_galaxy_unit_flux(pos::Array{Float64, 1},
                                 pixels::Matrix{Float64};
                                 offset::Array{Float64, 1}=[0., 0.],
                                 flux::Float64=1.)
-    # write the unit-flux scaled, correctly offset galaxy shape + 
+    # write the unit-flux scaled, correctly offset galaxy shape +
     # psf convolution
     e_devs = [gal_frac_dev, 1 - gal_frac_dev]
     XiXi = Model.get_bvn_cov(gal_axis_ratio, gal_angle, gal_scale)
@@ -275,7 +275,7 @@ function write_galaxy_unit_flux_pixel(px_pos::Array{Float64, 1},
                                       gal_scale::Float64,
                                       pixels::Matrix{Float64};
                                       flux::Float64=1.)
-    # write the unit-flux scaled, correctly offset galaxy shape + 
+    # write the unit-flux scaled, correctly offset galaxy shape +
     # psf convolution
     e_devs = [gal_frac_dev, 1 - gal_frac_dev]
     XiXi = Model.get_bvn_cov(gal_axis_ratio, gal_angle, gal_scale)
@@ -356,7 +356,7 @@ end
 
 
 #########################################
-# older interface 
+# older interface
 #########################################
 function write_star_unit_flux(img0::Image,
                               pos::Array{Float64, 1},
@@ -451,7 +451,7 @@ function patch_to_image(patch::SkyPatch, img::Image; round_pixels_to_int=true)
     calibration = img.sky.calibration[Hr]
     sky_x       = img.sky.sky_x[Hr]
     sky_y       = img.sky.sky_y[Wr]
-    sky         = SkyIntensity(sky_small, sky_x, sky_y, calibration)
+    sky         = SDSSBackground(sky_small, sky_x, sky_y, calibration)
     nelec_per_nmgy = img.nelec_per_nmgy[Hr]
 
     # TODO create an adjusted WCS object
@@ -465,5 +465,3 @@ function patch_to_image(patch::SkyPatch, img::Image; round_pixels_to_int=true)
                         sky, nelec_per_nmgy, img.raw_psf_comp)
     return patch_image
 end
-
-

--- a/src/mcmc/mcmc_misc.jl
+++ b/src/mcmc/mcmc_misc.jl
@@ -459,9 +459,8 @@ function patch_to_image(patch::SkyPatch, img::Image; round_pixels_to_int=true)
     #wcs[:crpix] = wcs[:crpix] - patch.bitmap_offset
 
     # instantiate a smaller patch image
-    patch_image = Image(H, W, patch_pixels, img.b, img.wcs,
+    patch_image = Image(patch_pixels, img.b, img.wcs,
                         patch.psf,
-                        img.run_num, img.camcol_num, img.field_num,
-                        sky, nelec_per_nmgy, img.raw_psf_comp)
+                        sky, nelec_per_nmgy, img.psfmap)
     return patch_image
 end

--- a/src/mcmc/slicesample.jl
+++ b/src/mcmc/slicesample.jl
@@ -19,13 +19,13 @@ http://en.wikipedia.org/wiki/Slice_sampling
 """
 function slicesample(init_x::Vector{Float64},
                      logprob::Function;
-                     sigma = 1.0,
+                     sigma = 1.,
                      step_out=true,
-                     max_steps_out=1000,
+                     max_steps_out=10,
                      compwise=true,
                      numdir=2,
                      doubling_step = true,
-                     verbose = true,
+                     verbose = false,
                      upper_bound = Inf,
                      lower_bound = -Inf)
 
@@ -37,20 +37,38 @@ function slicesample(init_x::Vector{Float64},
         end
 
         function acceptable(z, llh_s, L, U)
-            while (U-L) > 1.1*sigma
-                middle = 0.5*(L+U)
-                splits = ((middle > 0) & (z >= middle)) | 
-                         ((middle <= 0) & (z < middle))
+            #println(" ... entered acceptable... ")
+            starting_width = U - L
+            Lt, Ut = L, U
+            iter = 0
+            while ((Ut-Lt) > 1.1*sigma) && ((Ut - Lt) < 1.1*starting_width)
+                middle = 0.5*(Lt + Ut)
+                splits = ((middle > 0) && (z >= middle)) ||
+                         ((middle <= 0) && (z < middle))
                 if z < middle
-                    U = middle
+                    Ut = middle
                 else
-                    L = middle
+                    Lt = middle
                 end
                 # Probably these could be cached from the stepping out.
-                if splits & (llh_s >= dir_logprob(U)) & (llh_s >= dir_logprob(L))
+                if splits && (llh_s >= dir_logprob(Ut)) && (llh_s >= dir_logprob(Lt))
+                    #println(" ... leaving acceptable... ")
                     return false
                 end
+
+                # catch infinite loops
+                if iter > 1000
+                  throw("acceptable caught in a loop --- exiting")
+                else
+                  iter += 1
+                end
+                if (iter > 100) && (iter % 100 == 0)
+                  @printf "stuck in acceptable: interval = %2.4f; 1.1*sigma = %2.4f\n" (Ut - Lt) 1.1*sigma
+                  println("  interval: ", Ut - Lt)
+                  println("  starting width: ", starting_width)
+                end
             end
+            #println(" ... leaving acceptable... ")
             return true
         end
 
@@ -62,16 +80,17 @@ function slicesample(init_x::Vector{Float64},
         #    dir_upper_bound = np.min(np.sign(direction)*(upper_bound - init_x)/direction)
         #    dir_lower_bound = np.max(np.sign(direction)*(lower_bound - init_x)/direction)
 
-        # compute initial interval bounds
+        # compute initial interval bounds (of length sigma)
         upper = sigma * rand()
         lower = upper - sigma
 
         # sample uniformly under the probability at z = 0
-        llh_s = log(rand()) + dir_logprob(0.0)
+        #llh_s = log(rand()) + dir_logprob(0.0)
+        llh_s = dir_logprob(0.0) - randexp() # equivalent to + log(rand())
 
-        # perform the stepping out or doubling procedure to compute interval I
-        l_steps_out = 0
-        u_steps_out = 0
+        # perform the stepping out or doubling procedure to compute
+        # interval I = [lower, upper]
+        l_steps_out, u_steps_out = 0, 0
         if step_out
             if doubling_step
                 while ((dir_logprob(lower) > llh_s) | (dir_logprob(upper) > llh_s)) &
@@ -96,32 +115,37 @@ function slicesample(init_x::Vector{Float64},
             end
         end
 
-        # uniformly sample - perform shrinkage (with accept check)
-        start_upper = upper
-        start_lower = lower
-        steps_in = 0
-        new_z    = 0.
-        new_llh  = -Inf
+        # uniformly sample - perform shrinkage (with accept check) on
+        # interval I = [lower, upper]
+        start_lower, start_upper = lower, upper
+        if (start_upper - start_lower) > 1e5
+            println("  ... pre-shrinkage interval size: ", start_upper-start_lower)
+            println("  ... lower ", start_lower)
+            println("  ... upper ", start_upper)
+            println("  ... num steps out ....", l_steps_out + u_steps_out)
+            println("  ... dir ", direction)
+        end
+        steps_in, new_z, new_llh = 0, 0., -Inf
         while true
             steps_in += 1
             if steps_in % 100 == 0
                 println("shrinking, steps", steps_in)
             end
 
-            new_z     = (upper - lower)*rand() + lower
-            new_llh   = dir_logprob(new_z)
+            # sample uniformly in the interval
+            new_z   = (upper - lower)*rand() + lower
+            new_llh = dir_logprob(new_z)
             if isnan(new_llh)
-                println("new_z: ", new_z)
-                println("new_th: ", direction*new_z + init_x)
-                println("new_llh: ", new_llh)
-                println("llh_s: ", llh_s)
-                println("init_x", init_x)
-                println("ll_init_x", logprob(init_x))
+                println("new_z, new_th, new_llh: ", new_z, ", ",
+                        direction*new_z + init_x, ", ", new_llh)
+                println("init_x, llh_s, ll_init_x", init_x, ", ",
+                        llh_s, ", ", logprob(init_x))
                 throw("Slice sampler got a NaN")
             end
 
-            # accept/or shrink
-            if (new_llh > llh_s) & acceptable(new_z, llh_s, start_lower, start_upper)
+            # accept (break) otherwise shrink the interval
+            if (llh_s < new_llh) &&
+                  acceptable(new_z, llh_s, start_lower, start_upper)
                 break
             elseif new_z < 0
                 lower = new_z
@@ -155,7 +179,13 @@ function slicesample(init_x::Vector{Float64},
     if compwise
         ordering = shuffle(1:dims)
         new_x = copy(init_x)
+        if verbose
+            println("compwise call: ")
+        end
         for d in ordering
+            if verbose
+                println("  ... slice sampling component ", d)
+            end
             direction    = zeros(dims)
             direction[d] = 1.0
             new_x, new_llh = direction_slice(direction, new_x)
@@ -176,16 +206,19 @@ end
 """
 Helper that draws N samples using slice sampling
 """
-function slicesample_chain(lnpdf, th, N; print_skip=50)
-    NUM_COLOR_COMPONENTS = length(th)
-    samps = zeros(N, NUM_COLOR_COMPONENTS)
+function slicesample_chain(lnpdf, th, N;
+                           print_skip=50,
+                           verbose=false)
+    D = length(th)
+    samps = zeros(N, D)
     lls   = zeros(N)
     tic()
     @printf "  iter : \t loglike \n"
     for n in 1:N
         th, ll = slicesample(th, lnpdf;
                              doubling_step=true,
-                             compwise=true)
+                             compwise=true,
+                             verbose=verbose)
         samps[n,:] = th
         lls[n]     = ll
         if mod(n, print_skip) == 0
@@ -193,7 +226,6 @@ function slicesample_chain(lnpdf, th, N; print_skip=50)
         end
     end
     elapsed = toc()
-    @printf "%2.3f ms per sample (20k samples in %2.3f seconds) \n" 1000*(elapsed/N) elapsed
+    @printf "%2.3f ms per sample (%d samples in %2.3f seconds) \n" 1000*(elapsed/N) N elapsed
     return samps, lls
 end
-

--- a/src/model/log_prob.jl
+++ b/src/model/log_prob.jl
@@ -260,7 +260,7 @@ function construct_prior()
         LogNormal(pp.flux_mean[2], sqrt(pp.flux_var[2])),
         Categorical(pp.k[:,2]),
         [MvNormal(pp.color_mean[:,k,2], pp.color_cov[:,:,k,2]) for k in 1:NUM_COLOR_COMPONENTS],
-        LogNormal(0, 10),
+        LogNormal(pp.gal_radius_px_mean, sqrt(pp.gal_radius_px_var)),
         Beta(1, 1),
         Beta(1, 1))
 

--- a/test/test_infer.jl
+++ b/test/test_infer.jl
@@ -6,6 +6,17 @@ using Celeste.SDSSIO
 using Celeste.ParallelRun
 
 
+@testset "one_node_single_infer_mcmc with a single (run, camcol, field)" begin
+    # very small patch of sky that turns out to have 4 sources.
+    # We checked that this patch is in the given field.
+    box = ParallelRun.BoundingBox(164.39, 164.41, 39.11, 39.13)
+    rcfs = [RunCamcolField(3900, 6, 269),]
+    strategy = PlainFITSStrategy(datadir)
+    ctni = ParallelRun.infer_init(rcfs, strategy; box=box)
+    result = ParallelRun.one_node_single_infer(ctni...; config=Config(2.0, 3, 2), do_vi=false)
+end
+
+
 @testset "infer_box runs" begin
     box = ParallelRun.BoundingBox("164.39", "164.41", "39.11", "39.13")
     rcfs = [RunCamcolField(3900, 6, 269),]
@@ -21,17 +32,6 @@ end
     strategy = PlainFITSStrategy(datadir)
     ctni = ParallelRun.infer_init(rcfs, strategy; box=box)
     result = ParallelRun.one_node_single_infer(ctni...)
-end
-
-
-@testset "one_node_single_infer_mcmc with a single (run, camcol, field)" begin
-    # very small patch of sky that turns out to have 4 sources.
-    # We checked that this patch is in the given field.
-    box = ParallelRun.BoundingBox(164.39, 164.41, 39.11, 39.13)
-    rcfs = [RunCamcolField(3900, 6, 269),]
-    strategy = PlainFITSStrategy(datadir)
-    ctni = ParallelRun.infer_init(rcfs, strategy; box=box)
-    result = ParallelRun.one_node_single_infer(ctni...; config=Config(2.0, 3, 2), do_vi=false)
 end
 
 

--- a/test/test_infer.jl
+++ b/test/test_infer.jl
@@ -24,6 +24,17 @@ end
 end
 
 
+@testset "one_node_single_infer_mcmc with a single (run, camcol, field)" begin
+    # very small patch of sky that turns out to have 4 sources.
+    # We checked that this patch is in the given field.
+    box = ParallelRun.BoundingBox(164.39, 164.41, 39.11, 39.13)
+    rcfs = [RunCamcolField(3900, 6, 269),]
+    strategy = PlainFITSStrategy(datadir)
+    ctni = ParallelRun.infer_init(rcfs, strategy; box=box)
+    result = ParallelRun.one_node_single_infer(ctni...; config=Config(2.0, 3, 2), do_vi=false)
+end
+
+
 @testset "load active pixels" begin
     ea, vp, catalog = gen_sample_star_dataset()
 


### PR DESCRIPTION
added support for MCMC within AIS inference

- implemented annealed importance sampling to approximate the marginal likelihood of a star vs galaxy
- code for running slice-sampling within AIS on both star and galaxy conditional distributions
- code for consolidating samples and assembling output dataframes (`mcmc/mcmc_infer.jl`)
- added a `process_source_mcmc` function in `ParallelRun.jl`; added a boolean `do_vi` flag to `one_node_single_infer` (defaults to VI)

The following call should return a list of `res` objects (dictionaries)
```
 res_list = ParallelRun.one_node_single_infer(
     catalog_entries, target_sources, neighbor_map, images;
     config=Config(25.0), do_vi=false)
```
each object is a dictionary, with the following entries
- `star_samples` and `gal_samples` : dataframe of parameter samples
- `star_lls` and `gal_lls` : log joint probability for the star or galaxy samples
- `ave_pstar` : average log probability that the source is a star
- `star_bootstrap`, `gal_bootstrap`: bootstrap samples of the marginal likelihood of the data under the star model and the gal model, respectively (these are used to compute the posterior prob(star | data)). 

The list of dictionaries above can be consolidated into a one-source-per-row dataframe with approximate posterior means and stderr values with the following call
```
star_summary, gal_summary, joint_summary = MCMC.consolidate_samples(res_list)
```
Here, `star_summary` assumes all sources are stars, `gal_summary` assumes all sources are galaxies, and `joint_summary` presents star posterior inferences if `exp(ave_pstar) > .5`, and galaxy posterior inferences otherwise. 

Closes #387 . Closes #324 . 