### PR TITLE
add structure for supporting DECALS dataset

### DIFF
--- a/src/AccuracyBenchmark.jl
+++ b/src/AccuracyBenchmark.jl
@@ -921,10 +921,15 @@ function match_catalogs(truth::DataFrame, prediction_dfs::Vector{DataFrame};
     matched = trues(nrow(truth))
     idxs = Vector{Int}[]
     for prediction in prediction_dfs
-        idx, dists = match_coordinates(truth[:ra],
-                                       truth[:dec],
-                                       prediction[:ra],
-                                       prediction[:dec])
+        # remove missings before feeding to match_coordinates
+        @assert sum(ismissing.(truth[:ra])) == 0
+        @assert sum(ismissing.(truth[:dec])) == 0
+        @assert sum(ismissing.(prediction[:ra])) == 0
+        @assert sum(ismissing.(prediction[:dec])) == 0
+        idx, dists = match_coordinates(Vector{Float64}(truth[:ra]),
+                                       Vector{Float64}(truth[:dec]),
+                                       Vector{Float64}(prediction[:ra]),
+                                       Vector{Float64}(prediction[:dec]))
         matched .&= dists .< tol
         push!(idxs, idx)
     end

--- a/src/Celeste.jl
+++ b/src/Celeste.jl
@@ -33,6 +33,7 @@ include("Synthetic.jl")
 include("AccuracyBenchmark.jl")
 include("GalsimBenchmark.jl")
 
+include("DECALSIO.jl")
 include("ArgumentParse.jl")
 include("main.jl")
 

--- a/src/Coordinates.jl
+++ b/src/Coordinates.jl
@@ -33,7 +33,7 @@ where spherical coordinates are given in *degrees*.
 function _spherical_to_cartesian(lon::AbstractVector, lat::AbstractVector)
     length(lon) == length(lat) || error("lengths of `lon` and `lat` must match")
 
-    T = float(promote_type(eltype(lon), eltype(lat)))
+    T = promote_type(eltype(lon), eltype(lat))
     result = Array{T}(3, length(lon))
     for i in eachindex(lon)
         coslat = cosd(lat[i])

--- a/src/DECALSIO.jl
+++ b/src/DECALSIO.jl
@@ -1,0 +1,153 @@
+"""
+I/O routines for Dark Energy Camera (DECam) images from the Dark Energy
+Camera Legacy Survey (DECaLS).
+"""
+module DECALSIO
+
+import FITSIO
+import ..Celeste: SurveyDataSet, BoundingBox, load_images
+
+
+struct DECALSDataSet <: SurveyDataSet
+basedir::String
+"FITS file with CCD metadata, relative to base dir. E.g., survey-ccds-dr5.kd.fits"
+metadatafile::String
+end
+
+function _linear_pix_to_world(crpix1, crpix2, crval1, crval2,
+                              cd1_1, cd1_2, cd2_1, cd2_2, x, y)
+    dx = x .- crpix1
+    dy = y .- crpix2
+    ra = crval1 + cd1_1 .* dx + cd1_2 .* dy
+    dec = crval2 + cd2_1 .* dx + cd2_2 .* dy
+    return ra, dec
+end
+    
+function _get_overlapping_ccds(dataset::DECALSDataSet, box::BoundingBox)
+    f = FITSIO.FITS(joinpath(dataset.basedir, dataset.metadatafile))
+    hdu = f[2]::FITSIO.TableHDU
+    crpix1 = read(hdu, "crpix1")::Vector{Float32}
+    crpix2 = read(hdu, "crpix2")::Vector{Float32}
+    crval1 = read(hdu, "crval1")::Vector{Float64}
+    crval2 = read(hdu, "crval2")::Vector{Float64}
+    cd1_1 = read(hdu, "cd1_1")::Vector{Float32}
+    cd1_2 = read(hdu, "cd1_2")::Vector{Float32}
+    cd2_1 = read(hdu, "cd2_1")::Vector{Float32}
+    cd2_2 = read(hdu, "cd2_2")::Vector{Float32}
+    width = read(hdu, "width")::Vector{Int16}
+    height = read(hdu, "height")::Vector{Int16}
+    close(f)
+
+    function _linear_pix_to_world(x, y)
+        dx = x .- crpix1
+        dy = y .- crpix2
+        ra = crval1 .+ cd1_1 .* dx .+ cd1_2 .* dy
+        dec = crval2 .+ cd2_1 .* dx .+ cd2_2 .* dy
+        return ra, dec
+    end
+
+    # calculate RA, Dec of all CCD corners using a linear WCS approximation
+    ra1, dec1 = _linear_pix_to_world(1.0, 1.0)
+    ra2, dec2 = _linear_pix_to_world(width, 1.0)
+    ra3, dec3 = _linear_pix_to_world(1.0, height)
+    ra4, dec4 = _linear_pix_to_world(width, height)
+
+    # Calculate potential overlap by checking the minimum and maximum
+    # extent of each CCD in RA/Dec
+    # overlap the target bounding box.
+    # 
+    # It would be better to do this by checking whether each line
+    # segment of the CCD boundary intersects any line segment of the
+    # bounding box. But this is generally good enough.
+    ramin = min.(ra1, ra2, ra3, ra4)
+    ramax = max.(ra1, ra2, ra3, ra4)
+    decmin = min.(dec1, dec2, dec3, dec4)
+    decmax = max.(dec1, dec2, dec3, dec4)
+
+    # We need to treat the discontinuity at RA = 0. We will use a
+    # "good-enough", but not complete, solution. In particular, it doesn't
+    # account for singularities at the poles and it doesn't treat
+    # extremely large (~180 degrees) boxes.  A more complete treatment
+    # would use spherical geometry. See
+    # https://github.com/spacetelescope/spherical_geometry
+    # for an example implementation in Python.
+    #
+    # Because the corner RA/Dec values (ra1, ra2,...) were derived
+    # from crval, crpix, we might have situations where ramin=-0.1,
+    # ramax=0.1, or ramin=359.9, ramax=360.1, but fortunately we
+    # *don't* need to worry about situations where ramin=0.1,
+    # ramax=359.9. (erroneously swapping the east and west limits of
+    # the CCD).
+    #
+    # We also know that the target box doesn't overlap the
+    # discontinuity because we required that ramax > ramin when
+    # constructing the box.
+    #
+    # Our strategy is simply to rotate everything away from the
+    # discontinuity as far as possible. We find the angle that will
+    # center the box at ra = 180, and then rotate all our CCD
+    # ramin/ramax by the same angle.
+    box_mean_ra = (box.ramax + box.ramin) / 2.0
+    offset = 180.0 - box_mean_ra
+    box = BoundingBox(box.ramin + offset, box.ramax + offset,
+                      box.decmin, box.decmax)
+    ramin .= (ramin .+ offset) .% 360.0
+    ramax .= (ramax .+ offset) .% 360.0
+
+    # The comparisons are a little unintuitive, because we're looking
+    # for *any* overlap.
+    mask = ((ramax .> box.ramin) .&
+            (ramin .< box.ramax) .&
+            (decmax .> box.decmin) .&
+            (decmin .< box.decmax))
+
+    # we could return an array of file names and an array of hdu's
+    # (from `image_filename` and `image_hdu` columns), but for now just return
+    # indices)
+    return find(mask)
+end
+
+
+function load_images(dataset::DECALSDataSet, box::BoundingBox)
+
+    # This could return filenames and hdus in which to find images overlapping
+    # the box:
+    idx = _get_overlapping_ccds(dataset, box)
+
+    # Rest of this function not implemented yet. In order to finish loading
+    # Celeste.Image objects from the DECals data, we need to:
+    #
+    # - Create a function to read in both raw and calibrated images and
+    #   determine calibration array (simply divide the calibrated image
+    #   by the raw image)
+    #
+    # - Change the Image type to accept a 2-d rather than 1-d calibration
+    #   array (in general, calibration will not be constant in one
+    #   dimension like in SDSS.)
+    # 
+    # - Add `has_background` to Image (make background optional in Image)
+    #   Then after calling `load_images(dataset, box)`, check `has_background`
+    #   and if false, calculate the background with SEP. This allows us to
+    #   optionally read the background from the dataset (e.g., SDSS supplies
+    #   one, but DECaLS does not).
+    #
+    # - Add option to SDSSDataSet to read background or not (e.g., use the
+    #   SDSS-calculated background or let Celeste determine the background).
+    #
+    # - Add general config options for background subtraction,
+    #   detection parameters (not actually necessary for this function
+    #   but nice to have)
+    #
+    # - Do something for the PSF (needs investigation into DECaLS PSF model).
+    #
+    # Testing: make smaller versions of some calibrated and raw images
+    # images in that ra, dec range (remove ccds from files) and put
+    # them at NERSC for download with a Makefile (Are the raw and
+    # calibrated images actually on disk at NERSC?)
+
+    error("Not yet implemented")
+end
+    
+
+
+end

--- a/src/GalsimBenchmark.jl
+++ b/src/GalsimBenchmark.jl
@@ -64,10 +64,10 @@ function truth_comparison_df(truth_df::DataFrame, prediction_df::DataFrame)
     prediction_df = hcat(DataFrame(index=idx), prediction_df)
 
     long_truth_df = stack(truth_df, parameter_columns)
-    sort!(long_truth_df, cols=[:index, :variable])
+    sort!(long_truth_df, [:index, :variable])
 
     long_prediction_df = stack(prediction_df, parameter_columns)
-    sort!(long_prediction_df, cols=[:index, :variable])
+    sort!(long_prediction_df, [:index, :variable])
 
     rename!(long_truth_df, :value => :truth)
     long_truth_df[:estimate] = long_prediction_df[:value]

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -3,7 +3,15 @@ struct BoundingBox
     ramax::Float64
     decmin::Float64
     decmax::Float64
+
+    function BoundingBox(ramin::Float64, ramax::Float64,
+                         decmin::Float64, decmax::Float64)
+        @assert ramax > ramin "ramax must be greater than ramin"
+        @assert decmax > decmin "decmax must be greater than decmin"
+        new(ramin, ramax, decmin, decmax)
+    end
 end
+
 
 function BoundingBox(ramin::String, ramax::String,
                      decmin::String, decmax::String)

--- a/test/data/decam/Makefile
+++ b/test/data/decam/Makefile
@@ -1,0 +1,11 @@
+
+# small subset of survey-ccds-dr5.kd.fits for testing
+survey-ccds-dr5-0.0-0.5-0.0-0.5.fits :
+	curl -o survey-ccds-dr5-0.0-0.5-0.0-0.5.fits http://portal.nersc.gov/project/dasrepo/celeste/survey-ccds-dr5-0.0-0.5-0.0-0.5.fits
+
+# This file is 303MB. This is because a single DECam file contains 62
+# CCDs.  We need to create some smaller files for testing; ones with
+# just a few CCDs.  But I'm leaving this here for now as a record of
+# how to access the calibrated files.
+calibrated/000/0001p000/c4d_121020_014450_oki_g_a1.fits.fz :
+	curl --create-dirs -o calibrated/000/0001p000/c4d_121020_014450_oki_g_a1.fits.fz ftp://archive.noao.edu/public/hlsp/ls/dr5/calibrated/000/0001p000/c4d_121020_014450_oki_g_a1.fits.fz

--- a/test/test_decalsio.jl
+++ b/test/test_decalsio.jl
@@ -1,0 +1,30 @@
+import Celeste: BoundingBox
+import Celeste.DECALSIO: DECALSDataSet, _get_overlapping_ccds
+
+
+@testset "decalsio" begin
+
+    # ensure files downloaded
+    DATADIR = joinpath(Pkg.dir("Celeste"), "test", "data", "decam")
+    wd = pwd()
+    cd(DATADIR)
+    make_output = readstring(`make survey-ccds-dr5-0.0-0.5-0.0-0.5.fits`)
+    if !startswith(make_output, "make: Nothing to be done for")
+        print(make_output)  # only print output if something was done
+    end
+    cd(wd)
+
+
+    @testset "overlapping ccds" begin
+        dataset = DECALSDataSet(DATADIR,
+                                "survey-ccds-dr5-0.0-0.5-0.0-0.5.fits")
+        box = BoundingBox(0.0, 0.5, 0.0, 0.5)
+        idx = _get_overlapping_ccds(dataset, box)
+        @test length(idx) == 134  # all CCDs in FITS file should overlap.
+
+        small_box = BoundingBox(0.2, 0.4, 0.2, 0.4)
+        idx2 = _get_overlapping_ccds(dataset, small_box)
+        @test length(idx2) == 82  # determined from running code!
+                                  # (But should be less than 134)
+    end
+end


### PR DESCRIPTION
In my previous PRs, I laid the groundwork for supporting general (non-SDSS) datasets, by making an interface where Celeste creates a `SurveyDataSet` object describing how the data is stored, and then calling `load_images(dataset, box)` and expecting to get back an array of survey-agnostic `Celeste.Image` objects containing image data. The SDSS data I/O routines now conform to this interface.

This PR lays out implementing `load_images` for a new `SurveyDataSet` type, called `DECALSDataSet`, which represents data from the Dark Energy Camera Legacy Survey. It goes as far as determining which images overlap the given bounding box, but does not yet load them.

The remaining to-dos to actually load the images are fairly straight-forward, but I don't know when I'm going to have time to implement them so I'm handing this off now. Most of the hard part is figuring out where the raw and calibrated images are actually located.

Here are the remaining to-do items (also commented in the code itself):

- Create a function to read in both raw and calibrated images and determine calibration array (simply divide the calibrated image by the raw image)

- Change the `Celeste.Image` type to accept a 2-d rather than 1-d calibration array (in general, calibration will not be constant in one dimension like in SDSS.)

- Add a `has_background` boolean flag to `Celeste.Image` (e.g., make the background array optional). Then after calling `load_images(dataset, box)`, check `has_background` and if false, calculate the background with SEP (and set flag to `true`). This allows us to optionally read the background from the dataset (e.g., SDSS supplies one, but DECaLS does not).

- Add option to SDSSDataSet type to read background or not (e.g., use the SDSS-calculated background or let Celeste determine the background).

- Add general config options for background subtraction, detection parameters (OK, not actually necessary for `load_images`, but nice to have).

- Do something for the PSF (needs investigation into DECaLS PSF model). OK, this is another hard part.

- Testing: make smaller versions of some calibrated and raw images images in that ra, dec range (remove ccds from files) and put them at NERSC for download with a Makefile (Are the raw and calibrated images actually on disk at NERSC?)