### PR TITLE
update to new `where` syntax

### DIFF
--- a/src/BivariateNormals.jl
+++ b/src/BivariateNormals.jl
@@ -26,10 +26,9 @@ Args:
 Returns:
   The 2x2 covariance matrix parameterized by the inputs.
 """
-function get_bvn_cov{NumType <: Number}(
-    ab::NumType, angle::NumType, scale::NumType)
+function get_bvn_cov(ab::T, angle::T, scale::T) where {T<:Number}
 
-    if NumType <: AbstractFloat
+    if T <: AbstractFloat
         @assert 0 < scale
         @assert 0 < ab <= 1.
     end
@@ -39,8 +38,8 @@ function get_bvn_cov{NumType <: Number}(
     ab_term = (ab ^ 2 - 1)
     scale_squared = scale ^ 2
     off_diag_term = -scale_squared * cp * sp * ab_term
-    @SMatrix NumType[scale_squared * (1 + ab_term * (sp ^ 2))  off_diag_term;
-                     off_diag_term                             scale_squared * (1 + ab_term * (cp ^ 2))]
+    @SMatrix T[scale_squared * (1 + ab_term * (sp ^ 2))  off_diag_term;
+               off_diag_term                             scale_squared * (1 + ab_term * (cp ^ 2))]
 end
 
 
@@ -49,61 +48,61 @@ end
 Pre-allocated memory for quantities related to derivatives of bivariate
 normals.
 """
-struct BivariateNormalDerivatives{NumType <: Number}
+struct BivariateNormalDerivatives{T<:Number}
 
-  # Pre-allocated memory for py1, py2, and f when evaluating BVNs
-  py1::Array{NumType, 1}
-  py2::Array{NumType, 1}
-  f_pre::Array{NumType, 1}
+    # Pre-allocated memory for py1, py2, and f when evaluating BVNs
+    py1::Array{T, 1}
+    py2::Array{T, 1}
+    f_pre::Array{T, 1}
 
-  # Derivatives of a bvn with respect to (x, sig).
-  bvn_x_d::Array{NumType, 1}
-  bvn_sig_d::Array{NumType, 1}
-  bvn_xx_h::SizedMatrix{2, 2, NumType, 2}
-  bvn_xsig_h::SizedMatrix{2, 3, NumType, 2}
-  bvn_sigsig_h::SizedMatrix{3, 3, NumType, 2}
+    # Derivatives of a bvn with respect to (x, sig).
+    bvn_x_d::Array{T, 1}
+    bvn_sig_d::Array{T, 1}
+    bvn_xx_h::SizedMatrix{2, 2, T, 2}
+    bvn_xsig_h::SizedMatrix{2, 3, T, 2}
+    bvn_sigsig_h::SizedMatrix{3, 3, T, 2}
 
-  # intermediate values used in d bvn / d(x, sig)
-  dpy1_dsig::Array{NumType, 1}
-  dpy2_dsig::Array{NumType, 1}
+    # intermediate values used in d bvn / d(x, sig)
+    dpy1_dsig::Array{T, 1}
+    dpy2_dsig::Array{T, 1}
 
-  # Derivatives of a bvn with respect to (pos, shape)
-  bvn_u_d::Array{NumType, 1}
-  bvn_uu_h::SizedMatrix{2, 2, NumType, 2}
-  bvn_s_d::Array{NumType, 1}
-  bvn_ss_h::SizedMatrix{GAL_SHAPE_IDS_LENGTH, GAL_SHAPE_IDS_LENGTH, NumType, 2}
-  bvn_us_h::SizedMatrix{2, GAL_SHAPE_IDS_LENGTH, NumType, 2}
+    # Derivatives of a bvn with respect to (pos, shape)
+    bvn_u_d::Array{T, 1}
+    bvn_uu_h::SizedMatrix{2, 2, T, 2}
+    bvn_s_d::Array{T, 1}
+    bvn_ss_h::SizedMatrix{GAL_SHAPE_IDS_LENGTH, GAL_SHAPE_IDS_LENGTH, T, 2}
+    bvn_us_h::SizedMatrix{2, GAL_SHAPE_IDS_LENGTH, T, 2}
 
-  function (::Type{BivariateNormalDerivatives{NumType}}){NumType}()
-    py1 = zeros(NumType, 1)
-    py2 = zeros(NumType, 1)
-    f_pre = zeros(NumType, 1)
+    function BivariateNormalDerivatives{T}() where {T<:Number}
+        py1 = zeros(T, 1)
+        py2 = zeros(T, 1)
+        f_pre = zeros(T, 1)
 
-    bvn_x_d = zeros(NumType, 2)
-    bvn_sig_d = zeros(NumType, 3)
-    bvn_xx_h = zeros(NumType, 2, 2)
-    bvn_xsig_h = zeros(NumType, 2, 3)
-    bvn_sigsig_h = zeros(NumType, 3, 3)
+        bvn_x_d = zeros(T, 2)
+        bvn_sig_d = zeros(T, 3)
+        bvn_xx_h = zeros(T, 2, 2)
+        bvn_xsig_h = zeros(T, 2, 3)
+        bvn_sigsig_h = zeros(T, 3, 3)
 
-    dpy1_dsig = zeros(NumType, 3)
-    dpy2_dsig = zeros(NumType, 3)
+        dpy1_dsig = zeros(T, 3)
+        dpy2_dsig = zeros(T, 3)
 
-    # Derivatives wrt pos.
-    bvn_u_d = zeros(NumType, 2)
-    bvn_uu_h = zeros(NumType, 2, 2)
+        # Derivatives wrt pos.
+        bvn_u_d = zeros(T, 2)
+        bvn_uu_h = zeros(T, 2, 2)
 
-    # Shape deriviatives.  Here, s stands for "shape".
-    bvn_s_d = zeros(NumType, GAL_SHAPE_IDS_LENGTH)
+        # Shape deriviatives.  Here, s stands for "shape".
+        bvn_s_d = zeros(T, GAL_SHAPE_IDS_LENGTH)
 
-    # The hessians.
-    bvn_ss_h = zeros(NumType, GAL_SHAPE_IDS_LENGTH, GAL_SHAPE_IDS_LENGTH)
-    bvn_us_h = zeros(NumType, 2, GAL_SHAPE_IDS_LENGTH)
+        # The hessians.
+        bvn_ss_h = zeros(T, GAL_SHAPE_IDS_LENGTH, GAL_SHAPE_IDS_LENGTH)
+        bvn_us_h = zeros(T, 2, GAL_SHAPE_IDS_LENGTH)
 
-    new{NumType}(py1, py2, f_pre,
-        bvn_x_d, bvn_sig_d, bvn_xx_h, bvn_xsig_h, bvn_sigsig_h,
-        dpy1_dsig, dpy2_dsig,
-        bvn_u_d, bvn_uu_h, bvn_s_d, bvn_ss_h, bvn_us_h)
-  end
+        new(py1, py2, f_pre,
+            bvn_x_d, bvn_sig_d, bvn_xx_h, bvn_xsig_h, bvn_sigsig_h,
+            dpy1_dsig, dpy2_dsig,
+            bvn_u_d, bvn_uu_h, bvn_s_d, bvn_ss_h, bvn_us_h)
+    end
 end
 
 function zero!(bvn_derivs::BivariateNormalDerivatives{T}) where {T}
