### PR TITLE
fix test comparing joint and single infer

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,10 +30,6 @@ if length(test_files) > 0
 else
     testdir = joinpath(Pkg.dir("Celeste"), "test")
     testfiles = filter(r"^test_.*\.jl$", readdir(testdir))
-    if !test_long_running
-        info("Skipping stripe82 tests without --long-running flag.")
-        testfiles = setdiff(testfiles, ["test_stripe82.jl"])
-    end
 end
 
 timing_info = Any[]

--- a/test/test_infer.jl
+++ b/test/test_infer.jl
@@ -4,6 +4,29 @@ import JLD
 import Celeste: Config
 using Celeste.SDSSIO
 using Celeste.ParallelRun
+import Celeste.ParallelRun: OptimizedSource
+using Celeste.DeterministicVI
+
+function compute_obj_value(images::Vector{<:Image},
+                           catalog::Vector{CatalogEntry},
+                           box::BoundingBox,
+                           results::Vector{OptimizedSource})
+
+    # TODO: This stuff is duplicated from ParallelRun.infer_box.
+    # We should refactor infer_box to return the objective value in some way!
+    patches = Model.get_sky_patches(images, catalog)
+    entry_in_range = entry->((box.ramin < entry.pos[1] < box.ramax) &&
+                             (box.decmin < entry.pos[2] < box.decmax))
+    target_ids = find(entry_in_range, catalog)
+
+    # There must be a vp for every patch in the call to elbo().
+    # So, here we must limit patches to just the targets we optimized
+    # and pass [1, 2, 3, ...] as the target indexes.
+    ea = ElboArgs(images, patches[target_ids, :],
+                  collect(1:length(target_ids)); include_kl=false)
+    vp = [r.vs for r in results]
+    DeterministicVI.elbo(ea, vp).v[]
+end
 
 @testset "infer" begin
     @testset "infer_box() runs" begin
@@ -28,5 +51,26 @@ using Celeste.ParallelRun
         rcfs = [RunCamcolField(3900, 6, 269)]
         datadir = SampleData.DATADIR
         ParallelRun.infer_box(box, datadir, datadir)
+    end
+
+    @testset "joint vs single on overlapping sources" begin
+            images = SampleData.get_sdss_images(4263, 5, 119)
+        catalog = SampleData.get_sdss_catalog(4263, 5, 119)
+
+        # This box has 3 overlapping objects in it.
+        box = BoundingBox(0.467582, 0.473275, 0.588383, 0.595095)
+
+        results_single = ParallelRun.infer_box(images, catalog, box;
+                                               method=:single)
+        results_joint = ParallelRun.infer_box(images, catalog, box;
+                                              method=:joint)
+
+        @test length(results_single) == 3
+        @test length(results_joint) == 3
+
+        score_single = compute_obj_value(images, catalog, box, results_single)
+        score_joint = compute_obj_value(images, catalog, box, results_joint)
+
+        @test score_joint > score_single
     end
 end


### PR DESCRIPTION
Currently there isn't actually a test of joint inference. It had been tested in the long-running tests, but these have become quite out-of-date and thoroughly broken. This PR rescues one of those tests and leaves the rest of the long-running tests in a file `test/outofdate.jl`. (It is not clear how to fix these or whether they are really necessary and it's not currently a priority.)

The rescued test has been moved to `test_infer.jl` and is now always run. It runs joint VI and single VI on a few overlapping sources and checks that the joint result is better.

There are also a few whitespace changes and minor cleanups in `ParallelRun.jl`.