### PR TITLE
initialize via source detection rather than SDSS catalog

### DIFF
--- a/src/AccuracyBenchmark.jl
+++ b/src/AccuracyBenchmark.jl
@@ -1012,33 +1012,5 @@ function score_uncertainty(uncertainty_df::DataFrame)
     end
 end
 
-################################################################################
-# Utilities
-################################################################################
-
-# Run Celeste with any combination of single/joint inference
-function run_celeste(
-    config::Config, catalog_entries, target_sources, images;
-    use_joint_inference=false,
-)
-    neighbor_map = ParallelRun.find_neighbors(target_sources, catalog_entries, images)
-    if use_joint_inference
-        ParallelRun.one_node_joint_infer(
-            catalog_entries,
-            target_sources,
-            neighbor_map,
-            images,
-            config=config,
-        )
-    else
-        ParallelRun.one_node_single_infer(
-            catalog_entries,
-            target_sources,
-            neighbor_map,
-            images,
-            config=config,
-        )
-    end
-end
 
 end # module AccuracyBenchmark

--- a/test/test_accuracy_benchmarks.jl
+++ b/test/test_accuracy_benchmarks.jl
@@ -22,12 +22,12 @@ import Celeste: Model
     # see http://legacysurvey.org/viewer/jpeg-cutout/?ra=0.5130&dec=0.5358&zoom=16&layer=sdss2
     target_sources = [8,]
 
-    results = AccuracyBenchmark.run_celeste(
-        Celeste.Config(),
-        catalog_entries,
-        target_sources,
-        images,
-    )
+    neighbor_map = ParallelRun.find_neighbors(target_sources, catalog_entries,
+                                              images)
+    results = ParallelRun.one_node_single_infer(catalog_entries,
+                                                target_sources,
+                                                neighbor_map, images,
+                                                config=Celeste.Config())
     results_df = AccuracyBenchmark.celeste_to_df(results)
 
     coadd_path = joinpath(datadir, "coadd_for_4263_5_119.fit")

--- a/test/test_infer.jl
+++ b/test/test_infer.jl
@@ -12,8 +12,9 @@ using Celeste.ParallelRun
     box = ParallelRun.BoundingBox(164.39, 164.41, 39.11, 39.13)
     rcfs = [RunCamcolField(3900, 6, 269),]
     strategy = PlainFITSStrategy(datadir)
-    ctni = ParallelRun.infer_init(rcfs, strategy; box=box)
-    result = ParallelRun.one_node_single_infer(ctni...; config=Config(2.0, 3, 2), do_vi=false)
+    images = SDSSIO.load_field_images(strategy, rcfs)
+    c, t, n = ParallelRun.infer_init(images; box=box)
+    result = ParallelRun.one_node_single_infer(c, t, n, images; config=Config(2.0, 3, 2), do_vi=false)
 end
 
 
@@ -30,8 +31,9 @@ end
     box = ParallelRun.BoundingBox(164.39, 164.41, 39.11, 39.13)
     rcfs = [RunCamcolField(3900, 6, 269),]
     strategy = PlainFITSStrategy(datadir)
-    ctni = ParallelRun.infer_init(rcfs, strategy; box=box)
-    result = ParallelRun.one_node_single_infer(ctni...)
+    images = SDSSIO.load_field_images(strategy, rcfs)
+    c, t, n = ParallelRun.infer_init(images; box=box)
+    result = ParallelRun.one_node_single_infer(c, t, n, images)
 end
 
 


### PR DESCRIPTION
This substitutes in `infer_init_new()`, which uses SEP to find sources for the initialization catalog, for `infer_init()` which used an SDSS catalog.

In the accuracy benchmarks, `run_celeste_on_field.jl` now takes no arguments and uses source detection by default. The option to initialize from a catalog is still there, with `--initialization-catalog <filename>`.

## master