@@ -141,19 +140,21 @@ Attributes:
    dsiginv_dsig: The derivative of sigma inverse with respect to sigma.
    major_sd: The standard deviation of the major axis.
 """
-struct BvnComponent{NumType <: Number}
-    the_mean::SVector{2,NumType}
-    precision::SMatrix{2,2,NumType,4}
-    z::NumType
-    dsiginv_dsig::SMatrix{3,3,NumType,9}
-    major_sd::NumType
+struct BvnComponent{T<:Number}
+    the_mean::SVector{2,T}
+    precision::SMatrix{2,2,T,4}
+    z::T
+    dsiginv_dsig::SMatrix{3,3,T,9}
+    major_sd::T
 end
 
-function BvnComponent{T1<:Number,T2<:Number,T3<:Number}(
-    the_mean::SVector{2,T1}, the_cov::SMatrix{2,2,T2,4}, weight::T3,
-    calculate_siginv_deriv::Bool=true)
+function BvnComponent(
+    the_mean::SVector{2,T1},
+    the_cov::SMatrix{2,2,T2,4},
+    weight::T3,
+    calculate_siginv_deriv::Bool=true) where {T1<:Number,T2<:Number,T3<:Number}
 
-    NumType = promote_type(T1,T2,T3)
+    T = promote_type(T1, T2, T3)
     c = 1 / (sqrt(det(the_cov)) * 2pi)
     major_sd = sqrt(max( the_cov[1, 1], the_cov[2, 2] ))
 
@@ -177,15 +178,15 @@ function BvnComponent{T1<:Number,T2<:Number,T3<:Number}(
         dsiginv_dsig32 = - 2 * precision[2, 2] * precision[2, 1]
         dsiginv_dsig33 = -precision[2, 2] ^ 2
 
-        dsiginv_dsig = @SMatrix NumType[ dsiginv_dsig11 dsiginv_dsig12 dsiginv_dsig13;
-                                           dsiginv_dsig21 dsiginv_dsig22 dsiginv_dsig23;
-                                           dsiginv_dsig13 dsiginv_dsig32 dsiginv_dsig33 ]
+        dsiginv_dsig = @SMatrix T[dsiginv_dsig11 dsiginv_dsig12 dsiginv_dsig13;
+                                  dsiginv_dsig21 dsiginv_dsig22 dsiginv_dsig23;
+                                  dsiginv_dsig13 dsiginv_dsig32 dsiginv_dsig33]
 
-        BvnComponent{NumType}(the_mean, precision, c * weight,
-                              dsiginv_dsig, major_sd)
+        BvnComponent{T}(the_mean, precision, c * weight,
+                        dsiginv_dsig, major_sd)
     else
-        BvnComponent{NumType}(the_mean, precision, c * weight,
-                              zeros(SMatrix{3,3,NumType,9}), major_sd)
+        BvnComponent{T}(the_mean, precision, c * weight,
+                        zeros(SMatrix{3,3,T,9}), major_sd)
     end
 end
 
@@ -204,19 +205,20 @@ Returns:
   - py2: The second row of the precision times (x - the_mean)
   - The density of the bivariate normal times the weight.
 """
-function eval_bvn_pdf!{NumType <: Number}(
-    bvn_derivs::BivariateNormalDerivatives{NumType},
-    bmc::BvnComponent{NumType}, x::SVector{2,Float64})
+function eval_bvn_pdf!(
+    bvn_derivs::BivariateNormalDerivatives{T},
+    bmc::BvnComponent{T},
+    x::SVector{2,Float64}) where {T<:Number}
 
-  bvn_derivs.py1[1] =
-    bmc.precision[1,1] * (x[1] - bmc.the_mean[1]) +
-    bmc.precision[1,2] * (x[2] - bmc.the_mean[2])
-  bvn_derivs.py2[1] =
-    bmc.precision[2,1] * (x[1] - bmc.the_mean[1]) +
-    bmc.precision[2,2] * (x[2] - bmc.the_mean[2])
-  bvn_derivs.f_pre[1] =
-    bmc.z * exp(-0.5 * ((x[1] - bmc.the_mean[1]) * bvn_derivs.py1[1] +
-                        (x[2] - bmc.the_mean[2]) * bvn_derivs.py2[1]))
+    bvn_derivs.py1[1] =
+        bmc.precision[1,1] * (x[1] - bmc.the_mean[1]) +
+        bmc.precision[1,2] * (x[2] - bmc.the_mean[2])
+    bvn_derivs.py2[1] =
+        bmc.precision[2,1] * (x[1] - bmc.the_mean[1]) +
+        bmc.precision[2,2] * (x[2] - bmc.the_mean[2])
+    bvn_derivs.f_pre[1] =
+        bmc.z * exp(-0.5 * ((x[1] - bmc.the_mean[1]) * bvn_derivs.py1[1] +
+                            (x[2] - bmc.the_mean[2]) * bvn_derivs.py2[1]))
 end
 
 ##################
