### PR TITLE
remove RawImage type

### DIFF
--- a/src/model/image_model.jl
+++ b/src/model/image_model.jl
@@ -47,6 +47,15 @@ Image(pixels::Matrix{Float32},
     Image{B,P}(pixels, b, wcs, psf, sky, nelec_per_nmgy, psfmap)
 
 
+# TODO: better name for this.
+"""
+    calibrated_pixels(im::Image)
+
+Calibrated, sky-subtracted pixel values in nmgy.
+"""
+calibrated_pixels(im::Image) = im.pixels ./ im.nelec_per_nmgy .- im.sky
+
+
 # The code below lets us JLD serialize images instances.
 # Without this code we get an error for trying to serialize C pointers from WCS
 # and some problems for StaticArrays too.

--- a/test/test_joint_infer.jl
+++ b/test/test_joint_infer.jl
@@ -154,8 +154,8 @@ function test_detect_sources()
 
     # Get raw images
     strategy = SDSSIO.PlainFITSStrategy(datadir)
-    raw_images = SDSSIO.load_raw_images(strategy, [rcf])
-    catalog, source_radii = detect_sources(raw_images)
+    images = SDSSIO.load_field_images(strategy, rcf)
+    catalog, source_radii = detect_sources(images)
 
     ra = [ce.pos[1] for ce in catalog]
     dec = [ce.pos[2] for ce in catalog]


### PR DESCRIPTION
Removes `RawImage`, the SDSS specific version of `Image`, was very similar to `Image`, and only used in one place outside of SDSSIO. After this, the only image-reading interface is `SDSSIO.load_field_images(strategy, rcf)`, which returns a `Vector{Image}`; no need for `RawImage`.

A lot of the changeset here is just moving `IOStrategy` stuff earlier in the SDSSIO module (so that we can dispatch on it in functions below).