### PR TITLE
More Image generalizations

### DIFF
--- a/src/AccuracyBenchmark.jl
+++ b/src/AccuracyBenchmark.jl
@@ -551,7 +551,6 @@ function make_image(
         band_index,
         wcs,
         psf,
-        Int16(0), UInt8(0), Int16(0), # run, camcol, field
         sky_intensity,
         fill(Float32(nelec_per_nmgy), height_px),
         Model.ConstantPSFMap(psfstamp)

--- a/src/AccuracyBenchmark.jl
+++ b/src/AccuracyBenchmark.jl
@@ -545,8 +545,6 @@ function make_image(
     psfstamp = Model.render_psf(psf, (51, 51))
 
     Model.Image(
-        height_px,
-        width_px,
         pixels,
         band_index,
         wcs,

--- a/src/AccuracyBenchmark.jl
+++ b/src/AccuracyBenchmark.jl
@@ -529,17 +529,10 @@ function serialize_psf_to_header(psf::Vector{Model.PsfComponent}, header::FITSIO
     end
 end
 
-function make_image(
-    pixels::Matrix{Float32}, band_index::Int, wcs::WCS.WCSTransform, psf::Vector{Model.PsfComponent},
-    sky_level_nmgy::Float64, nelec_per_nmgy::Float64
-)
-    height_px, width_px = size(pixels)
-    sky_intensity = Model.SkyIntensity(
-        fill(sky_level_nmgy, height_px, width_px),
-        collect(1:height_px),
-        collect(1:width_px),
-        ones(height_px),
-    )
+function make_image(pixels::Matrix{Float32}, band_index::Int,
+                    wcs::WCS.WCSTransform, psf::Vector{Model.PsfComponent},
+                    sky_level_nmgy::Real, nelec_per_nmgy::Real)
+    nx, ny = size(pixels)
 
     # Render the PSF on a grid, to be used as a (spatially constant) PSF map.
     psfstamp = Model.render_psf(psf, (51, 51))
@@ -549,8 +542,8 @@ function make_image(
         band_index,
         wcs,
         psf,
-        sky_intensity,
-        fill(Float32(nelec_per_nmgy), height_px),
+        fill(Float32(sky_level_nmgy), nx, ny),
+        fill(Float32(nelec_per_nmgy), nx),
         Model.ConstantPSFMap(psfstamp)
     )
 end
@@ -563,8 +556,8 @@ function make_images(band_extensions::Vector{FitsImage})
             band_index,
             extension.wcs,
             make_psf_from_header(extension.header),
-            convert(Float64, extension.header["CLSKY"]),
-            convert(Float64, extension.header["CLIOTA"]),
+            extension.header["CLSKY"]::Float64,
+            extension.header["CLIOTA"]::Float64
         )
     end
 end

--- a/src/Model.jl
+++ b/src/Model.jl
@@ -10,7 +10,7 @@ export Image, SkyPatch, PsfComponent,
        PriorParams, CanonicalParams, BrightnessParams, StarPosParams,
        GalaxyPosParams, GalaxyShapeParams,
        PsfParams, CatalogEntry,
-       ParamSet, SkyIntensity
+       ParamSet
 
 # functions
 export align

--- a/src/SDSSIO.jl
+++ b/src/SDSSIO.jl
@@ -409,7 +409,7 @@ function convert(::Type{Image}, r::RawImage)
 
     nelec_per_nmgy = r.gain ./ r.calibration
 
-    Image(H, W, r.pixels, r.b, r.wcs, celeste_psf,
+    Image(r.pixels, r.b, r.wcs, celeste_psf,
           r.sky, nelec_per_nmgy, r.psfmap)
 end
 

--- a/src/SDSSIO.jl
+++ b/src/SDSSIO.jl
@@ -410,7 +410,6 @@ function convert(::Type{Image}, r::RawImage)
     nelec_per_nmgy = r.gain ./ r.calibration
 
     Image(H, W, r.pixels, r.b, r.wcs, celeste_psf,
-          r.rcf.run, r.rcf.camcol, r.rcf.field,
           r.sky, nelec_per_nmgy, r.psfmap)
 end
 

--- a/src/model/image_model.jl
+++ b/src/model/image_model.jl
@@ -1,67 +1,9 @@
-# See https://github.com/jeff-regier/Celeste.jl/wiki/About-SDSS-and-Stripe-82
-struct SkyIntensity
-    sky_small::Matrix{Float32} # background flux per pixel, in DNs
-    sky_x::Vector{Float32} # interpolation coordinates
-    sky_y::Vector{Float32}
-    calibration::Vector{Float64} # nMgy per DN for each row
-end
-
-
 """
-Interpolate the 2-d array `sky_small` at the grid of array coordinates spanned
-by the vectors `sky_x` and `sky_y` using bilinear interpolation.
-The output array will have size `(length(sky_x), length(sky_y))`.
-For example, if `x[1] = 3.3` and `y[2] = 4.7`, the element `out[1, 2]`
-will be a result of linear interpolation between the values
-`sky_small[3:4, 4:5]`.
+    Image
 
-For coordinates that are out-of-bounds (e.g., `sky_x[i] < 1.0` or
-`sky_x[i] > size(sky_small,1)` where the interpolation would index sky_small values
-outside the array, the nearest values in the sky_small array are used. (This is
-constant extrapolation.)
-
-Return value has units of nMgy.
+An image, taken though a particular filter band.
 """
-function interp_sky_kernel(sky::SkyIntensity, i::Int, j::Int)
-    nx, ny = size(sky.sky_small)
-
-    y0 = floor(Int, sky.sky_y[j])
-    y1 = y0 + 1
-    yw0 = sky.sky_y[j] - y0
-    yw1 = 1.0f0 - yw0
-
-    # modify out-of-bounds indicies to 1 or ny
-    y0 = min(max(y0, 1), ny)
-    y1 = min(max(y1, 1), ny)
-
-    x0 = floor(Int, sky.sky_x[i])
-    x1 = x0 + 1
-    xw0 = sky.sky_x[i] - x0
-    xw1 = 1.0f0 - xw0
-
-    # modify out-of-bounds indicies to 1 or nx
-    x0 = min(max(x0, 1), nx)
-    x1 = min(max(x1, 1), nx)
-
-    # bi-linear interpolation
-    sky_dns = (xw0 * yw0 * sky.sky_small[x0, y0]
-             + xw1 * yw0 * sky.sky_small[x1, y0]
-             + xw0 * yw1 * sky.sky_small[x0, y1]
-             + xw1 * yw1 * sky.sky_small[x1, y1])
-
-    # return sky intensity in nMgy
-    sky_dns * sky.calibration[i]
-end
-
-import Base.getindex
-
-function getindex(sky::SkyIntensity, i::Int, j::Int)
-    interp_sky_kernel(sky, i, j)
-end
-
-
-"""An image, taken though a particular filter band"""
-mutable struct Image{T <: AbstractPSFMap}
+mutable struct Image{B<:AbstractMatrix, P<:AbstractPSFMap}
     H::Int  # image height in pixels
     W::Int  # image width in pixels
 
@@ -73,7 +15,7 @@ mutable struct Image{T <: AbstractPSFMap}
     psf::Vector{PsfComponent}  # The PSF at the center of the image
 
     # The background intensity in nanomaggies. (varies by position)
-    sky::SkyIntensity
+    sky::B
 
     # The expected number of photons contributed to this image
     # by a source 1 nanomaggie in brightness. (varies by row)
@@ -82,15 +24,15 @@ mutable struct Image{T <: AbstractPSFMap}
     # The image PSF map: a callable f(x, y) -> Matrix that takes a pixel
     # coordinate and returns the rasterized PSF image at that coordinate,
     # with the PSF centered in the image.
-    psfmap::T
+    psfmap::P
 
-    Image{T}(pixels::Matrix{Float32},
-             b::Int,
-             wcs::WCSTransform,
-             psf::Vector{PsfComponent},
-             sky::SkyIntensity,
-             nelec_per_nmgy::Array{Float32, 1},
-             psfmap::T) where {T <: AbstractPSFMap} =
+    Image{B,P}(pixels::Matrix{Float32},
+               b::Int,
+               wcs::WCSTransform,
+               psf::Vector{PsfComponent},
+               sky::B,
+               nelec_per_nmgy::Array{Float32, 1},
+               psfmap::P) where {B<:AbstractMatrix, P<:AbstractPSFMap} =
         new(size(pixels, 1), size(pixels, 2), pixels, b, wcs, psf, sky,
             nelec_per_nmgy, psfmap)
 end
@@ -99,10 +41,11 @@ Image(pixels::Matrix{Float32},
       b::Int,
       wcs::WCSTransform,
       psf::Vector{PsfComponent},
-      sky::SkyIntensity,
+      sky::B,
       nelec_per_nmgy::Array{Float32, 1},
-      psfmap::T) where {T <: AbstractPSFMap} =
-    Image{T}(pixels, b, wcs, psf, sky, nelec_per_nmgy, psfmap)
+      psfmap::P) where {B<:AbstractMatrix, P<:AbstractPSFMap} =
+    Image{B,P}(pixels, b, wcs, psf, sky, nelec_per_nmgy, psfmap)
+
 
 # The code below lets us JLD serialize images instances.
 # Without this code we get an error for trying to serialize C pointers from WCS

--- a/src/model/image_model.jl
+++ b/src/model/image_model.jl
@@ -80,12 +80,6 @@ mutable struct Image{T <: AbstractPSFMap}
     # The components of the point spread function.
     psf::Vector{PsfComponent}
 
-    # SDSS-specific identifiers. A field is a particular region of the sky.
-    # A Camcol is the output of one camera column as part of a Run.
-    run_num::Int16
-    camcol_num::UInt8
-    field_num::Int16
-
     # The background noise in nanomaggies. (varies by position)
     sky::SkyIntensity
 

--- a/test/SampleData.jl
+++ b/test/SampleData.jl
@@ -2,7 +2,8 @@ module SampleData
 
 using Celeste: Model, DeterministicVI
 import Celeste: Synthetic
-import Celeste.SDSSIO: RunCamcolField, load_field_images, PlainFITSStrategy
+import Celeste.SDSSIO: RunCamcolField, load_field_images, PlainFITSStrategy,
+                       SDSSBackground
 
 using Distributions
 using StaticArrays
@@ -196,9 +197,9 @@ function gen_n_body_dataset(S::Int; patch_pixel_radius=20., perturb=true)
     # Make non-constant background.
     for b=1:5
         images[b].nelec_per_nmgy = fill(images[b].nelec_per_nmgy[1], images[b].H)
-        images[b].sky = SkyIntensity(fill(images[b].sky[1,1], images[b].H, images[b].W),
-                                     collect(1:images[b].H), collect(1:images[b].W),
-                                     ones(images[b].H))
+        images[b].sky = SDSSBackground(fill(images[b].sky[1,1], images[b].H, images[b].W),
+                                       collect(1:images[b].H), collect(1:images[b].W),
+                                       ones(images[b].H))
     end
 
     ea = make_elbo_args(

--- a/test/test_sdssio.jl
+++ b/test/test_sdssio.jl
@@ -1,5 +1,5 @@
 using Celeste.SDSSIO
-import Celeste.SDSSIO: SkyIntensity
+import Celeste.SDSSIO: SDSSBackground
 
 
 @testset "sky interpolations" begin
@@ -8,7 +8,7 @@ import Celeste.SDSSIO: SkyIntensity
                  9. 10. 11. 12]
     sky_x = [0.1, 2.5]
     sky_y = [0.5, 2.5, 4.]
-    sky = SkyIntensity(small_sky, sky_x, sky_y, ones(2))
+    sky = SDSSBackground(small_sky, sky_x, sky_y, ones(2))
 
     @test sky[1, 1] ≈ 1.0
     @test sky[2, 1] ≈ 7.0
@@ -24,7 +24,7 @@ end
             9. 10. 11. 12]
     sky_x = [-5.0, 4.0]
     sky_y = [-4.0, 5.0]
-    sky = SkyIntensity(small_sky, sky_x, sky_y, ones(2))
+    sky = SDSSBackground(small_sky, sky_x, sky_y, ones(2))
 
     @test sky[1,1] == 1.0
     @test sky[1,2] == 4.0


### PR DESCRIPTION
More changes to `Image` to be agnostic with respect to SDSS.

- remove run, camcol, field info from `Image` (turns out these were not really used anywhere)
- remove dimensions info from `Image` constructor (redundant with `size()` on the `pixels` argument).
- make `Image` parametric in the "sky" attribute. Formerly the sky had to be `SkyIntensity` which was specific to the SDSS data model. Now, it can be any `AbstractMatrix`.

  `SDSSBackground` (formerly `SkyIntensity`) is now a `AbstractMatrix`:
```julia
julia> using Celeste

julia> bkg = Celeste.SDSSIO.SDSSBackground(fill(1., 1, 1), ones(5), ones(5), fill(3., 5))
5×5 Celeste.SDSSIO.SDSSBackground:
 3.0  3.0  3.0  3.0  3.0
 3.0  3.0  3.0  3.0  3.0
 3.0  3.0  3.0  3.0  3.0
 3.0  3.0  3.0  3.0  3.0
 3.0  3.0  3.0  3.0  3.0
```