@@ -235,83 +237,85 @@ Args:
   - calculate_x_hess: Whether to calcualte x Hessian terms.
   - calculate_sigma_hess: Whether to calcualte sigma Hessian terms.
 """
-function get_bvn_derivs!{NumType <: Number}(
-    bvn_derivs::BivariateNormalDerivatives{NumType},
-    bvn::BvnComponent{NumType}, calculate_x_hess::Bool,
-    calculate_sigma_hessian::Bool)
+function get_bvn_derivs!(
+    bvn_derivs::BivariateNormalDerivatives{T},
+    bvn::BvnComponent{T},
+    calculate_x_hess::Bool,
+    calculate_sigma_hessian::Bool) where {T<:Number}
 
-  @inbounds begin
+    @inbounds begin
 
-    # Gradient with respect to x.
-    bvn_x_d = bvn_derivs.bvn_x_d
-    bvn_x_d[1] = -bvn_derivs.py1[1]
-    bvn_x_d[2] = -bvn_derivs.py2[1]
+        # Gradient with respect to x.
+        bvn_x_d = bvn_derivs.bvn_x_d
+        bvn_x_d[1] = -bvn_derivs.py1[1]
+        bvn_x_d[2] = -bvn_derivs.py2[1]
 
-    if calculate_x_hess
-      bvn_xx_h = bvn_derivs.bvn_xx_h
+        if calculate_x_hess
+            bvn_xx_h = bvn_derivs.bvn_xx_h
 
-      # Hessian terms involving only x
-      bvn_xx_h[1, 1] = -bvn.precision[1, 1]
-      bvn_xx_h[2, 2] = -bvn.precision[2, 2]
-      bvn_xx_h[1, 2] = bvn_xx_h[2, 1] = -bvn.precision[1 ,2]
+            # Hessian terms involving only x
+            bvn_xx_h[1, 1] = -bvn.precision[1, 1]
+            bvn_xx_h[2, 2] = -bvn.precision[2, 2]
+            bvn_xx_h[1, 2] = bvn_xx_h[2, 1] = -bvn.precision[1 ,2]
+        end
+
+        # The first term is the derivative of -0.5 * x' Sigma^{-1} x
+        # The second term is the derivative of -0.5 * log|Sigma|
+        bvn_sig_d = bvn_derivs.bvn_sig_d
+        bvn_sig_d[1] =
+            0.5 * bvn_derivs.py1[1] * bvn_derivs.py1[1] - 0.5 * bvn.precision[1, 1]
+        bvn_sig_d[2] =
+            bvn_derivs.py1[1] * bvn_derivs.py2[1]             - bvn.precision[1, 2]
+        bvn_sig_d[3] =
+            0.5 * bvn_derivs.py2[1] * bvn_derivs.py2[1] - 0.5 * bvn.precision[2, 2]
+
+        if calculate_sigma_hessian
+
+            # Hessian calculation for terms containing sigma.
+
+            # Derivatives of py1 and py2 with respect to s11, s12, s22
+            # in that order.  These are used for the hessian
+            # calculations.
+            dpy1_dsig = bvn_derivs.dpy1_dsig
+            dpy1_dsig[1] = -bvn_derivs.py1[1] * bvn.precision[1,1]
+            dpy1_dsig[2] = -bvn_derivs.py2[1] * bvn.precision[1,1] -
+                            bvn_derivs.py1[1] * bvn.precision[1,2]
+            dpy1_dsig[3] = -bvn_derivs.py2[1] * bvn.precision[1,2]
+
+            dpy2_dsig = bvn_derivs.dpy2_dsig
+            dpy2_dsig[1] = -bvn_derivs.py1[1] * bvn.precision[1,2]
+            dpy2_dsig[2] = -bvn_derivs.py1[1] * bvn.precision[2,2] -
+                            bvn_derivs.py2[1] * bvn.precision[1,2]
+            dpy2_dsig[3] = -bvn_derivs.py2[1] * bvn.precision[2,2]
+
+            # Hessian terms involving only sigma
+            bvn_sigsig_h = bvn_derivs.bvn_sigsig_h
+            for s_ind=1:3
+                # Differentiate with respect to s_ind second.
+                bvn_sigsig_h[1, s_ind] = #bvn_sigsig_h[s_ind, 1] =
+                    bvn_derivs.py1[1] * dpy1_dsig[s_ind] - 0.5 * bvn.dsiginv_dsig[1, s_ind]
+
+                # d log|sigma| / dsigma12 is twice lambda12.
+                bvn_sigsig_h[2, s_ind] =
+                    bvn_derivs.py1[1] * dpy2_dsig[s_ind] + bvn_derivs.py2[1] * dpy1_dsig[s_ind] -
+                    bvn.dsiginv_dsig[2, s_ind]
+
+                bvn_sigsig_h[3, s_ind] = #bvn_sigsig_h[s_ind, 3] =
+                    bvn_derivs.py2[1] * dpy2_dsig[s_ind] - 0.5 * bvn.dsiginv_dsig[3, s_ind]
+            end
+
+            # Hessian terms involving both x and sigma.
+            # Note that dpyA / dxB = bvn.precision[A, B]
+            bvn_xsig_h = bvn_derivs.bvn_xsig_h
+            for x_ind=1:2
+                bvn_xsig_h[x_ind, 1] = bvn_derivs.py1[1] * bvn.precision[1, x_ind]
+                bvn_xsig_h[x_ind, 2] =
+                    bvn_derivs.py1[1] * bvn.precision[2, x_ind] +
+                    bvn_derivs.py2[1] * bvn.precision[1, x_ind]
+                bvn_xsig_h[x_ind, 3] = bvn_derivs.py2[1] * bvn.precision[2, x_ind]
+            end
+        end
     end
-
-    # The first term is the derivative of -0.5 * x' Sigma^{-1} x
-    # The second term is the derivative of -0.5 * log|Sigma|
-    bvn_sig_d = bvn_derivs.bvn_sig_d
-    bvn_sig_d[1] =
-      0.5 * bvn_derivs.py1[1] * bvn_derivs.py1[1] - 0.5 * bvn.precision[1, 1]
-    bvn_sig_d[2] =
-      bvn_derivs.py1[1] * bvn_derivs.py2[1]             - bvn.precision[1, 2]
-    bvn_sig_d[3] =
-      0.5 * bvn_derivs.py2[1] * bvn_derivs.py2[1] - 0.5 * bvn.precision[2, 2]
-
-    if calculate_sigma_hessian
-
-      # Hessian calculation for terms containing sigma.
-
-      # Derivatives of py1 and py2 with respect to s11, s12, s22 in that order.
-      # These are used for the hessian calculations.
-      dpy1_dsig = bvn_derivs.dpy1_dsig
-      dpy1_dsig[1] = -bvn_derivs.py1[1] * bvn.precision[1,1]
-      dpy1_dsig[2] = -bvn_derivs.py2[1] * bvn.precision[1,1] -
-                      bvn_derivs.py1[1] * bvn.precision[1,2]
-      dpy1_dsig[3] = -bvn_derivs.py2[1] * bvn.precision[1,2]
-
-      dpy2_dsig = bvn_derivs.dpy2_dsig
-      dpy2_dsig[1] = -bvn_derivs.py1[1] * bvn.precision[1,2]
-      dpy2_dsig[2] = -bvn_derivs.py1[1] * bvn.precision[2,2] -
-                      bvn_derivs.py2[1] * bvn.precision[1,2]
-      dpy2_dsig[3] = -bvn_derivs.py2[1] * bvn.precision[2,2]
-
-      # Hessian terms involving only sigma
-      bvn_sigsig_h = bvn_derivs.bvn_sigsig_h
-      for s_ind=1:3
-        # Differentiate with respect to s_ind second.
-        bvn_sigsig_h[1, s_ind] = #bvn_sigsig_h[s_ind, 1] =
-          bvn_derivs.py1[1] * dpy1_dsig[s_ind] - 0.5 * bvn.dsiginv_dsig[1, s_ind]
-
-        # d log|sigma| / dsigma12 is twice lambda12.
-        bvn_sigsig_h[2, s_ind] =
-          bvn_derivs.py1[1] * dpy2_dsig[s_ind] + bvn_derivs.py2[1] * dpy1_dsig[s_ind] -
-          bvn.dsiginv_dsig[2, s_ind]
-
-        bvn_sigsig_h[3, s_ind] = #bvn_sigsig_h[s_ind, 3] =
-          bvn_derivs.py2[1] * dpy2_dsig[s_ind] - 0.5 * bvn.dsiginv_dsig[3, s_ind]
-      end
-
-      # Hessian terms involving both x and sigma.
-      # Note that dpyA / dxB = bvn.precision[A, B]
-      bvn_xsig_h = bvn_derivs.bvn_xsig_h
-      for x_ind=1:2
-        bvn_xsig_h[x_ind, 1] = bvn_derivs.py1[1] * bvn.precision[1, x_ind]
-        bvn_xsig_h[x_ind, 2] =
-          bvn_derivs.py1[1] * bvn.precision[2, x_ind] +
-          bvn_derivs.py2[1] * bvn.precision[1, x_ind]
-        bvn_xsig_h[x_ind, 3] = bvn_derivs.py2[1] * bvn.precision[2, x_ind]
-      end
-    end
-  end
 end
 
 
@@ -324,9 +328,9 @@ parameters are indexed by GalaxyShapeParams.
  - t: A Sigma x GalaxyShapeParams x GalaxyShapeParams tensor of second
       derivatives d2 Sigma / d GalaxyShapeParams d GalaxyShapeParams.
 """
-struct GalaxySigmaDerivs{NumType <: Number}
-    j::SMatrix{3,GAL_SHAPE_IDS_LENGTH,NumType,9}
-    t::SArray{Tuple{3,GAL_SHAPE_IDS_LENGTH,GAL_SHAPE_IDS_LENGTH},NumType,3,27}
+struct GalaxySigmaDerivs{T <: Number}
+    j::SMatrix{3,GAL_SHAPE_IDS_LENGTH,T,9}
+    t::SArray{Tuple{3,GAL_SHAPE_IDS_LENGTH,GAL_SHAPE_IDS_LENGTH},T,3,27}
 end
 
 