(first = primary, second = celeste prediction)
```
│ Row │ N   │ first     │ second    │ diff        │ diff_sd    │ field           │
├─────┼─────┼───────────┼───────────┼─────────────┼────────────┼─────────────────┤
│ 1   │ 128 │ 0.078125  │ 0.09375   │ -0.015625   │ 0.0238138  │ missed_stars    │
│ 2   │ 343 │ 0.0379009 │ 0.0291545 │ 0.00874636  │ 0.00864345 │ missed_galaxies │
│ 3   │ 471 │ 0.264242  │ 0.308173  │ -0.0439314  │ 0.0057081  │ position        │
│ 4   │ 380 │ 0.177765  │ 0.182055  │ -0.00429001 │ 0.0148959  │ flux_r_mag      │
│ 5   │ 380 │ 0.642483  │ 0.824231  │ -0.181748   │ 0.0801018  │ flux_r_nmgy     │
│ 6   │ 99  │ 16.2583   │ 15.685    │ 0.573306    │ 1.44051    │ gal_angle_deg   │
│ 7   │ 203 │ 0.255117  │ 0.221463  │ 0.0336534   │ 0.0222404  │ gal_frac_dev    │
│ 8   │ 203 │ 0.202949  │ 0.165704  │ 0.0372453   │ 0.0108118  │ gal_axis_ratio  │
│ 9   │ 203 │ 1.31983   │ 0.897505  │ 0.422324    │ 0.338132   │ gal_radius_px   │
│ 10  │ 362 │ 1.02056   │ 0.578394  │ 0.442169    │ 0.0510424  │ color_ug        │
│ 11  │ 462 │ 0.332076  │ 0.174087  │ 0.157989    │ 0.0191702  │ color_gr        │
│ 12  │ 470 │ 0.20101   │ 0.120696  │ 0.0803139   │ 0.0103564  │ color_ri        │
│ 13  │ 466 │ 0.379088  │ 0.183435  │ 0.195653    │ 0.0221637  │ color_iz        │
```

### This branch
(first = primary, second = celeste prediction)

(note that I only ran about half the sources due to the long run time of the benchmarks at the moment)
```
│ Row │ N   │ first     │ second    │ diff        │ diff_sd    │ field           │
├─────┼─────┼───────────┼───────────┼─────────────┼────────────┼─────────────────┤
│ 1   │ 130 │ 0.0769231 │ 0.0846154 │ -0.00769231 │ 0.0223499  │ missed_stars    │
│ 2   │ 348 │ 0.0373563 │ 0.0287356 │ 0.00862069  │ 0.0101801  │ missed_galaxies │
│ 3   │ 478 │ 0.265789  │ 0.270879  │ -0.00509    │ 0.00660327 │ position        │
│ 4   │ 381 │ 0.179465  │ 0.149103  │ 0.0303624   │ 0.0116654  │ flux_r_mag      │
│ 5   │ 381 │ 0.658841  │ 0.610068  │ 0.0487726   │ 0.0395769  │ flux_r_nmgy     │
│ 6   │ 103 │ 16.9512   │ 14.3415   │ 2.60965     │ 1.42288    │ gal_angle_deg   │
│ 7   │ 207 │ 0.261412  │ 0.175869  │ 0.0855428   │ 0.0223267  │ gal_frac_dev    │
│ 8   │ 207 │ 0.197599  │ 0.146603  │ 0.0509962   │ 0.00986572 │ gal_axis_ratio  │
│ 9   │ 207 │ 1.28067   │ 0.650054  │ 0.630618    │ 0.336502   │ gal_radius_px   │
│ 10  │ 366 │ 1.03162   │ 0.592062  │ 0.439559    │ 0.0521393  │ color_ug        │
│ 11  │ 469 │ 0.338734  │ 0.174291  │ 0.164443    │ 0.0205884  │ color_gr        │
│ 12  │ 477 │ 0.192402  │ 0.114165  │ 0.078237    │ 0.00909477 │ color_ri        │
│ 13  │ 473 │ 0.376071  │ 0.177662  │ 0.198409    │ 0.0216543  │ color_iz        │
```

Future work: SEP definitely picks up lots of bright and saturated stars that are already masked in the SDSS catalog. We'll want some heuristic to mask these. They should not affect benchmarks though, as only sources in both the coadd and prediction catalogs are included in benchmarks.

Closes #157.