@@ -339,42 +343,63 @@ Args:
 
 Note that nubar is not included.
 """
-function GalaxySigmaDerivs{NumType <: Number}(
-    gal_angle::NumType, gal_axis_ratio::NumType, gal_radius_px::NumType,
-    XiXi::SMatrix{2,2,NumType,4}, nuBar::Float64=1.0, calculate_tensor::Bool=true)
+function GalaxySigmaDerivs(
+    gal_angle::T,
+    gal_axis_ratio::T,
+    gal_radius_px::T,
+    XiXi::SMatrix{2,2,T,4},
+    nuBar::Float64=1.0,
+    calculate_tensor::Bool=true) where {T<:Number}
 
-  cos_sin = cos(gal_angle)sin(gal_angle)
-  sin_sq  = sin(gal_angle)^2
-  cos_sq  = cos(gal_angle)^2
+    cos_sin = cos(gal_angle)sin(gal_angle)
+    sin_sq  = sin(gal_angle)^2
+    cos_sq  = cos(gal_angle)^2
 
-  j = hcat(2 * gal_axis_ratio * gal_radius_px^2 * SVector{3,NumType}(sin_sq, -cos_sin, cos_sq),
-           gal_radius_px^2 * (gal_axis_ratio^2 - 1) * SVector{3,NumType}(2cos_sin, sin_sq - cos_sq, -2cos_sin),
-           2 * SVector{3,NumType}(XiXi[1], XiXi[2], XiXi[4]) / gal_radius_px)
+    j = hcat(2 * gal_axis_ratio * gal_radius_px^2 * SVector{3,T}(sin_sq, -cos_sin, cos_sq),
+             gal_radius_px^2 * (gal_axis_ratio^2 - 1) * SVector{3,T}(2cos_sin, sin_sq - cos_sq, -2cos_sin),
+             2 * SVector{3,T}(XiXi[1], XiXi[2], XiXi[4]) / gal_radius_px)
 
-  if calculate_tensor
-    # Second derivatives.
+    if calculate_tensor
+        # Second derivatives.
+        t = SArray{Tuple{3,3,3}, T, 3, 27}(sin_sq * 2 * gal_radius_px^2,
+                                           -cos_sin * 2 * gal_radius_px^2,
+                                           cos_sq * 2 * gal_radius_px^2,
+                                           2cos_sin * 2 * gal_radius_px^2 * gal_axis_ratio,
+                                           (sin_sq - cos_sq) * 2 * gal_radius_px^2 * gal_axis_ratio,
+                                           -2cos_sin * 2 * gal_radius_px^2 * gal_axis_ratio,
+                                           2 * j[1, 1]  / gal_radius_px,
+                                           2 * j[2, 1]  / gal_radius_px,
+                                           2 * j[3, 1]  / gal_radius_px,
+                                           2cos_sin * 2 * gal_radius_px^2 * gal_axis_ratio,
+                                           (sin_sq - cos_sq) * 2 * gal_radius_px^2 * gal_axis_ratio,
+                                           -2cos_sin * 2 * gal_radius_px^2 * gal_axis_ratio,
+                                           (cos_sq - sin_sq) * 2 * gal_radius_px^2 * (gal_axis_ratio^2 - 1),
+                                           2cos_sin * 2 * gal_radius_px^2 * (gal_axis_ratio^2 - 1),
+                                           (sin_sq - cos_sq) * 2 * gal_radius_px^2 * (gal_axis_ratio^2 - 1),
+                                           2 * j[1, 2] / gal_radius_px,
+                                           2 * j[2, 2] / gal_radius_px,
+                                           2 * j[3, 2] / gal_radius_px,
+                                           2 * j[1, 1]  / gal_radius_px,
+                                           2 * j[2, 1]  / gal_radius_px,
+                                           2 * j[3, 1]  / gal_radius_px,
+                                           2 * j[1, 2] / gal_radius_px,
+                                           2 * j[2, 2] / gal_radius_px,
+                                           2 * j[3, 2] / gal_radius_px,
+                                           2 * XiXi[1 << (1 - 1)] / gal_radius_px^2,
+                                           2 * XiXi[1 << (2 - 1)] / gal_radius_px^2,
+                                           2 * XiXi[1 << (3 - 1)] / gal_radius_px^2)
 
-    t = SArray{Tuple{3,3,3}, NumType, 3, 27}(sin_sq * 2 * gal_radius_px^2, -cos_sin * 2 * gal_radius_px^2, cos_sq * 2 * gal_radius_px^2,
-      2cos_sin * 2 * gal_radius_px^2 * gal_axis_ratio, (sin_sq - cos_sq) * 2 * gal_radius_px^2 * gal_axis_ratio, -2cos_sin * 2 * gal_radius_px^2 * gal_axis_ratio,
-      2 * j[1, 1]  / gal_radius_px, 2 * j[2, 1]  / gal_radius_px, 2 * j[3, 1]  / gal_radius_px,
-      2cos_sin * 2 * gal_radius_px^2 * gal_axis_ratio, (sin_sq - cos_sq) * 2 * gal_radius_px^2 * gal_axis_ratio, -2cos_sin * 2 * gal_radius_px^2 * gal_axis_ratio,
-      (cos_sq - sin_sq) * 2 * gal_radius_px^2 * (gal_axis_ratio^2 - 1), 2cos_sin * 2 * gal_radius_px^2 * (gal_axis_ratio^2 - 1), (sin_sq - cos_sq) * 2 * gal_radius_px^2 * (gal_axis_ratio^2 - 1),
-      2 * j[1, 2] / gal_radius_px, 2 * j[2, 2] / gal_radius_px, 2 * j[3, 2] / gal_radius_px,
-      2 * j[1, 1]  / gal_radius_px, 2 * j[2, 1]  / gal_radius_px, 2 * j[3, 1]  / gal_radius_px,
-      2 * j[1, 2] / gal_radius_px, 2 * j[2, 2] / gal_radius_px, 2 * j[3, 2] / gal_radius_px,
-      2 * XiXi[1 << (1 - 1)] / gal_radius_px^2, 2 * XiXi[1 << (2 - 1)] / gal_radius_px^2, 2 * XiXi[1 << (3 - 1)] / gal_radius_px^2)
+    else
+        t = @SArray zeros(T, 3, 3, 3)
+    end
 
-  else
-    t = @SArray zeros(NumType, 3, 3, 3)
-  end
-
-  GalaxySigmaDerivs(j*nuBar, t*nuBar)
+    return GalaxySigmaDerivs{T}(j*nuBar, t*nuBar)
 end
 
 
-GalaxySigmaDerivs{NumType}(::Type{NumType}) = GalaxySigmaDerivs(
-                                                     @SMatrix(zeros(NumType,3,GAL_SHAPE_IDS_LENGTH)),
-                                                     @SArray( zeros(NumType,3,GAL_SHAPE_IDS_LENGTH,GAL_SHAPE_IDS_LENGTH)))
+GalaxySigmaDerivs(::Type{T}) where {T<:Number} =
+    GalaxySigmaDerivs{T}(@SMatrix(zeros(T,3,GAL_SHAPE_IDS_LENGTH)),
+                         @SArray( zeros(T,3,GAL_SHAPE_IDS_LENGTH,GAL_SHAPE_IDS_LENGTH)))
 
 
 ###################################################
@@ -386,114 +411,118 @@ galaxy parameters (pos). Updates bvn_u_d and bvn_uu_h in place.
 
 bvn_x_d and bvn_xx_h should already have been set using get_bvn_derivs!()
 """
-function transform_bvn_ux_derivs!{NumType <: Number}(
-    bvn_derivs::BivariateNormalDerivatives{NumType},
-    wcs_jacobian, calculate_hessian::Bool)
+function transform_bvn_ux_derivs!(
+    bvn_derivs::BivariateNormalDerivatives{T},
+    wcs_jacobian,
+    calculate_hessian::Bool) where {T<:Number}
 
-  # Gradient calculations.
+    # Gradient calculations.
 
-  # Note that dxA_duB = -wcs_jacobian[A, B].  (It is minus the jacobian
-  # because the object position affects the bvn.the_mean term, which is
-  # subtracted from the pixel location as defined in bvn_sf.d.)
-  bvn_u_d = bvn_derivs.bvn_u_d
-  bvn_x_d = bvn_derivs.bvn_x_d
-  bvn_u_d[1] =
-    -(bvn_x_d[1] * wcs_jacobian[1, 1] + bvn_x_d[2] * wcs_jacobian[2, 1])
-  bvn_u_d[2] =
-    -(bvn_x_d[1] * wcs_jacobian[1, 2] + bvn_x_d[2] * wcs_jacobian[2, 2])
+    # Note that dxA_duB = -wcs_jacobian[A, B].  (It is minus the jacobian
+    # because the object position affects the bvn.the_mean term, which is
+    # subtracted from the pixel location as defined in bvn_sf.d.)
+    bvn_u_d = bvn_derivs.bvn_u_d
+    bvn_x_d = bvn_derivs.bvn_x_d
+    bvn_u_d[1] =
+        -(bvn_x_d[1] * wcs_jacobian[1, 1] + bvn_x_d[2] * wcs_jacobian[2, 1])
+    bvn_u_d[2] =
+        -(bvn_x_d[1] * wcs_jacobian[1, 2] + bvn_x_d[2] * wcs_jacobian[2, 2])
 
-  if calculate_hessian
-    # Hessian calculations.
+    if calculate_hessian
+        # Hessian calculations.
 
-    bvn_uu_h = bvn_derivs.bvn_uu_h
-    bvn_xx_h = bvn_derivs.bvn_xx_h
-    fill!(bvn_uu_h, 0.0)
-    # Second derivatives involving only pos.
-    # As above, dxA_duB = -wcs_jacobian[A, B] and d2x / du2 = 0.
-    # TODO: time consuming **************
-    @inbounds for x_id2 in 1:2, x_id1 in 1:2, u_id2 in 1:2
-      inner_term = bvn_xx_h[x_id1, x_id2] * wcs_jacobian[x_id2, u_id2]
-      @inbounds for u_id1 in 1:u_id2
-        bvn_uu_h[u_id1, u_id2] += inner_term * wcs_jacobian[x_id1, u_id1]
-      end
+        bvn_uu_h = bvn_derivs.bvn_uu_h
+        bvn_xx_h = bvn_derivs.bvn_xx_h
+        fill!(bvn_uu_h, 0.0)
+        # Second derivatives involving only pos.
+        # As above, dxA_duB = -wcs_jacobian[A, B] and d2x / du2 = 0.
+        # TODO: time consuming **************
+        @inbounds for x_id2 in 1:2, x_id1 in 1:2, u_id2 in 1:2
+            inner_term = bvn_xx_h[x_id1, x_id2] * wcs_jacobian[x_id2, u_id2]
+            @inbounds for u_id1 in 1:u_id2
+                bvn_uu_h[u_id1, u_id2] += inner_term * wcs_jacobian[x_id1, u_id1]
+            end
+        end
+        @inbounds bvn_uu_h[2, 1] = bvn_uu_h[1, 2]
     end
-    @inbounds bvn_uu_h[2, 1] = bvn_uu_h[1, 2]
-  end
 end
 
-@generated function fast_fill!{T<:SizedMatrix}(s::T, x)
-  quote
-    $(Expr(:meta, :inline))
-    @unroll_loop for i in 1:$(size(s, 1))
-      @unroll_loop for j in 1:$(size(s, 2))
-        @inbounds s[i, j] = x
-      end
+
+@generated function fast_fill!(s::T, x) where {T<:SizedMatrix}
+    quote
+        $(Expr(:meta, :inline))
+        @unroll_loop for i in 1:$(size(s, 1))
+            @unroll_loop for j in 1:$(size(s, 2))
+                @inbounds s[i, j] = x
+            end
+        end
     end
-  end
 end
-fast_fill!{T<:Array}(s::T, x) = fill!(s, x)
+fast_fill!(s::T, x) where {T<:Array} = fill!(s, x)
+
 
 # WARNING: HUGE PERFORMANCE HOTSPOT
-function transform_bvn_derivs_hessian!{NumType <: Number}(
-    bvn_derivs::BivariateNormalDerivatives{NumType},
-    sig_sf::GalaxySigmaDerivs{NumType},
-    wcs_jacobian)
-  @aliasscope begin
-    # Hessian calculations.
+function transform_bvn_derivs_hessian!(
+    bvn_derivs::BivariateNormalDerivatives{T},
+    sig_sf::GalaxySigmaDerivs{T},
+    wcs_jacobian) where {T<:Number}
 
-    bvn_ss_h = bvn_derivs.bvn_ss_h
-    bvn_us_h = bvn_derivs.bvn_us_h
-    bvn_sig_d = Const(bvn_derivs.bvn_sig_d)
-    #wcs_jacobian = Const(wcs_jacobian)
-    sig_sf_j = sig_sf.j
+    @aliasscope begin
+        # Hessian calculations.
 
-    # Manually inlined version of fill!
-    fast_fill!(bvn_ss_h, 0.0)
-    fast_fill!(bvn_us_h, 0.0)
+        bvn_ss_h = bvn_derivs.bvn_ss_h
+        bvn_us_h = bvn_derivs.bvn_us_h
+        bvn_sig_d = Const(bvn_derivs.bvn_sig_d)
+        #wcs_jacobian = Const(wcs_jacobian)
+        sig_sf_j = sig_sf.j
 
-    # Second derviatives involving only shape parameters.
-    # TODO: time consuming **************
-    sig_sf_t = sig_sf.t
-    @unroll_loop for shape_id2 in 1:GAL_SHAPE_IDS_LENGTH
-      @unroll_loop for shape_id1 in 1:shape_id2
-        @inbounds @unroll_loop for sig_id1 in 1:3
-          bvn_ss_h[shape_id1, shape_id2] += bvn_sig_d[sig_id1] * sig_sf_t[sig_id1, shape_id1, shape_id2]
+        # Manually inlined version of fill!
+        fast_fill!(bvn_ss_h, 0.0)
+        fast_fill!(bvn_us_h, 0.0)
+
+        # Second derviatives involving only shape parameters.
+        # TODO: time consuming **************
+        sig_sf_t = sig_sf.t
+        @unroll_loop for shape_id2 in 1:GAL_SHAPE_IDS_LENGTH
+            @unroll_loop for shape_id1 in 1:shape_id2
+                @inbounds @unroll_loop for sig_id1 in 1:3
+                    bvn_ss_h[shape_id1, shape_id2] += bvn_sig_d[sig_id1] * sig_sf_t[sig_id1, shape_id1, shape_id2]
+                end
+            end
         end
-      end
-    end
 
-    bvn_sigsig_h = Const(bvn_derivs.bvn_sigsig_h)
-    @unroll_loop for sig_id1 in 1:3
-      @unroll_loop for sig_id2 in 1:3
-        @inbounds @unroll_loop for shape_id2 in 1:GAL_SHAPE_IDS_LENGTH
-          inner_term = bvn_sigsig_h[sig_id1, sig_id2] * sig_sf_j[sig_id2, shape_id2]
-          @unroll_loop for shape_id1 in 1:shape_id2
-            bvn_ss_h[shape_id1, shape_id2] += inner_term * sig_sf_j[sig_id1, shape_id1]
-          end
+        bvn_sigsig_h = Const(bvn_derivs.bvn_sigsig_h)
+        @unroll_loop for sig_id1 in 1:3
+            @unroll_loop for sig_id2 in 1:3
+                @inbounds @unroll_loop for shape_id2 in 1:GAL_SHAPE_IDS_LENGTH
+                    inner_term = bvn_sigsig_h[sig_id1, sig_id2] * sig_sf_j[sig_id2, shape_id2]
+                    @unroll_loop for shape_id1 in 1:shape_id2
+                        bvn_ss_h[shape_id1, shape_id2] += inner_term * sig_sf_j[sig_id1, shape_id1]
+                    end
+                end
+            end
         end
-      end
-    end
 
-    @unroll_loop for shape_id2 in 1:GAL_SHAPE_IDS_LENGTH
-      @inbounds @unroll_loop for shape_id1 in 1:shape_id2
-        bvn_ss_h[shape_id2, shape_id1] = bvn_ss_h[shape_id1, shape_id2]
-      end
-    end
-
-    # Second derivates involving both a shape term and a pos term.
-    # TODO: time consuming **************
-    bvn_xsig_h = Const(bvn_derivs.bvn_xsig_h)
-    @unroll_loop for shape_id in 1:GAL_SHAPE_IDS_LENGTH
-      @unroll_loop for u_id in 1:2
-        @unroll_loop for sig_id in 1:3
-          @inbounds @unroll_loop for x_id in 1:2
-            bvn_us_h[u_id, shape_id] +=
-              bvn_xsig_h[x_id, sig_id] * sig_sf_j[sig_id, shape_id] * (-wcs_jacobian[x_id, u_id])
-          end
+        @unroll_loop for shape_id2 in 1:GAL_SHAPE_IDS_LENGTH
+            @inbounds @unroll_loop for shape_id1 in 1:shape_id2
+                bvn_ss_h[shape_id2, shape_id1] = bvn_ss_h[shape_id1, shape_id2]
+            end
         end
-      end
+
+        # Second derivates involving both a shape term and a pos term.
+        # TODO: time consuming **************
+        bvn_xsig_h = Const(bvn_derivs.bvn_xsig_h)
+        @unroll_loop for shape_id in 1:GAL_SHAPE_IDS_LENGTH
+            @unroll_loop for u_id in 1:2
+                @unroll_loop for sig_id in 1:3
+                    @inbounds @unroll_loop for x_id in 1:2
+                        bvn_us_h[u_id, shape_id] +=
+                            bvn_xsig_h[x_id, sig_id] * sig_sf_j[sig_id, shape_id] * (-wcs_jacobian[x_id, u_id])
+                    end
+                end
+            end
+        end
     end
-  end
 end
 
 
@@ -508,36 +537,37 @@ bvn_sig_d
 bvn_sigsig_h
 bvn_xsig_h
 """
-function transform_bvn_derivs!{NumType <: Number}(
-    bvn_derivs::BivariateNormalDerivatives{NumType},
-    sig_sf::GalaxySigmaDerivs{NumType},
-    wcs_jacobian, calculate_hessian::Bool)
+function transform_bvn_derivs!(
+    bvn_derivs::BivariateNormalDerivatives{T},
+    sig_sf::GalaxySigmaDerivs{T},
+    wcs_jacobian,
+    calculate_hessian::Bool) where {T<:Number}
 
-  # Transform the pos derivates first.
-  # bvn_x_d and bvn_xx_h should already have been set using get_bvn_derivs!()
-  transform_bvn_ux_derivs!(bvn_derivs, wcs_jacobian, calculate_hessian)
+    # Transform the pos derivates first.
+    # bvn_x_d and bvn_xx_h should already have been set using get_bvn_derivs!()
+    transform_bvn_ux_derivs!(bvn_derivs, wcs_jacobian, calculate_hessian)
 
-  # Gradient calculations.
+    # Gradient calculations.
 
-  @aliasscope begin
-      # Use the chain rule for the shape derviatives.
-      # TODO: time consuming **************
-      @aliasscope begin
-        bvn_s_d   = bvn_derivs.bvn_s_d
-        bvn_sig_d = Const(bvn_derivs.bvn_sig_d)
-        sig_sf_j = sig_sf.j
+    @aliasscope begin
+        # Use the chain rule for the shape derviatives.
+        # TODO: time consuming **************
+        @aliasscope begin
+            bvn_s_d   = bvn_derivs.bvn_s_d
+            bvn_sig_d = Const(bvn_derivs.bvn_sig_d)
+            sig_sf_j = sig_sf.j
 
-        fast_fill!(bvn_s_d, 0.0)
-        @unroll_loop for shape_id in 1:GAL_SHAPE_IDS_LENGTH
-          @inbounds @unroll_loop for sig_id in 1:3
-            bvn_s_d[shape_id] += bvn_sig_d[sig_id] * sig_sf_j[sig_id, shape_id]
-          end
+            fast_fill!(bvn_s_d, 0.0)
+            @unroll_loop for shape_id in 1:GAL_SHAPE_IDS_LENGTH
+                @inbounds @unroll_loop for sig_id in 1:3
+                    bvn_s_d[shape_id] += bvn_sig_d[sig_id] * sig_sf_j[sig_id, shape_id]
+                end
+            end
         end
-      end
 
-      if calculate_hessian
-        transform_bvn_derivs_hessian!(bvn_derivs, sig_sf, wcs_jacobian)
-      end
+        if calculate_hessian
+            transform_bvn_derivs_hessian!(bvn_derivs, sig_sf, wcs_jacobian)
+        end
     end
 end
 

--- a/src/deterministic_vi/ConstraintTransforms.jl
+++ b/src/deterministic_vi/ConstraintTransforms.jl
@@ -86,11 +86,10 @@ simplexify(x::Real, c::SimplexConstraint) = (1 - c.n * c.lower) * x + c.lower
 
 unsimplexify(x::Real, c::SimplexConstraint) = (x - c.lower) / (1 - c.n * c.lower)
 
-# to_bound!
 
-function to_bound!{T<:Real}(bound::Vector{T}, bound_range::UnitRange,
-                            free::Vector{T}, free_range::UnitRange,
-                            c::SimplexConstraint)
+function to_bound!(bound::Vector{T}, bound_range::UnitRange,
+                   free::Vector{T}, free_range::UnitRange,
+                   c::SimplexConstraint) where {T<:Real}
     for i in 1:length(free_range)
         x = free[free_range[i]]
         @assert isfinite(x)
@@ -114,11 +113,10 @@ function to_bound!{T<:Real}(bound::Vector{T}, bound_range::UnitRange,
     return bound
 end
 
-# to_free!
 
-function to_free!{T<:Real}(free::Vector{T}, free_range::UnitRange,
-                           bound::Vector{T}, bound_range::UnitRange,
-                           c::SimplexConstraint)
+function to_free!(free::Vector{T}, free_range::UnitRange,
+                  bound::Vector{T}, bound_range::UnitRange,
+                  c::SimplexConstraint) where {T<:Real}
     log_last = log(unsimplexify(bound[bound_range[end]], c))
     for i in 1:length(free_range)
         ith_term = log(unsimplexify(bound[bound_range[i]], c)) - log_last
@@ -130,11 +128,10 @@ end
 # ParameterConstraint #
 #---------------------#
 
-# to_bound!
 
-function to_bound!{T<:Real}(bound::Vector{T}, free::Vector{T},
-                            c::ParameterConstraint{BoxConstraint},
-                            free_index::Integer)
+function to_bound!(bound::Vector{T}, free::Vector{T},
+                   c::ParameterConstraint{BoxConstraint},
+                   free_index::Integer) where {T<:Real}
     for i in c.indices
         bound[i] = to_bound(free[free_index], c.constraint)
         free_index += 1
@@ -142,20 +139,20 @@ function to_bound!{T<:Real}(bound::Vector{T}, free::Vector{T},
     return free_index
 end
 
-function to_bound!{T<:Real}(bound::Vector{T}, free::Vector{T},
-                            c::ParameterConstraint{SimplexConstraint},
-                            free_index::Integer)
+
+function to_bound!(bound::Vector{T}, free::Vector{T},
+                   c::ParameterConstraint{SimplexConstraint},
+                   free_index::Integer) where {T<:Real}
     free_length = (c.constraint.n - 1)
     free_range = (1:free_length) + free_index - 1
     to_bound!(bound, c.indices, free, free_range, c.constraint)
     return free_index + free_length
 end
 
-# to_free!
 
-function to_free!{T<:Real}(free::Vector{T}, bound::Vector{T},
-                           c::ParameterConstraint{BoxConstraint},
-                           free_index::Integer)
+function to_free!(free::Vector{T}, bound::Vector{T},
+                  c::ParameterConstraint{BoxConstraint},
+                  free_index::Integer) where {T<:Real}
     for i in c.indices
         free[free_index] = to_free(bound[i], c.constraint)
         free_index += 1
@@ -163,9 +160,10 @@ function to_free!{T<:Real}(free::Vector{T}, bound::Vector{T},
     return free_index
 end
 
-function to_free!{T<:Real}(free::Vector{T}, bound::Vector{T},
-                           c::ParameterConstraint{SimplexConstraint},
-                           free_index::Integer)
+
+function to_free!(free::Vector{T}, bound::Vector{T},
+                  c::ParameterConstraint{SimplexConstraint},
+                  free_index::Integer) where {T<:Real}
     free_length = (c.constraint.n - 1)
     free_range = (1:free_length) + free_index - 1
     to_free!(free, free_range, bound, c.indices, c.constraint)
@@ -176,10 +174,8 @@ end
 # ConstraintBatch #
 #-----------------#
 
-# to_bound!
-
-function to_bound!{T<:Real}(bound::Vector{T}, free::Vector{T},
-                            constraints::ConstraintBatch, src::Integer)
+function to_bound!(bound::Vector{T}, free::Vector{T},
+                   constraints::ConstraintBatch, src::Integer) where {T<:Real}
     free_index = 1
     for constraint in constraints.boxes[src]
         free_index = to_bound!(bound, free, constraint, free_index)
@@ -189,18 +185,18 @@ function to_bound!{T<:Real}(bound::Vector{T}, free::Vector{T},
     end
 end
 
-function to_bound!{T}(bound::VariationalParams{T}, free::VariationalParams{T},
-                      constraints::ConstraintBatch)
+
+function to_bound!(bound::VariationalParams{T}, free::VariationalParams{T},
+                   constraints::ConstraintBatch) where {T}
     @assert length(free) == length(bound)
     for src in 1:length(free)
         to_bound!(bound[src], free[src], constraints, src)
     end
 end
 
-# to_free!
 
-function to_free!{T<:Real}(free::Vector{T}, bound::Vector{T},
-                           constraints::ConstraintBatch, src::Integer)
+function to_free!(free::Vector{T}, bound::Vector{T},
+                  constraints::ConstraintBatch, src::Integer) where {T<:Real}
     free_index = 1
     for constraint in constraints.boxes[src]
         free_index = to_free!(free, bound, constraint, free_index)
@@ -210,8 +206,9 @@ function to_free!{T<:Real}(free::Vector{T}, bound::Vector{T},
     end
 end
 
-function to_free!{T}(free::VariationalParams{T}, bound::VariationalParams{T},
-                     constraints::ConstraintBatch)
+
+function to_free!(free::VariationalParams{T}, bound::VariationalParams{T},
+                  constraints::ConstraintBatch) where {T}
     @assert length(free) == length(bound)
     for src in 1:length(free)
         to_free!(free[src], bound[src], constraints, src)
@@ -258,22 +255,26 @@ end
 # ParameterConstraint #
 #---------------------#
 
-function enforce!{T<:Real}(bound::Vector{T}, c::ParameterConstraint{BoxConstraint})
+function enforce!(bound::Vector{T}, c::ParameterConstraint{BoxConstraint}) where {T<:Real}
     for i in c.indices
         bound[i] = enforce(bound[i], c.constraint)
     end
     return bound
 end
 
-function enforce!{T<:Real}(bound::Vector{T}, c::ParameterConstraint{SimplexConstraint})
+
+function enforce!(bound::Vector{T}, c::ParameterConstraint{SimplexConstraint}) where {T<:Real}
     enforce!(view(bound, c.indices), c.constraint)
     return bound
 end
 
+
 # ConstraintBatch #
 #-----------------#
 
-function enforce!{T<:Real}(bound::Vector{T}, constraints::ConstraintBatch, src::Integer)
+function enforce!(bound::Vector{T},
+                  constraints::ConstraintBatch,
+                  src::Integer) where {T<:Real}
     for constraint in constraints.boxes[src]
         enforce!(bound, constraint)
     end
@@ -282,7 +283,8 @@ function enforce!{T<:Real}(bound::Vector{T}, constraints::ConstraintBatch, src::
     end
 end
 
-function enforce!{T}(bound::VariationalParams{T}, constraints::ConstraintBatch)
+function enforce!(bound::VariationalParams{T},
+                  constraints::ConstraintBatch) where {T}
     for src in 1:length(bound)
         enforce!(bound[src], constraints, src)
     end
@@ -300,7 +302,7 @@ function free_length(simplexes::Vector{ParameterConstraint{SimplexConstraint}})
     return sum(simplex.constraint.n - 1 for simplex in simplexes)
 end
 
-function allocate_free_params{T}(bound::VariationalParams{T}, constraints::ConstraintBatch)
+function allocate_free_params(bound::VariationalParams{T}, constraints::ConstraintBatch) where {T}
     free = similar(bound)
     for src in 1:length(bound)
         n_simplex_params = free_length(constraints.simplexes[src])
@@ -332,27 +334,32 @@ end
 # this is a good chunk size because it divides evenly into `length(CanonicalParams)`
 const DEFAULT_CHUNK = 11
 
-function TransformDerivatives{T<:Real,N}(output::Vector{T}, input::Vector{T},
-                                         ::Type{Val{N}} = Val{DEFAULT_CHUNK})
+function TransformDerivatives(
+    output::Vector{T}, input::Vector{T},
+    ::Type{Val{N}} = Val{DEFAULT_CHUNK}) where {T<:Real,N}
+
     jacobian = zeros(T, length(output), length(input))
     hessian = zeros(T, length(output), length(input), length(input))
     output_dual = copy!(similar(output, Dual{N,T}), output)
     inner_cfg = JacobianConfig{N}(output_dual, similar(input, Dual{N,T}))
     outer_cfg = JacobianConfig{N}(jacobian, input)
-    return TransformDerivatives(jacobian, hessian, output_dual, inner_cfg, outer_cfg)
+    return TransformDerivatives{N,T}(jacobian, hessian, output_dual, inner_cfg, outer_cfg)
 end
 
-function TransformDerivatives{T<:Real,N}(output::VariationalParams{T},
-                                         input::VariationalParams{T},
-                                         ::Type{Val{N}} = Val{DEFAULT_CHUNK})
+function TransformDerivatives(
+    output::VariationalParams{T},
+    input::VariationalParams{T},
+    ::Type{Val{N}} = Val{DEFAULT_CHUNK}) where {T<:Real,N}
+
     @assert length(output) == length(input)
     @assert all(length(src) == length(output[1]) for src in output)
     @assert all(length(src) == length(input[1]) for src in input)
     return TransformDerivatives(output[1], input[1], Val{N})
 end
 
-function differentiate!{F,T<:Number}(transform!::F, derivs::TransformDerivatives,
-                                     input::Vector{T})
+function differentiate!(transform!::F,
+                        derivs::TransformDerivatives,
+                        input::Vector{T}) where {F,T<:Number}
     jacobian!(reshape(derivs.hessian, length(derivs.jacobian), length(input)),
               (out, x) -> jacobian!(out, transform!, derivs.output_dual, x, derivs.inner_cfg),
               derivs.jacobian, input, derivs.outer_cfg)
@@ -363,12 +370,12 @@ end
 # (`sf_output`) to the input-parameterized SensitiveFloat (`sf_input`). Note that the memory
 # for the raw output parameters is supplied via `derivs`, whose constructor is
 # `TransformDerivatives(output_params, input_params)`.
-function propagate_derivatives!{F,T}(transform!::F,
-                                     sf_output::SensitiveFloat,
-                                     sf_input::SensitiveFloat,
-                                     input_sources::VariationalParams{T},
-                                     constraints::ConstraintBatch,
-                                     derivs::TransformDerivatives)
+function propagate_derivatives!(transform!::F,
+                                sf_output::SensitiveFloat,
+                                sf_input::SensitiveFloat,
+                                input_sources::VariationalParams{T},
+                                constraints::ConstraintBatch,
+                                derivs::TransformDerivatives) where {F,T}
     sf_input.v[] = sf_output.v[]
     n_sources = length(input_sources)
     n_input_params = size(sf_input.d, 1)
@@ -421,22 +428,22 @@ function first_quad_form!(C, A, B, src)
     n = size(A, 2)
     scratch = Array{Float64, 2}(m, m)
     @aliasscope begin
-      for i in 1:m, j in 1:m
-        scratch[i, j] = Const(B)[src, j, src, i]
-      end
+        for i in 1:m, j in 1:m
+            scratch[i, j] = Const(B)[src, j, src, i]
+        end
     end
     @aliasscope begin
-      for i in 1:n, j in 1:n
-          x = zero(eltype(C))
-          for k in 1:m
-              y = zero(eltype(C))
-              @inbounds for l in 1:m
-                  @fastmath y += Const(scratch)[l, k] * Const(A)[l, j]
-              end
-              @inbounds x += Const(A)[k, i] * y
-          end
-          @inbounds C[src, i, src, j] = x
-      end
+        for i in 1:n, j in 1:n
+            x = zero(eltype(C))
+            for k in 1:m
+                y = zero(eltype(C))
+                @inbounds for l in 1:m
+                    @fastmath y += Const(scratch)[l, k] * Const(A)[l, j]
+                end
+                @inbounds x += Const(A)[k, i] * y
+            end
+            @inbounds C[src, i, src, j] = x
+        end
     end
     return C
 end

--- a/src/deterministic_vi/elbo_kl.jl
+++ b/src/deterministic_vi/elbo_kl.jl
@@ -173,7 +173,7 @@ end
 
 const PARAM_LENGTH = length(CanonicalParams)
 
-function KLHelper{N,T}(::Type{Dual{N,T}})
+function KLHelper(::Type{Dual{N,T}}) where {N,T}
     dual_buffer = zeros(Dual{N,T}, PARAM_LENGTH)
     jacobian_config = JacobianConfig{N}(rand(T, PARAM_LENGTH))
     gradient_tape = CompiledTape{:kl_gradient}(GradientTape(subtract_kl, rand(T, PARAM_LENGTH)))
@@ -211,11 +211,11 @@ function subtract_kl_source!(kl_source::SensitiveFloat, result::DiffBase.DiffRes
     return kl_source
 end
 
-function subtract_kl_all_sources!{T}(ea::ElboArgs,
-                                     vp::VariationalParams{T},
-                                     accum::SensitiveFloat,
-                                     kl_source::SensitiveFloat = get_kl_source(T),
-                                     helper::KLHelper = get_kl_helper(T))
+function subtract_kl_all_sources!(ea::ElboArgs,
+                                  vp::VariationalParams{T},
+                                  accum::SensitiveFloat,
+                                  kl_source::SensitiveFloat = get_kl_source(T),
+                                  helper::KLHelper = get_kl_helper(T)) where {T}
     result = DiffBase.DiffResult(zero(T), kl_source.d)
     for sa in 1:length(ea.active_sources)
         subtract_kl_source!(kl_source, result, vp[ea.active_sources[sa]], helper)

--- a/src/deterministic_vi/source_brightness.jl
+++ b/src/deterministic_vi/source_brightness.jl
@@ -15,18 +15,18 @@ and all other rows are lognormal offsets.
   squared color terms.  The rows are bands, and the columns
   are star / galaxy.
 """
-struct SourceBrightness{NumType <: Number}
+struct SourceBrightness{T<:Number}
     # [E[l|a=0], E[l]|a=1]]
-    E_l_a::Matrix{SensitiveFloat{NumType}}
+    E_l_a::Matrix{SensitiveFloat{T}}
 
     # [E[l^2|a=0], E[l^2]|a=1]]
-    E_ll_a::Matrix{SensitiveFloat{NumType}}
+    E_ll_a::Matrix{SensitiveFloat{T}}
 end
 
 
-function SourceBrightness{NumType <: Number}(vs::Vector{NumType};
-                                             calculate_gradient=true,
-                                             calculate_hessian=true)
+function SourceBrightness(vs::Vector{T};
+                          calculate_gradient=true,
+                          calculate_hessian=true) where {T<:Number}
     flux_loc = vs[ids.flux_loc]
     flux_scale = vs[ids.flux_scale]
     color_mean = vs[ids.color_mean]
@@ -34,12 +34,12 @@ function SourceBrightness{NumType <: Number}(vs::Vector{NumType};
 
     # E_l_a has a row for each of the five colors and columns
     # for star / galaxy.
-    E_l_a  = Matrix{SensitiveFloat{NumType}}(NUM_BANDS, NUM_SOURCE_TYPES)
-    E_ll_a = Matrix{SensitiveFloat{NumType}}(NUM_BANDS, NUM_SOURCE_TYPES)
+    E_l_a  = Matrix{SensitiveFloat{T}}(NUM_BANDS, NUM_SOURCE_TYPES)
+    E_ll_a = Matrix{SensitiveFloat{T}}(NUM_BANDS, NUM_SOURCE_TYPES)
 
     for i = 1:NUM_SOURCE_TYPES
         for b = 1:NUM_BANDS
-            E_l_a[b, i] = SensitiveFloat{NumType}(length(BrightnessParams), 1,
+            E_l_a[b, i] = SensitiveFloat{T}(length(BrightnessParams), 1,
                                        calculate_gradient, calculate_hessian)
         end
 
@@ -116,7 +116,7 @@ function SourceBrightness{NumType <: Number}(vs::Vector{NumType};
         # Squared terms.
 
         for b = 1:NUM_BANDS
-            E_ll_a[b, i] = SensitiveFloat{NumType}(length(BrightnessParams), 1,
+            E_ll_a[b, i] = SensitiveFloat{T}(length(BrightnessParams), 1,
                                            calculate_gradient, calculate_hessian)
         end
 
@@ -198,7 +198,7 @@ function SourceBrightness{NumType <: Number}(vs::Vector{NumType};
         end # calculate_gradient
     end
 
-    SourceBrightness(E_l_a, E_ll_a)
+    SourceBrightness{T}(E_l_a, E_ll_a)
 end
 
 
@@ -210,12 +210,12 @@ Returns:
   - An array of SourceBrightness objects for each object in 1:ea.S.  Only
     sources in ea.active_sources will have derivative information.
 """
-function load_source_brightnesses{NumType <: Number}(
-                    ea::ElboArgs,
-                    vp::VariationalParams{NumType};
-                    calculate_gradient::Bool=true,
-                    calculate_hessian::Bool=true)
-    sbs = Vector{SourceBrightness{NumType}}(ea.S)
+function load_source_brightnesses(
+        ea::ElboArgs,
+        vp::VariationalParams{T};
+        calculate_gradient::Bool=true,
+        calculate_hessian::Bool=true) where {T<:Number}
+    sbs = Vector{SourceBrightness{T}}(ea.S)
 
     for s in 1:ea.S
         this_deriv = (s in ea.active_sources) && calculate_gradient

--- a/src/mcmc/mcmc_infer.jl
+++ b/src/mcmc/mcmc_infer.jl
@@ -56,8 +56,8 @@ function run_ais(entry::CatalogEntry,
     lnZ  = res_star[:lnZ]
     lnZs = res_star[:lnZ_bootstrap]
     lo, hi = percentile(lnZs, 2.5), percentile(lnZs, 97.5)
-    Log.info(@sprintf "STAR AIS estimate : %2.4f [%2.3f, %2.3f]\n" lnZ lo hi)
-    Log.info(@sprintf "  CI width : %2.5f \n" (hi-lo))
+    Log.info(@sprintf "STAR AIS estimate : %6.3f [%6.3f, %6.3f]\n" lnZ lo hi)
+    Log.info(@sprintf "  CI width : %6.5f \n" (hi-lo))
 
     ####################
     # run galaxy AIS   #
@@ -91,8 +91,8 @@ function run_ais(entry::CatalogEntry,
     lnZ = res_gal[:lnZ]
     lnZs = res_gal[:lnZ_bootstrap]
     lo, hi = percentile(lnZs, 2.5), percentile(lnZs, 97.5)
-    Log.info(@sprintf "GAL AIS estimate : %2.4f [%2.3f, %2.3f]\n" lnZ lo hi)
-    Log.info(@sprintf "  CI width : %2.5f \n" (hi-lo))
+    Log.info(@sprintf "GAL AIS estimate : %6.3f [%6.3f, %6.3f]\n" lnZ lo hi)
+    Log.info(@sprintf "  CI width : %6.5f \n" (hi-lo))
 
     #########################################################
     # Compute prob star vs gal based on marginal likelihood #

--- a/src/model/light_source_model.jl
+++ b/src/model/light_source_model.jl
@@ -87,7 +87,7 @@ struct PriorParams
 end
 
 
-function load_prior()
+function load_prior_init()
     # set is_star = [.95, .05] if stars are underrepresented
     # due to the greater flexibility of the galaxy model
     #is_star = [0.28, 0.72]
@@ -130,4 +130,7 @@ function load_prior()
 end
 
 
-const prior = load_prior()
+const prior = load_prior_init()
+
+# TODO: is deepcopy necessary here? (do callers modify the result?)
+load_prior() = deepcopy(prior)

--- a/src/model/param_set.jl
+++ b/src/model/param_set.jl
@@ -147,7 +147,7 @@ getids(::Type{PsfParams}) = psf_ids
 length(::Type{PsfParams}) = 6
 
 # define length(value) in addition to length(Type) for ParamSets
-length{T<:ParamSet}(::T) = length(T)
+length(::T) where {T<:ParamSet} = length(T)
 
 #TODO: build these from ue_align, etc., here.
 align(::StarPosParams, ids) = ids.pos

--- a/src/model/wcs_utils.jl
+++ b/src/model/wcs_utils.jl
@@ -11,10 +11,10 @@ Args:
 Returns:
     - The 1-indexed pixel locations in the same shape as the input.
 """
-linear_world_to_pix{T <: Number}(wcs_jacobian::Matrix{Float64},
-                          world_offset::Vector{Float64},
-                          pix_offset::Vector{Float64},
-                          worldcoords::VecOrMat{T}) =
+linear_world_to_pix(wcs_jacobian::Matrix{Float64},
+                    world_offset::Vector{Float64},
+                    pix_offset::Vector{Float64},
+                    worldcoords::VecOrMat{T}) where {T<:Number} =
     wcs_jacobian * (worldcoords .- world_offset) + pix_offset
 
 
@@ -34,7 +34,7 @@ Returns:
    coordinates across columns.
 """
 function pixel_world_jacobian(wcs::WCSTransform, pix_loc::Array{Float64, 1};
-                          pixel_delt=0.5)
+                              pixel_delt=0.5)
 
     # Choose a step size.
     # Assume that about a half a pixel is a reasonable step size and the


### PR DESCRIPTION
This updates all parameteric method definitions to use the new `where` syntax in Julia 0.6 (I believe required in 0.7).

Along the way, I made the style more uniform and conventional by always using `T` for a numeric type rather than `NumType` and always using 4-space indents. (Reindenting is the reason for the large diff.)

This also has two bugfixes:

- In `src/mcmc/mcmc_infer.jl`: Sometimes the `@sprintf` calls were resulting in a string with an embedded NULL, causing an error when passed to `Log.info()`. I believe (but am not certain) that this happens when the format code is not long enough for the value. I widened the format codes.

- In `src/model/light_source_model.jl`: We were getting errors from JLD/HDF5 that *might* have been due to from calling `load_prior()` from threads (`load_prior()` does I/O with JLD). I replaced the `load_prior()` function. It now returns a copy of the prior loaded on module import. `load_prior_init()` does the I/O and is now called only on module import.